### PR TITLE
Add FastAPI ingest service

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,5 +11,8 @@ async def ingest(domain: str, req: Request, x_auth: str = Header(default="")):
         obj = json.loads((await req.body()).decode("utf-8"))
     except Exception:
         return PlainTextResponse("invalid json", status_code=400)
-    (DATA / f"{domain}.jsonl").open("a", encoding="utf-8").write(json.dumps(obj, ensure_ascii=False)+"\n")
+    target_path = (DATA / f"{domain}.jsonl").resolve()
+    if not str(target_path).startswith(str(DATA.resolve()) + os.sep):
+        return PlainTextResponse("invalid domain name", status_code=400)
+    target_path.open("a", encoding="utf-8").write(json.dumps(obj, ensure_ascii=False)+"\n")
     return PlainTextResponse("ok")

--- a/app.py
+++ b/app.py
@@ -6,6 +6,9 @@ DATA = pathlib.Path("data"); DATA.mkdir(parents=True, exist_ok=True)
 SECRET = os.environ.get("LEITSTAND_TOKEN","")
 @app.post("/ingest/{domain}")
 async def ingest(domain: str, req: Request, x_auth: str = Header(default="")):
+    import re
+    if not re.fullmatch(r"[\w-]+", domain):
+        return PlainTextResponse("invalid domain name", status_code=400)
     if SECRET and x_auth != SECRET: return PlainTextResponse("unauthorized", status_code=401)
     try:
         obj = json.loads((await req.body()).decode("utf-8"))

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, Request, Header
 from fastapi.responses import PlainTextResponse
 import json, pathlib, os
+import os.path
 app = FastAPI(title="leitstand-ingest")
 DATA = pathlib.Path("data"); DATA.mkdir(parents=True, exist_ok=True)
 SECRET = os.environ.get("LEITSTAND_TOKEN","")
@@ -15,7 +16,8 @@ async def ingest(domain: str, req: Request, x_auth: str = Header(default="")):
     except Exception:
         return PlainTextResponse("invalid json", status_code=400)
     target_path = (DATA / f"{domain}.jsonl").resolve()
-    if not str(target_path).startswith(str(DATA.resolve()) + os.sep):
+    data_dir = str(DATA.resolve())
+    if os.path.commonpath([str(target_path), data_dir]) != data_dir:
         return PlainTextResponse("invalid domain name", status_code=400)
     target_path.open("a", encoding="utf-8").write(json.dumps(obj, ensure_ascii=False)+"\n")
     return PlainTextResponse("ok")

--- a/app.py
+++ b/app.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI, Request, Header
+from fastapi.responses import PlainTextResponse
+import json, pathlib, os
+app = FastAPI(title="leitstand-ingest")
+DATA = pathlib.Path("data"); DATA.mkdir(parents=True, exist_ok=True)
+SECRET = os.environ.get("LEITSTAND_TOKEN","")
+@app.post("/ingest/{domain}")
+async def ingest(domain: str, req: Request, x_auth: str = Header(default="")):
+    if SECRET and x_auth != SECRET: return PlainTextResponse("unauthorized", status_code=401)
+    try:
+        obj = json.loads((await req.body()).decode("utf-8"))
+    except Exception:
+        return PlainTextResponse("invalid json", status_code=400)
+    (DATA / f"{domain}.jsonl").open("a", encoding="utf-8").write(json.dumps(obj, ensure_ascii=False)+"\n")
+    return PlainTextResponse("ok")


### PR DESCRIPTION
## Summary
- add a FastAPI application that provides an authenticated ingest endpoint
- persist ingested JSON objects in domain-specific JSONL files under data/

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb6222dc4c832cbbc53802049febbc