### PR TITLE
feat(leitstand): add /ingest/{domain} API (JSONL append)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # leitstand
+
+## Run (Codex/Codespaces)
+```
+pip install -r requirements.txt
+export LEITSTAND_TOKEN=$(openssl rand -hex 12)   # optional
+uvicorn app:app --host 0.0.0.0 --port 8788
+# In Codex/Codespaces: Port 8788 → Public schalten, URL kopieren
+```

--- a/app.py
+++ b/app.py
@@ -12,5 +12,11 @@ async def ingest(domain: str, req: Request, x_auth: str = Header(default="")):
         obj = json.loads((await req.body()).decode("utf-8"))
     except Exception:
         return PlainTextResponse("invalid json", status_code=400)
-    (DATA / f"{domain}.jsonl}").open("a", encoding="utf-8").write(json.dumps(obj, ensure_ascii=False)+"\n")
+    # Only allow alphanumerics, dash, underscore in domain
+    import re
+    safe_domain = re.sub(r"[^a-zA-Z0-9_-]", "_", domain)
+    target_path = (DATA / f"{safe_domain}.jsonl").resolve()
+    if DATA.resolve() not in target_path.parents:
+        return PlainTextResponse("invalid domain", status_code=400)
+    target_path.open("a", encoding="utf-8").write(json.dumps(obj, ensure_ascii=False)+"\n")
     return PlainTextResponse("ok")

--- a/app.py
+++ b/app.py
@@ -16,7 +16,8 @@ async def ingest(domain: str, req: Request, x_auth: str = Header(default="")):
     import re
     safe_domain = re.sub(r"[^a-zA-Z0-9_-]", "_", domain)
     target_path = (DATA / f"{safe_domain}.jsonl").resolve()
-    if DATA.resolve() not in target_path.parents:
+    # Ensure the resolved path is actually within DATA directory
+    if os.path.commonpath([str(DATA.resolve()), str(target_path)]) != str(DATA.resolve()):
         return PlainTextResponse("invalid domain", status_code=400)
     target_path.open("a", encoding="utf-8").write(json.dumps(obj, ensure_ascii=False)+"\n")
     return PlainTextResponse("ok")

--- a/app.py
+++ b/app.py
@@ -1,23 +1,16 @@
 from fastapi import FastAPI, Request, Header
 from fastapi.responses import PlainTextResponse
 import json, pathlib, os
-import os.path
 app = FastAPI(title="leitstand-ingest")
 DATA = pathlib.Path("data"); DATA.mkdir(parents=True, exist_ok=True)
 SECRET = os.environ.get("LEITSTAND_TOKEN","")
 @app.post("/ingest/{domain}")
 async def ingest(domain: str, req: Request, x_auth: str = Header(default="")):
-    import re
-    if not re.fullmatch(r"[\w-]+", domain):
-        return PlainTextResponse("invalid domain name", status_code=400)
-    if SECRET and x_auth != SECRET: return PlainTextResponse("unauthorized", status_code=401)
+    if SECRET and x_auth != SECRET:
+        return PlainTextResponse("unauthorized", status_code=401)
     try:
         obj = json.loads((await req.body()).decode("utf-8"))
     except Exception:
         return PlainTextResponse("invalid json", status_code=400)
-    target_path = (DATA / f"{domain}.jsonl").resolve()
-    data_dir = str(DATA.resolve())
-    if os.path.commonpath([str(target_path), data_dir]) != data_dir:
-        return PlainTextResponse("invalid domain name", status_code=400)
-    target_path.open("a", encoding="utf-8").write(json.dumps(obj, ensure_ascii=False)+"\n")
+    (DATA / f"{domain}.jsonl}").open("a", encoding="utf-8").write(json.dumps(obj, ensure_ascii=False)+"\n")
     return PlainTextResponse("ok")

--- a/app.py
+++ b/app.py
@@ -15,9 +15,12 @@ async def ingest(domain: str, req: Request, x_auth: str = Header(default="")):
     # Only allow alphanumerics, dash, underscore in domain
     import re
     safe_domain = re.sub(r"[^a-zA-Z0-9_-]", "_", domain)
-    target_path = (DATA / f"{safe_domain}.jsonl").resolve()
-    # Ensure the resolved path is actually within DATA directory
-    if os.path.commonpath([str(DATA.resolve()), str(target_path)]) != str(DATA.resolve()):
+    target_path = (DATA / f"{safe_domain}.jsonl")
+    # Normalize and resolve both DATA and target_path
+    data_dir = DATA.resolve()
+    fullpath = target_path.resolve()
+    # Ensure the resolved path is strictly within DATA directory
+    if os.path.commonpath([str(data_dir), str(fullpath)]) != str(data_dir):
         return PlainTextResponse("invalid domain", status_code=400)
-    target_path.open("a", encoding="utf-8").write(json.dumps(obj, ensure_ascii=False)+"\n")
+    fullpath.open("a", encoding="utf-8").write(json.dumps(obj, ensure_ascii=False)+"\n")
     return PlainTextResponse("ok")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add a FastAPI application exposing /ingest/{domain}
- record posted JSON payloads into per-domain JSONL files
- document how to run the service and add required dependencies

## Testing
- not run (environment only supports code changes)


------
https://chatgpt.com/codex/tasks/task_e_68eb7996ffbc832ca249e21f22056b56