### PR TITLE
docs(leitstand): ADRs für Ingest & Datenablage

### DIFF
--- a/docs/adr/0001-python-fastapi-panels.md
+++ b/docs/adr/0001-python-fastapi-panels.md
@@ -1,0 +1,15 @@
+# ADR-0001: Python/FastAPI für Ingest & Panels
+Status: Accepted
+Date: 2025-10-12
+
+## Kontext
+Schnelle IO/UI-Iteration, geringe Einstiegshürde.
+
+## Entscheidung
+- Python (FastAPI) für Ingest, später Panels.
+
+## Konsequenzen
+- Schneller MVP; bei Bedarf Rust-Worker daneben.
+
+## Alternativen
+- Rust-Only: mehr Entwicklungsaufwand für UI.

--- a/docs/adr/0002-data-jsonl-per-domain.md
+++ b/docs/adr/0002-data-jsonl-per-domain.md
@@ -1,0 +1,16 @@
+# ADR-0002: Per-Domain JSONL in `data/` + optional Token
+Status: Accepted
+Date: 2025-10-12
+
+## Kontext
+Einfacher Speicher für eingehende Events.
+
+## Entscheidung
+- Append-only `data/{domain}.jsonl`
+- Optionaler Header `x-auth` mit `LEITSTAND_TOKEN`
+
+## Konsequenzen
+- Einfach zu debuggen; Logs git-ignorieren.
+
+## Alternativen
+- DB früh: unnötig für MVP.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,4 @@
+# Architekturentscheidungsaufzeichnungen (ADR)
+
+- [ADR-0001: Python/FastAPI für Ingest & Panels](0001-python-fastapi-panels.md)
+- [ADR-0002: Per-Domain JSONL in `data/` + optional Token](0002-data-jsonl-per-domain.md)


### PR DESCRIPTION
## Summary
- add ADR index under docs/adr
- record ADR-0001 covering Python/FastAPI for ingest and panels
- record ADR-0002 documenting per-domain JSONL storage strategy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb92582f44832c8f6c4724b772aec8