### PR TITLE
Fix security vulnerability and improve domain validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import re
+import secrets
 from pathlib import Path
 from typing import Final
 
@@ -19,8 +20,8 @@ SECRET = os.environ.get("LEITSTAND_TOKEN", "")
 
 _DOMAIN_RE: Final[re.Pattern[str]] = re.compile(
     r"^(?=.{1,253}$)"
-    r"(?:[a-z0-9_](?:[a-z0-9_-]{0,61}[a-z0-9_])?)"
-    r"(?:\.(?:[a-z0-9_](?:[a-z0-9_-]{0,61}[a-z0-9_])?))*$"
+    r"(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)"
+    r"(?:\.(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?))*$"
 )
 
 
@@ -54,7 +55,7 @@ def _safe_target_path(domain: str) -> Path:
 
 
 def _require_auth(x_auth: str) -> None:
-    if SECRET and x_auth != SECRET:
+    if SECRET and not secrets.compare_digest(x_auth, SECRET):
         raise HTTPException(status_code=401, detail="unauthorized")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+httpx

--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,36 @@
+import pytest
+from fastapi.testclient import TestClient
+from app import app, _sanitize_domain
+
+client = TestClient(app)
+
+def test_ingest_auth_ok(monkeypatch):
+    monkeypatch.setattr("app.SECRET", "secret")
+    response = client.post("/ingest/example.com", headers={"X-Auth": "secret"}, json={"data": "value"})
+    assert response.status_code == 200
+    assert response.text == "ok"
+
+def test_ingest_auth_fail(monkeypatch):
+    monkeypatch.setattr("app.SECRET", "secret")
+    response = client.post("/ingest/example.com", headers={"X-Auth": "wrong"}, json={"data": "value"})
+    assert response.status_code == 401
+
+def test_ingest_auth_missing(monkeypatch):
+    monkeypatch.setattr("app.SECRET", "secret")
+    response = client.post("/ingest/example.com", json={"data": "value"})
+    assert response.status_code == 401
+
+def test_ingest_no_auth(monkeypatch):
+    monkeypatch.setattr("app.SECRET", "")
+    response = client.post("/ingest/example.com", json={"data": "value"})
+    assert response.status_code == 200
+
+def test_sanitize_domain_ok():
+    assert _sanitize_domain("example.com") == "example.com"
+    assert _sanitize_domain(" ex-ample.com ") == "ex-ample.com"
+
+def test_sanitize_domain_bad():
+    with pytest.raises(Exception):
+        _sanitize_domain("example_com")
+    with pytest.raises(Exception):
+        _sanitize_domain("example.com_")


### PR DESCRIPTION
- Use `secrets.compare_digest` for constant-time token comparison to prevent timing attacks.
- Update the domain validation regex to disallow underscores, conforming to RFC 1035.
- Add a test suite with `pytest` to verify the fixes and improve code quality.