### PR TITLE
Align domain regex documentation and pin runtime deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ In GitHub Codespaces sollte der Port 8788 veröffentlicht werden, um Anfragen an
 
 ## API
 ### `POST /ingest/{domain}`
-* **Pfadparameter** `domain`: Muss dem Muster  
-  `^(?=.{1,253}$)(?:[a-z0-9_](?:[a-z0-9_-]{0,61}[a-z0-9_])?)(?:\.(?:[a-z0-9_](?:[a-z0-9_-]{0,61}[a-z0-9_])?))*$`  
-  entsprechen. Ungültige Werte führen zu `400 invalid domain`.
+* **Pfadparameter** `domain`: Muss dem Muster (RFC-nah, ohne Unterstriche)
+  `^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(?:\.(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?))*$`
+  entsprechen. Gültige Beispiele sind `api.example.com` oder `svc-a.local`. Ungültig
+  sind etwa `api__x`, `-foo.` oder `.bar`. Ungültige Werte führen zu
+  `400 invalid domain`.
 * **Header** `X-Auth`: erforderlich, wenn `LEITSTAND_TOKEN` gesetzt ist, sonst optional. Fehlerhafte Werte führen zu `401 unauthorized`.
 * **Request-Body**: UTF-8-kodiertes JSON-Objekt oder -Array. Einzelne Objekte ohne `domain`-Feld erhalten automatisch das Feld `domain` mit dem bereinigten Domainnamen.
 * **Antwort**: `200 ok` als Text bei Erfolg. Bei ungültigem JSON wird `400 invalid json` zurückgegeben.

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,7 +15,7 @@ Dieses Dokument beschreibt die HTTP-Schnittstelle des Leitstand-Ingest-Dienstes 
 | Eigenschaft    | Beschreibung |
 |----------------|--------------|
 | Methode        | `POST` |
-| Pfadparameter  | `domain` – wird in Kleinbuchstaben gewandelt und muss dem regulären Ausdruck `^(?=.{1,253}$)(?:[a-z0-9_](?:[a-z0-9_-]{0,61}[a-z0-9_])?)(?:\.(?:[a-z0-9_](?:[a-z0-9_-]{0,61}[a-z0-9_])?))*$` entsprechen. |
+| Pfadparameter  | `domain` – wird in Kleinbuchstaben gewandelt und muss dem regulären Ausdruck `^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(?:\.(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?))*$` entsprechen. |
 | Header         | `Content-Type: application/json`; `X-Auth: <token>` sofern `LEITSTAND_TOKEN` gesetzt ist. |
 | Request-Body   | Gültiges JSON-Dokument. Einzelne Objekte erhalten automatisch ein Feld `domain`, sofern es fehlt. |
 | Antwort        | `200 OK` (Text: `ok`) bei Erfolg. Fehlerhafte Eingaben erzeugen `400 invalid domain` / `400 invalid json`, fehlende Authentifizierung `401 unauthorized`. |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-fastapi
-uvicorn
-filelock
+fastapi>=0.110
+uvicorn[standard]>=0.27
+filelock>=3.13
 pytest
 httpx


### PR DESCRIPTION
## Summary
- clarify the README domain validation description and add concrete examples that match the FastAPI validation
- update the API documentation to use the same underscore-free domain regex
- pin runtime dependencies with minimum versions, including filelock

## Testing
- LEITSTAND_TOKEN=test pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed79ef9098832c84c960b80c542cc9