### PR TITLE
fix: Reject negative Content-Length

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,6 +96,8 @@ async def ingest(domain: str, req: Request, x_auth: str = Header(default="")):
         cl = int(cl_raw)
     except (ValueError, TypeError):  # defensive
         raise HTTPException(status_code=400, detail="invalid content-length")
+    if cl < 0:
+        raise HTTPException(status_code=400, detail="invalid content-length")
     if cl > 1024 * 1024:
         raise HTTPException(status_code=413, detail="payload too large")
 

--- a/test_app.py
+++ b/test_app.py
@@ -136,6 +136,17 @@ def test_ingest_no_content_length(monkeypatch):
     assert "length required" in response.text
 
 
+def test_ingest_negative_content_length(monkeypatch):
+    monkeypatch.setattr("app.SECRET", "secret")
+    response = client.post(
+        "/ingest/example.com",
+        headers={"X-Auth": "secret", "Content-Length": "-1"},
+        json={"data": "value"},
+    )
+    assert response.status_code == 400
+    assert "invalid content-length" in response.text
+
+
 def test_health_endpoint(monkeypatch):
     monkeypatch.setattr("app.SECRET", "secret")
     response = client.get("/health", headers={"X-Auth": "secret"})


### PR DESCRIPTION
The ingest endpoint did not validate against negative values for the Content-Length header. This could cause unexpected behavior and lead to a denial-of-service vulnerability.

This commit adds a check to ensure that Content-Length is not negative, returning a 400 Bad Request if it is. A new test case has been added to verify this behavior.