### PR TITLE
Refactor: Code-Inkonsistenzen beheben

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 # runtime
-data/*.jsonl
 __pycache__/
 *.pyc

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,3 @@
+# Ingested data and locks
 *.jsonl
 *.lock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 fastapi>=0.110
-werkzeug==3.1.3
 uvicorn[standard]>=0.27
 filelock>=3.13
 pytest


### PR DESCRIPTION
Diese Änderung behebt mehrere Inkonsistenzen im Code:

- Entfernt die `werkzeug`-Abhängigkeit und ersetzt `secure_filename` durch eine leichtere, interne Implementierung.
- Aktualisiert die `.gitignore`-Dateien, um `*.lock`-Dateien korrekt zu ignorieren und die Projektstruktur zu verbessern.
- Stellt die ursprüngliche `Content-Length`-Prüfung in `app.py` wieder her, um die Kompatibilität mit den Tests zu gewährleisten.