### PR TITLE
Add reusable workflow for aussen JSONL validation

### DIFF
--- a/.github/workflows/validate-aussen-fixtures.yml
+++ b/.github/workflows/validate-aussen-fixtures.yml
@@ -1,0 +1,20 @@
+name: validate (aussen in leitstand)
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  fixtures:
+    name: fixtures (tests/fixtures/aussen.jsonl)
+    uses: heimgewebe/metarepo/.github/workflows/reusable-validate-jsonl.yml@contracts-v1
+    with:
+      jsonl_path: tests/fixtures/aussen.jsonl
+      schema_url: https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/aussen.event.schema.json
+      strict: false
+      validate_formats: true
+
+  demo:
+    name: demo (demo/aussen.jsonl)
+    uses: heimgewebe/metarepo/.github/workflows/reusable-validate-jsonl.yml@contracts-v1
+    with:
+      jsonl_path: demo/aussen.jsonl
+      schema_url: https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/aussen.event.schema.json
+      strict: false
+      validate_formats: true

--- a/demo/.gitkeep
+++ b/demo/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep demo directory tracked

--- a/tests/fixtures/.gitkeep
+++ b/tests/fixtures/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep fixtures directory tracked


### PR DESCRIPTION
## Summary
- add a workflow that validates the aussen fixture and demo JSONL files against the shared schema
- include placeholder .gitkeep files so the directories exist in the repository

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3bbedfda4832c993ef8b8c5a23261