### PR TITLE
Add GitHub workflow to validate leitstand fixtures

### DIFF
--- a/.github/workflows/validate-leitstand-fixtures.yml
+++ b/.github/workflows/validate-leitstand-fixtures.yml
@@ -1,0 +1,26 @@
+name: validate-leitstand-fixtures
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  fixtures:
+    name: fixtures (tests/fixtures/leitstand.jsonl)
+    if: hashFiles('tests/fixtures/leitstand.jsonl') != ''
+    uses: heimgewebe/metarepo/.github/workflows/reusable-validate-jsonl.yml@codex/add-github-workflows
+    with:
+      jsonl_path: tests/fixtures/leitstand.jsonl
+      schema_url: https://raw.githubusercontent.com/heimgewebe/metarepo/main/contracts/leitstand-fixtures.schema.json
+      strict: false
+      validate_formats: true
+
+  demo:
+    name: demo (demo/leitstand.jsonl)
+    if: hashFiles('demo/leitstand.jsonl') != ''
+    uses: heimgewebe/metarepo/.github/workflows/reusable-validate-jsonl.yml@codex/add-github-workflows
+    with:
+      jsonl_path: demo/leitstand.jsonl
+      schema_url: https://raw.githubusercontent.com/heimgewebe/metarepo/main/contracts/leitstand-fixtures.schema.json
+      strict: false
+      validate_formats: true


### PR DESCRIPTION
## Summary
- add a workflow to validate leitstand fixtures using the reusable JSONL schema validation
- skip validation jobs automatically when the referenced JSONL files are absent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f3c1308898832cb518ce75fe137f7b