### PR TITLE
Avoid redundant domain sanitation and clarify docs

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,22 +1,25 @@
 from __future__ import annotations
 
-import hashlib
 import json
 import os
-import re
 import secrets
-from pathlib import Path
 from typing import Final
 
 from fastapi import FastAPI, Header, HTTPException, Request
 from fastapi.responses import PlainTextResponse
 from filelock import FileLock
 
+from storage import (
+    DATA_DIR,
+    DomainError,
+    safe_target_path,
+    sanitize_domain,
+    target_filename,
+)
+
 app = FastAPI(title="leitstand-ingest")
 
-# Datenverzeichnis resolven und anlegen
-DATA: Final[Path] = Path(os.environ.get("LEITSTAND_DATA_DIR", "data")).resolve()
-DATA.mkdir(parents=True, exist_ok=True)
+DATA = DATA_DIR
 
 VERSION: Final[str] = os.environ.get("LEITSTAND_VERSION", "dev")
 
@@ -26,73 +29,29 @@ if not SECRET_ENV:
 
 SECRET: Final[str] = SECRET_ENV
 
-# RFC-nahe FQDN-Validierung: labels 1..63, a-z0-9 und '-' (kein '_' ), gesamt ≤ 253
-_DOMAIN_RE: Final[re.Pattern[str]] = re.compile(
-    r"^(?=.{1,253}$)"
-    r"(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)"
-    r"(?:\.(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?))*$"
-)
-
-
-def _sanitize_domain(domain: str) -> str:
-    d = (domain or "").strip().lower()
-    if not _DOMAIN_RE.fullmatch(d):
-        raise HTTPException(status_code=400, detail="invalid domain")
-    return d
-
-
-def _is_under(path: Path, base: Path) -> bool:
-    try:
-        return path.is_relative_to(base)  # Py 3.9+
-    except AttributeError:
-        return os.path.commonpath([str(path), str(base)]) == str(base)
-
-
-_FNAME_MAX: Final[int] = 255  # typische FS-Grenze (ext4 etc.)
-
-# Zusätzliche Zeichen, die wir aus Sicherheitsgründen entfernen (neben / und \0)
-_UNSAFE_FILENAME_CHARS: Final[re.Pattern[str]] = re.compile(r'[][<>:"|?*]')
-
-
-def _secure_filename(name: str) -> str:
-    """
-    Vereinfachte, aber ausreichende Bereinigung. Entfernt unsichere Zeichen.
-    Verhindert Directory Traversal ('..').
-    """
-    name = name.replace("..", ".")
-    return _UNSAFE_FILENAME_CHARS.sub("", name)
-
-
-def _target_filename(domain: str) -> str:
-    """
-    Liefert einen deterministischen, dateisystem-sicheren Dateinamen für die Domain.
-    Falls die Domain + '.jsonl' länger als das FS-Limit ist, nehmen wir eine
-    trunkierte Variante plus 8-stelligem SHA-256-Suffix.
-    """
-
-    base = domain
-    ext = ".jsonl"
-    # Reserve 1–2 Zeichen Sicherheit wegen Encoding/FS
-    if len(base) + len(ext) > (_FNAME_MAX - 1):
-        h = hashlib.sha256(domain.encode("utf-8")).hexdigest()[:8]
-        # so viel wie möglich behalten, dann '-{hash}'
-        keep = max(16, (_FNAME_MAX - len(ext) - 1 - len(h)))  # 1 für '-'
-        base = f"{domain[:keep]}-{h}"
-    filename = f"{base}{ext}"
-    # Sanitize filename to avoid any unwanted characters or traversal
-    return _secure_filename(filename)
-
-
-def _safe_target_path(domain: str) -> Path:
-    candidate = (DATA / _target_filename(domain)).resolve()
-    if not _is_under(candidate, DATA):
-        raise HTTPException(status_code=400, detail="invalid path")
-    return candidate
-
-
 def _require_auth(x_auth: str) -> None:
     if not x_auth or not secrets.compare_digest(x_auth, SECRET):
         raise HTTPException(status_code=401, detail="unauthorized")
+
+
+def _sanitize_domain(domain: str) -> str:
+    try:
+        return sanitize_domain(domain)
+    except DomainError as exc:
+        raise HTTPException(status_code=400, detail="invalid domain") from exc
+
+
+def _target_filename(domain: str) -> str:
+    dom = _sanitize_domain(domain)
+    return target_filename(dom)
+
+
+def _safe_target_path(domain: str, *, already_sanitized: bool = False):
+    dom = domain if already_sanitized else _sanitize_domain(domain)
+    try:
+        return safe_target_path(dom, data_dir=DATA)
+    except DomainError as exc:
+        raise HTTPException(status_code=400, detail="invalid domain") from exc
 
 
 @app.post("/ingest/{domain}")
@@ -113,7 +72,7 @@ async def ingest(domain: str, req: Request, x_auth: str = Header(default="")):
         raise HTTPException(status_code=413, detail="payload too large")
 
     dom = _sanitize_domain(domain)
-    target_path = _safe_target_path(dom)
+    target_path = _safe_target_path(dom, already_sanitized=True)
 
     # JSON parsen
     try:
@@ -136,7 +95,10 @@ async def ingest(domain: str, req: Request, x_auth: str = Header(default="")):
             if not isinstance(entry_domain, str):
                 raise HTTPException(status_code=400, detail="invalid payload")
 
-            sanitized_entry_domain = _sanitize_domain(entry_domain)
+            try:
+                sanitized_entry_domain = sanitize_domain(entry_domain)
+            except DomainError as exc:
+                raise HTTPException(status_code=400, detail="invalid payload") from exc
             if sanitized_entry_domain != dom:
                 raise HTTPException(status_code=400, detail="domain mismatch")
 

--- a/docs/adr/0002-data-jsonl-per-domain.md
+++ b/docs/adr/0002-data-jsonl-per-domain.md
@@ -1,4 +1,4 @@
-# ADR-0002: Per-Domain JSONL in `data/` + optional Token
+# ADR-0002: Per-Domain JSONL in `data/` + verpflichtendes Token
 Status: Accepted
 Date: 2025-10-12
 
@@ -7,7 +7,7 @@ Einfacher Speicher für eingehende Events.
 
 ## Entscheidung
 - Append-only `data/{domain}.jsonl`
-- Optionaler Header `x-auth` mit `LEITSTAND_TOKEN`
+- Header `x-auth` ist verpflichtend und muss mit `LEITSTAND_TOKEN` übereinstimmen
 
 ## Konsequenzen
 - Einfach zu debuggen; Logs git-ignorieren.

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,7 @@ Dieses Dokument beschreibt die HTTP-Schnittstelle des Leitstand-Ingest-Dienstes 
 
 ## Übersicht
 * Basis-URL: `http://<host>:<port>` (Standard-Port 8788)
-* Authentifizierung: Optionaler Header `X-Auth`, sofern `LEITSTAND_TOKEN` gesetzt ist
+* Authentifizierung: Verpflichtender Header `X-Auth` mit dem Wert aus `LEITSTAND_TOKEN`
 * Datenformat: JSON bzw. JSON Lines
 * OpenAPI/Swagger: Automatisch unter `/docs` (Swagger UI) bzw. `/openapi.json` verfügbar
 
@@ -15,8 +15,8 @@ Dieses Dokument beschreibt die HTTP-Schnittstelle des Leitstand-Ingest-Dienstes 
 | Eigenschaft    | Beschreibung |
 |----------------|--------------|
 | Methode        | `POST` |
-| Pfadparameter  | `domain` – wird in Kleinbuchstaben gewandelt und muss dem regulären Ausdruck `^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(?:\.(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?))*$` entsprechen. |
-| Header         | `Content-Type: application/json`; `X-Auth: <token>` sofern `LEITSTAND_TOKEN` gesetzt ist. |
+| Pfadparameter  | `domain` – wird in Kleinbuchstaben gewandelt und muss klassischen FQDN-Regeln folgen (Labels 1–63 Zeichen, Kleinbuchstaben/Ziffern/Bindestrich, maximal 253 Zeichen gesamt). |
+| Header         | `Content-Type: application/json`; `X-Auth: <token>` (Pflicht). |
 | Request-Body   | Gültiges JSON-Dokument. Einzelne Objekte erhalten automatisch ein Feld `domain`, sofern es fehlt. |
 | Antwort        | `200 OK` (Text: `ok`) bei Erfolg. Fehlerhafte Eingaben erzeugen `400 invalid domain` / `400 invalid json`, fehlende Authentifizierung `401 unauthorized`. |
 
@@ -38,7 +38,11 @@ http POST :8788/ingest/service.internal event:=\
 |--------|---------------------|---------|
 | 400    | `invalid domain`    | Domain verletzt das erlaubte Namensschema |
 | 400    | `invalid json`      | Request-Body ist kein gültiges UTF-8/JSON |
+| 400    | `invalid payload`   | JSON ist kein Objekt/Array aus Objekten bzw. enthält ungültige Domains |
+| 400    | `domain mismatch`   | Eingebettete `domain` unterscheidet sich von der Pfad-Domain |
 | 401    | `unauthorized`      | Header `X-Auth` fehlt oder stimmt nicht |
+| 411    | `length required`   | `Content-Length`-Header fehlt |
+| 413    | `payload too large` | Payload überschreitet 1 MiB |
 
 ## Datenpersistenz
-Alle Requests werden in Domain-spezifischen JSONL-Dateien gespeichert. Der Dateiname ergibt sich aus dem SHA-256-Hash der Domain (`<hash>[:32].jsonl`). Jede Zeile repräsentiert eine Payload als JSON-String.
+Alle Requests werden in Domain-spezifischen JSONL-Dateien gespeichert. Der Dateiname leitet sich aus der Domain ab (`<domain>.jsonl`) und wird nur bei extrem langen Domains mit einem 8-stelligen SHA-Suffix gekürzt. Jede Zeile repräsentiert eine Payload als JSON-String.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -8,7 +8,7 @@ Dieses Dokument fasst die wichtigsten Betriebs- und Wartungsaufgaben für den Le
 uvicorn app:app --host 0.0.0.0 --port 8788
 ```
 * Vor dem Start sicherstellen, dass `LEITSTAND_DATA_DIR` beschreibbar ist.
-* Optionale Secrets (`LEITSTAND_TOKEN`) per Secret-Store oder Deployment-Tool setzen.
+* `LEITSTAND_TOKEN` muss gesetzt sein (ohne Token startet der Dienst nicht).
 
 ### Stoppen
 * Uvicorn-Prozess kontrolliert beenden (z. B. per `Ctrl+C`, `systemctl stop`, Kubernetes Rollout etc.).
@@ -32,7 +32,7 @@ uvicorn app:app --host 0.0.0.0 --port 8788
 | Symptom                        | Maßnahme |
 |--------------------------------|----------|
 | `401 unauthorized`             | Token-Header prüfen, Abgleich mit `LEITSTAND_TOKEN`. |
-| `400 invalid domain`           | Domain-Format prüfen. Nur Kleinbuchstaben, Ziffern, `_` und `-` erlaubt. |
+| `400 invalid domain`           | Domain-Format prüfen. Nur Kleinbuchstaben, Ziffern und `-` erlaubt. |
 | `400 invalid json`             | Payload auf gültiges JSON prüfen. Sonderzeichen ggf. escapen. |
 | Keine neuen Dateien unter `data`| Schreibrechte des Prozesses und Pfadkonfiguration kontrollieren. |
 | Dienst startet nicht           | Fehlermeldungen im Uvicorn-Log auswerten, Python-Abhängigkeiten prüfen. |

--- a/scripts/ingest_append.py
+++ b/scripts/ingest_append.py
@@ -1,11 +1,50 @@
 #!/usr/bin/env python3
-import sys, os, json
-if len(sys.argv) < 3:
-    print("usage: ingest_append.py <domain> <json-payload>", file=sys.stderr); sys.exit(2)
-domain = sys.argv[1]
-payload = json.loads(sys.argv[2])
-os.makedirs("data", exist_ok=True)
-path = os.path.join("data", f"{domain}.jsonl")
-with open(path, "a", encoding="utf-8") as f:
-    f.write(json.dumps(payload, ensure_ascii=False) + "\n")
-print(path)
+"""CLI helper to append JSON payloads in the same format as the API."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from storage import DATA_DIR, DomainError, safe_target_path, sanitize_domain
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print("usage: ingest_append.py <domain> <json-payload>", file=sys.stderr)
+        return 2
+
+    _, domain, raw_payload = argv
+
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        print(f"invalid json payload: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        dom = sanitize_domain(domain)
+        target_path = safe_target_path(dom, data_dir=DATA_DIR)
+    except DomainError:
+        print("invalid domain", file=sys.stderr)
+        return 1
+
+    if not isinstance(payload, dict):
+        print("payload must be a JSON object", file=sys.stderr)
+        return 1
+
+    payload = dict(payload)
+    payload["domain"] = dom
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with target_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+    print(str(target_path))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv))

--- a/storage.py
+++ b/storage.py
@@ -81,7 +81,8 @@ def safe_target_path(domain: str, *, data_dir: Path | None = None) -> Path:
 
     base = DATA_DIR if data_dir is None else data_dir.resolve()
     candidate = (base / target_filename(domain)).resolve()
-    if not _is_under(candidate, base):
+    # Ensure the resolved path is *strictly* inside the data dir, not merely equal.
+    if not _is_under(candidate, base) or candidate == base:
         raise DomainError(domain)
     return candidate
 

--- a/storage.py
+++ b/storage.py
@@ -1,0 +1,87 @@
+"""Shared domain and storage helpers for Leitstand ingest components."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from pathlib import Path
+from typing import Final
+
+__all__ = [
+    "DATA_DIR",
+    "DomainError",
+    "sanitize_domain",
+    "secure_filename",
+    "target_filename",
+    "safe_target_path",
+]
+
+
+class DomainError(ValueError):
+    """Raised when a domain does not meet the validation requirements."""
+
+
+DATA_DIR: Final[Path] = Path(os.environ.get("LEITSTAND_DATA_DIR", "data")).resolve()
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+# RFC-nahe FQDN-Validierung: labels 1..63, a-z0-9 und '-' (kein '_' ), gesamt ≤ 253
+_DOMAIN_RE: Final[re.Pattern[str]] = re.compile(
+    r"^(?=.{1,253}$)"
+    r"(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)"
+    r"(?:\.(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?))*$"
+)
+
+_FNAME_MAX: Final[int] = 255  # typische FS-Grenze (ext4 etc.)
+
+# Zusätzliche Zeichen, die wir aus Sicherheitsgründen entfernen (neben / und \0)
+_UNSAFE_FILENAME_CHARS: Final[re.Pattern[str]] = re.compile(r"[][<>:\"|?*]")
+
+
+def sanitize_domain(domain: str) -> str:
+    """Normalize and validate an incoming domain name."""
+
+    d = (domain or "").strip().lower()
+    if not _DOMAIN_RE.fullmatch(d):
+        raise DomainError(domain)
+    return d
+
+
+def _is_under(path: Path, base: Path) -> bool:
+    try:
+        return path.is_relative_to(base)  # Python 3.9+
+    except AttributeError:
+        return os.path.commonpath([str(path), str(base)]) == str(base)
+
+
+def secure_filename(name: str) -> str:
+    """Sanitize filenames to avoid traversal or unsupported characters."""
+
+    name = name.replace("..", ".")
+    return _UNSAFE_FILENAME_CHARS.sub("", name)
+
+
+def target_filename(domain: str) -> str:
+    """Return a deterministic filename for a given domain."""
+
+    base = domain
+    ext = ".jsonl"
+    # Reserve 1–2 Zeichen Sicherheit wegen Encoding/FS
+    if len(base) + len(ext) > (_FNAME_MAX - 1):
+        h = hashlib.sha256(domain.encode("utf-8")).hexdigest()[:8]
+        # so viel wie möglich behalten, dann '-{hash}'
+        keep = max(16, (_FNAME_MAX - len(ext) - 1 - len(h)))  # 1 für '-'
+        base = f"{domain[:keep]}-{h}"
+    filename = f"{base}{ext}"
+    return secure_filename(filename)
+
+
+def safe_target_path(domain: str, *, data_dir: Path | None = None) -> Path:
+    """Return an absolute path below the data directory for the domain."""
+
+    base = DATA_DIR if data_dir is None else data_dir.resolve()
+    candidate = (base / target_filename(domain)).resolve()
+    if not _is_under(candidate, base):
+        raise DomainError(domain)
+    return candidate
+


### PR DESCRIPTION
## Summary
- reuse the HTTP-layer sanitization helper when computing filenames and storage paths
- allow the storage helper to accept already sanitized domains to avoid repeated work
- simplify the API documentation wording for the allowed domain format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f46b4de1f0832cbdf5fa5d4b99921f