### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-leitstand-fixtures.yml
+++ b/.github/workflows/validate-leitstand-fixtures.yml
@@ -1,4 +1,6 @@
 name: validate-leitstand-fixtures
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/heimgewebe/leitstand/security/code-scanning/12](https://github.com/heimgewebe/leitstand/security/code-scanning/12)

To fix this issue, we need to explicitly set a `permissions` block in the workflow file `.github/workflows/validate-leitstand-fixtures.yml`. This can be done either at the root (top-level, applying to all jobs), or per-job (inside each job, allowing for fine-grained control). Since both jobs ("fixtures" and "demo") primarily run a reusable workflow which is intended to validate JSONL files, and unless more privileged actions are actually required, the most restrictive reasonable starting point is usually:

```yaml
permissions:
  contents: read
```

This grants read-only access to repository contents, sufficient for most validation purposes and for reading files, but does not allow any write operations. If further permissions are needed for the jobs to work correctly (e.g., writing pull requests, commenting, etc.), you could add those explicitly.

**Change to make:**  
Add the permissions block after the workflow `name` but before `on` (top-level), as shown below. Only a single block is needed as both jobs can inherit top-level permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
