### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-leitstand-fixtures.yml
+++ b/.github/workflows/validate-leitstand-fixtures.yml
@@ -1,4 +1,6 @@
 name: validate-leitstand-fixtures
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/heimgewebe/leitstand/security/code-scanning/14](https://github.com/heimgewebe/leitstand/security/code-scanning/14)

To fix this issue, add a `permissions` block to the workflow YAML file specifying the least required privileges for the jobs. Since the jobs just validate JSONL files using another workflow, it is almost certain that only read access to repository contents is sufficient. The correct fix is to add `permissions: contents: read` at the workflow level, just below the workflow `name`, so all jobs inherit this minimal permission. No changes to functionality and no changes within job definitions are necessary. If, in the future, more permissions are needed, those can be added granularly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
