### PR TITLE
Potential fix for code scanning alert no. 10: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,7 +45,10 @@ def _is_under(path: Path, base: Path) -> bool:
     try:
         return path.is_relative_to(base)  # Py 3.9+
     except AttributeError:
-        return os.path.commonpath([str(path), str(base)]) == str(base)
+        # Ensure both paths are absolute and normalized before comparison
+        path_resolved = Path(path).resolve()
+        base_resolved = Path(base).resolve()
+        return os.path.commonpath([str(path_resolved), str(base_resolved)]) == str(base_resolved)
 
 
 _FNAME_MAX: Final[int] = 255  # typische FS-Grenze (ext4 etc.)

--- a/app.py
+++ b/app.py
@@ -45,10 +45,10 @@ def _is_under(path: Path, base: Path) -> bool:
     try:
         return path.is_relative_to(base)  # Py 3.9+
     except AttributeError:
-        # Ensure both paths are absolute and normalized before comparison
-        path_resolved = Path(path).resolve()
-        base_resolved = Path(base).resolve()
-        return os.path.commonpath([str(path_resolved), str(base_resolved)]) == str(base_resolved)
+        # Ensure both paths are absolute and normalized before comparison (no Path constructor on tainted input)
+        path_abs = os.path.abspath(str(path))
+        base_abs = os.path.abspath(str(base))
+        return os.path.commonpath([path_abs, base_abs]) == base_abs
 
 
 _FNAME_MAX: Final[int] = 255  # typische FS-Grenze (ext4 etc.)


### PR DESCRIPTION
Potential fix for [https://github.com/heimgewebe/leitstand/security/code-scanning/10](https://github.com/heimgewebe/leitstand/security/code-scanning/10)

The main potential issue is that the fallback branch of `_is_under()`, which uses `os.path.commonpath`, compares strings directly:
```py
return os.path.commonpath([str(path), str(base)]) == str(base)
```
If `str(base)` is not resolved to an absolute path, a clever crafted path could match as a prefix but actually escape the containment boundary. To fix, both `path` and `base` should be resolved (i.e., absolute paths) when passed through this check.

Therefore,
- Update the fallback logic in `_is_under` so it compares the absolute, resolved string versions of both path and base.
  - Both should be passed via `.resolve()`.
- This can be done by updating only the `_is_under` function in app.py.
- No new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
