### PR TITLE
Potential fix for code scanning alert no. 11: Uncontrolled data used in path expression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi>=0.110
+Werkzeug==3.1.3
 uvicorn[standard]>=0.27
 filelock>=3.13
 pytest


### PR DESCRIPTION
Potential fix for [https://github.com/heimgewebe/leitstand/security/code-scanning/11](https://github.com/heimgewebe/leitstand/security/code-scanning/11)

The best way to fix this issue, per industry best practices, is to use a well-known and thoroughly vetted filename sanitization library—in Python, typically `werkzeug.utils.secure_filename`—in place of, or in addition to, the existing custom `_secure_filename` logic. This approach ensures that the process for cleaning user-provided filenames is robust against all common filesystem path attacks, including odd Unicode cases or alternate directory separators on Windows.

To implement this:
- Import `secure_filename` from `werkzeug.utils`.
- In `_secure_filename`, instead of using the custom regular expression, delegate to `secure_filename`.
- Remove or supplement regular expression-based filtering only as necessary, preserving needed safeguards (e.g., blocking "..").
- Ensure the returned filename is not empty and fits within filesystem limits.

All changes occur in app.py, in the region defining and using `_secure_filename`. You only need to add the import for `secure_filename` and update `_secure_filename` to use it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
