### PR TITLE
Potential fix for code scanning alert no. 20: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -131,6 +131,9 @@ async def ingest(
     # Use canonical and sanitized path components from target_path
     fname = target_path.name
 
+    # Ensure fname is exactly as expected for sanitized domain
+    if fname != target_filename(dom):
+        raise HTTPException(status_code=400, detail="invalid target")
     if os.path.basename(fname) != fname or ".." in fname:
         raise HTTPException(status_code=400, detail="invalid target")
     if not re.fullmatch(r"[a-z0-9][a-z0-9.-]{0,240}\.jsonl", fname):


### PR DESCRIPTION
Potential fix for [https://github.com/heimgewebe/leitstand/security/code-scanning/20](https://github.com/heimgewebe/leitstand/security/code-scanning/20)

To fully eliminate the risk and silence the warning, verify that the constructed `fname`—used for filesystem operations—is exactly the output produced by the trusted `target_filename()` function for the sanitized domain. This is a redundancy that raises the bar for future code changes and satisfies CodeQL's requirements.

- **General fix:** Before any file operation, ensure `fname == target_filename(dom)`, and abort otherwise. This ensures that *only* the expected sanitized filename can ever be used, preventing any accidental or deliberate bypass due to future code regression or subtle encoding tricks.
- **Detailed fix:**  
  - In `app.py`, just before file access—after the file name checks—add a line comparing `fname` to the output of `target_filename(dom)` (where `dom` is the sanitized domain string from above), and reject all other filenames with an HTTP 400.
  - No additional imports or dependencies are needed, just an extra check right before file operations in the `ingest` route.
- **Files/regions/lines to change:**  
  - Edit `app.py` inside the `ingest` endpoint, after setting `fname = target_path.name` (line 132) and before accessing the file (i.e., after the other checks and before the lock).
  - Use the same import of `target_filename` as already included.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
