### PR TITLE
Potential fix for code scanning alert no. 24: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from storage import (
     safe_target_path,
     sanitize_domain,
     target_filename,
+    _is_under,
 )
 
 if TYPE_CHECKING:
@@ -135,6 +136,11 @@ async def ingest(
         raise HTTPException(status_code=400, detail="invalid target")
     if not re.fullmatch(r"[a-z0-9][a-z0-9.-]{0,240}\.jsonl", fname):
         raise HTTPException(status_code=400, detail="invalid target")
+    # Extra normalization/containment check before file access
+    access_path = (DATA / fname).resolve(strict=False)
+    data_dir_resolved = DATA.resolve(strict=True)
+    if not _is_under(access_path, data_dir_resolved):
+        raise HTTPException(status_code=400, detail="invalid target path: path escape detected")
     lock_path = target_path.parent / (fname + ".lock")
     with FileLock(str(lock_path)):
         # Defense-in-depth: always use trusted DATA_DIR for dirfd

--- a/app.py
+++ b/app.py
@@ -137,7 +137,7 @@ async def ingest(
     if not re.fullmatch(r"[a-z0-9][a-z0-9.-]{0,240}\.jsonl", fname):
         raise HTTPException(status_code=400, detail="invalid target")
     # Extra normalization/containment check before file access
-    access_path = (DATA / fname).resolve(strict=False)
+    access_path = target_path.resolve(strict=False)
     data_dir_resolved = DATA.resolve(strict=True)
     if not _is_under(access_path, data_dir_resolved):
         raise HTTPException(status_code=400, detail="invalid target path: path escape detected")

--- a/storage.py
+++ b/storage.py
@@ -86,10 +86,10 @@ def safe_target_path(domain: str, *, data_dir: Path | None = None) -> Path:
     # Extra defense: enforce no separators after sanitizing (helps static analyzers)
     if "/" in fname or "\\" in fname:
         raise DomainError(domain)
-    # Join with trusted base. CodeQL: fname is sanitized and checked above.
-    candidate = (base / fname).resolve(strict=False)  # canonicalize before check
+    # Solution: normalize joined path before containment check
+    candidate = (base / fname).resolve(strict=True)  # canonicalize with strict=True
     base_resolved = base  # already resolved above
-    # Containment check using canonical base directory
+    # Containment check using canonical base directory and normalized paths
     if not _is_under(candidate, base_resolved):
         raise DomainError(domain)
     return candidate

--- a/storage.py
+++ b/storage.py
@@ -87,8 +87,9 @@ def safe_target_path(domain: str, *, data_dir: Path | None = None) -> Path:
     if "/" in fname or "\\" in fname:
         raise DomainError(domain)
     # Join with trusted base. CodeQL: fname is sanitized and checked above.
-    candidate = base / fname  # codeql[py/uncontrolled-data-in-path-expression]
+    candidate = (base / fname).resolve(strict=False)  # canonicalize before check
+    base_resolved = base  # already resolved above
     # Containment check using canonical base directory
-    if not _is_under(candidate, base):
+    if not _is_under(candidate, base_resolved):
         raise DomainError(domain)
     return candidate


### PR DESCRIPTION
Potential fix for [https://github.com/heimgewebe/leitstand/security/code-scanning/24](https://github.com/heimgewebe/leitstand/security/code-scanning/24)

The best way to fix this issue is to add an extra layer of path validation before using any filename that originated from user input (in this case, indirectly from the `domain` path parameter) in a filesystem operation. Specifically, after generating the canonical `target_path` via the helper, and before passing the filename to the `os.open` call, ensure that the resolved/absolute path of the file is strictly contained within the intended data directory. This can be done by normalizing the full file path and checking it starts with/resides under the canonical data directory (which in Python can be done by resolving both and checking one is a subdirectory of the other). 

Concretely, in the `ingest` handler in `app.py`, after determining `fname`, before using `os.open`, resolve the full intended path (`DATA/fname`), make sure it's inside `DATA` by using helper logic (e.g., similar to `_is_under` from `storage.py`). If it is not, abort with an error.

Minimal code changes required:
1. Add normalization/resolution of the full path (`DATA / fname`) before `os.open`.
2. Use an `_is_under` containment check to ensure the normalized path is indeed a child of the `DATA` directory.
3. If not, abort with a 400 error.
4. `storage.py` already contains `_is_under` – so import and use it in `app.py`.

Specific edits:
- In `app.py`, before line 139 (`with FileLock(str(lock_path)):`), insert containment/normalization check for the file to be written (i.e., `DATA / fname`).
- Add `_is_under` to app.py import from storage.py.
- Use that helper to validate the actual access path.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
