### PR TITLE
test: Improve `secure_filename` test coverage

### DIFF
--- a/test_app.py
+++ b/test_app.py
@@ -64,6 +64,7 @@ def test_secure_filename_rejects_nested_traversal():
     assert ".." not in storage.secure_filename("..test")
     assert ".." not in storage.secure_filename("test..")
     assert ".." not in storage.secure_filename("...test...")
+    assert storage.secure_filename("....test") == ".test"
 
 
 def test_ingest_single_object(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
Add a new assertion to `test_secure_filename_rejects_nested_traversal` to verify that `....test` is correctly sanitized to `.test`. This improves the test coverage for the `secure_filename` function.