### PR TITLE
Pin rate limiting and metrics dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ uvicorn[standard]>=0.27
 filelock>=3.13
 pytest
 httpx
+slowapi>=0.1.8,<0.2
+prometheus-fastapi-instrumentator>=6.1.0,<7


### PR DESCRIPTION
## Summary
- pin SlowAPI dependency to the 0.1.x series for stability
- constrain Prometheus FastAPI Instrumentator to the 6.x series to avoid breaking changes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fdaf0423c4832cb3f1e5292a6bfe19