### PR TITLE
Fix: Behebt Pfad-Traversal-Schwachstelle in secure_filename

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 fastapi>=0.110
-Werkzeug==3.1.3
 uvicorn[standard]>=0.27
 filelock>=3.13
 prometheus-fastapi-instrumentator>=6.1,<7

--- a/storage.py
+++ b/storage.py
@@ -61,7 +61,7 @@ def _is_under(path: Path, base: Path) -> bool:
 def secure_filename(name: str) -> str:
     """Sanitize filenames to avoid traversal or unsupported characters."""
 
-    s_name = name
+    s_name = name.replace("/", "").replace("\\", "")
     while ".." in s_name:
         s_name = s_name.replace("..", ".")
     return _UNSAFE_FILENAME_CHARS.sub("", s_name)

--- a/storage.py
+++ b/storage.py
@@ -61,7 +61,7 @@ def _is_under(path: Path, base: Path) -> bool:
 def secure_filename(name: str) -> str:
     """Sanitize filenames to avoid traversal or unsupported characters."""
 
-    s_name = name.replace("/", "").replace("\\", "")
+    s_name = name.replace("/", "").replace(r"\\", "")
     while ".." in s_name:
         s_name = s_name.replace("..", ".")
     return _UNSAFE_FILENAME_CHARS.sub("", s_name)

--- a/test_app.py
+++ b/test_app.py
@@ -66,6 +66,11 @@ def test_secure_filename_rejects_nested_traversal():
     assert ".." not in storage.secure_filename("test..")
     assert ".." not in storage.secure_filename("...test...")
     assert storage.secure_filename("....test") == ".test"
+    assert "/" not in storage.secure_filename("a/b")
+    assert ".." not in storage.secure_filename("..")
+    assert ".." not in storage.secure_filename("../")
+    assert ".." not in storage.secure_filename("/..")
+    assert ".." not in storage.secure_filename("a/../b")
 
 
 def test_ingest_single_object(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
Die `secure_filename`-Funktion in `storage.py` hat Schrägstriche nicht korrekt entfernt, was zu einer Pfad-Traversal-Schwachstelle führen konnte.

Diese Änderung behebt das Problem, indem sie Schrägstriche entfernt, bevor die `..`-Ersetzung stattfindet. Außerdem wurden Tests hinzugefügt, um die Korrektur zu überprüfen, und die nicht verwendete `Werkzeug`-Abhängigkeit wurde entfernt.