### PR TITLE
Fix: Correctly handle backslashes in secure_filename

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -61,7 +61,7 @@ def _is_under(path: Path, base: Path) -> bool:
 def secure_filename(name: str) -> str:
     """Sanitize filenames to avoid traversal or unsupported characters."""
 
-    s_name = name.replace("/", "").replace(r"\\", "")
+    s_name = name.replace("/", "").replace("\\", "")
     while ".." in s_name:
         s_name = s_name.replace("..", ".")
     return _UNSAFE_FILENAME_CHARS.sub("", s_name)

--- a/test_app.py
+++ b/test_app.py
@@ -67,6 +67,7 @@ def test_secure_filename_rejects_nested_traversal():
     assert ".." not in storage.secure_filename("...test...")
     assert storage.secure_filename("....test") == ".test"
     assert "/" not in storage.secure_filename("a/b")
+    assert "\\" not in storage.secure_filename("a\\b")
     assert ".." not in storage.secure_filename("..")
     assert ".." not in storage.secure_filename("../")
     assert ".." not in storage.secure_filename("/..")


### PR DESCRIPTION
The secure_filename function was not correctly handling backslashes, which could lead to a path traversal vulnerability on Windows systems.

This commit fixes the issue by replacing backslashes and adds a test case to verify the fix.