### PR TITLE
Fix: Sanitize backslashes in secure_filename

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -61,7 +61,7 @@ def _is_under(path: Path, base: Path) -> bool:
 def secure_filename(name: str) -> str:
     """Sanitize filenames to avoid traversal or unsupported characters."""
 
-    s_name = name.replace("/", "").replace(r"\\", "")
+    s_name = name.replace("/", "").replace("\\", "")
     while ".." in s_name:
         s_name = s_name.replace("..", ".")
     return _UNSAFE_FILENAME_CHARS.sub("", s_name)

--- a/test_app.py
+++ b/test_app.py
@@ -67,6 +67,7 @@ def test_secure_filename_rejects_nested_traversal():
     assert ".." not in storage.secure_filename("...test...")
     assert storage.secure_filename("....test") == ".test"
     assert "/" not in storage.secure_filename("a/b")
+    assert "\\" not in storage.secure_filename("a\\b")
     assert ".." not in storage.secure_filename("..")
     assert ".." not in storage.secure_filename("../")
     assert ".." not in storage.secure_filename("/..")


### PR DESCRIPTION
The `secure_filename` function in `storage.py` incorrectly used `r"\\"` to remove backslashes, which only matches a double backslash. This left single backslashes in the filename, creating a potential path traversal vulnerability, especially on Windows systems.

This commit corrects the issue by changing the replacement string to `"\\"` to ensure single backslashes are properly sanitized. A new test case has been added to `test_app.py` to verify the fix and prevent regressions.