### PR TITLE
chore: prepare v0.5.0 release notes and retry guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v0.5.0 – Hardening & Observability
-- Rate Limiting (429) + Lock-Timeout -> 429
+- Rate Limiting (429) + Lock-Timeout (503)
 - Prometheus /metrics
 - Striktes Filename-Matching, Domain-Validation
 - Content-Length & 1 MiB Limit (konfigurierbar)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## v0.5.0 – Hardening & Observability
+- Rate Limiting (429) + Lock-Timeout -> 429
+- Prometheus /metrics
+- Striktes Filename-Matching, Domain-Validation
+- Content-Length & 1 MiB Limit (konfigurierbar)
+- Doku & Makefile fixes

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ In GitHub Codespaces sollte der Port 8788 veröffentlicht werden, um Anfragen an
 * `401 Unauthorized`: Token fehlt oder stimmt nicht.
 * `411 Length Required`: `Content-Length`-Header fehlt.
 * `413 Payload Too Large`: Request-Body überschreitet `LEITSTAND_MAX_BODY`.
-* `429 Too Many Requests`: Rate-Limit aus `LEITSTAND_RATE_LIMIT` erreicht. Die Antwort enthält zusätzlich `Retry-After` sowie die Header `X-RateLimit-Limit` und `X-RateLimit-Remaining` (SlowAPI kümmert sich um die Berechnung dieser Werte).
+* `429 Too Many Requests`: Rate-Limit aus `LEITSTAND_RATE_LIMIT` erreicht. Die Antwort enthält zusätzlich `Retry-After` sowie die Header `X-RateLimit-Limit` und `X-RateLimit-Remaining` (SlowAPI kümmert sich um die Berechnung dieser Werte). Ein Beispiel für einen Client-Backoff findet sich in [docs/cli-curl.md](docs/cli-curl.md).
 * `503 Service Unavailable`: Schreibzugriff blockiert (`LEITSTAND_LOCK_TIMEOUT` überschritten).
 * `507 Insufficient Storage`: Kein freier Speicherplatz im Zielverzeichnis.
 

--- a/docs/cli-curl.md
+++ b/docs/cli-curl.md
@@ -33,4 +33,5 @@ for i in 1 2 3 4 5; do
   [ "$code" != "429" ] && echo "fail:$code" && exit 1
   sleep $((2**i))
 done
+echo "failed after 5 retries" && exit 1
 ```

--- a/docs/cli-curl.md
+++ b/docs/cli-curl.md
@@ -21,3 +21,16 @@ cat "$LEITSTAND_DATA_DIR/example.com.jsonl"
 
 ```
 
+
+# Beispiel: 429 Retry mit Curl (exponentielles Backoff bis 5x)
+```bash
+for i in 1 2 3 4 5; do
+  code=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "X-Auth:$LEITSTAND_TOKEN" -H "Content-Type: application/json" \
+    -d '{"event":"batch","status":"ok"}' \
+    http://localhost:8788/ingest/example.com)
+  [ "$code" = "200" ] && echo ok && break
+  [ "$code" != "429" ] && echo "fail:$code" && exit 1
+  sleep $((2**i))
+done
+```

--- a/docs/cli-curl.md
+++ b/docs/cli-curl.md
@@ -22,7 +22,7 @@ cat "$LEITSTAND_DATA_DIR/example.com.jsonl"
 ```
 
 
-# Beispiel: 429 Retry mit Curl (exponentielles Backoff bis 5x)
+# Beispiel: 429 Retry mit Curl (exponentieller Backoff, bis zu 5 Versuche)
 ```bash
 for i in 1 2 3 4 5; do
   code=$(curl -s -o /dev/null -w "%{http_code}" \


### PR DESCRIPTION
## Summary
- add the v0.5.0 release notes to the changelog
- document a curl retry loop so clients can gracefully recover from 429s
- mention the retry guidance in the API & Contracts section of the README

## Testing
- not run (doc-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df342e5c8832c8eccf4faafd5c4e0)