### PR TITLE
leitstand: feat(ingest): Add hauski_ingest client library and hermeti…

### DIFF
--- a/tools/hauski_ingest.py
+++ b/tools/hauski_ingest.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any, Mapping, MutableMapping, Optional
+
+import httpx
+
+__all__ = ["ingest_event", "IngestError"]
+
+
+class IngestError(RuntimeError):
+    """Raised when an ingest attempt ultimately fails."""
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def ingest_event(
+    domain: str,
+    data: Mapping[str, Any],
+    *,
+    url: Optional[str] = None,
+    token: Optional[str] = None,
+    timeout: Optional[float] = None,
+    retries: Optional[int] = None,
+    backoff: Optional[float] = None,
+    transport: Optional[httpx.BaseTransport] = None,
+) -> str:
+    """
+    Send a single JSON event to Leitstand.
+
+    Args:
+        domain: target domain (e.g. "example.com")
+        data: JSON-serializable mapping with at least an "event" field
+        url: base URL of Leitstand (env LEITSTAND_URL if None)
+        token: shared secret for X-Auth (env LEITSTAND_TOKEN if None)
+        timeout: request timeout seconds (env LEITSTAND_TIMEOUT, default 5)
+        retries: retry count for 429/5xx/timeout (env LEITSTAND_RETRIES, default 3)
+        backoff: initial backoff seconds (env LEITSTAND_BACKOFF, default 0.5)
+        transport: optional httpx transport (e.g., httpx.ASGITransport) for in-process testing
+
+    Returns:
+        "ok" on success
+
+    Raises:
+        IngestError on permanent failure or invalid configuration
+    """
+    base_url = (url or os.getenv("LEITSTAND_URL") or "http://localhost:8788").rstrip("/")
+    tok = token or os.getenv("LEITSTAND_TOKEN")
+    if not tok:
+        raise IngestError("LEITSTAND_TOKEN not set")
+
+    t = float(timeout if timeout is not None else _env_float("LEITSTAND_TIMEOUT", 5.0))
+    n = int(retries if retries is not None else _env_int("LEITSTAND_RETRIES", 3))
+    b0 = float(backoff if backoff is not None else _env_float("LEITSTAND_BACKOFF", 0.5))
+
+    # Validate payload early (must be JSON-serializable mapping)
+    if not isinstance(data, Mapping):
+        raise IngestError("payload must be a mapping")
+    if "event" not in data:
+        # nicht strikt nötig, aber hilfreich für Konsistenz
+        raise IngestError('payload missing required key "event"')
+
+    # httpx client per call keeps things simple for small volumes
+    base_url = base_url  # ensure we keep a base for ASGITransport clients
+    url_full = f"{base_url}/ingest/{domain}"
+    headers = {"X-Auth": tok, "Content-Type": "application/json"}
+    payload: MutableMapping[str, Any] = dict(data)
+
+    # Let server enforce "domain" field; if caller sets it, do not contradict path
+    # (server already checks for mismatch and will 400 if different).
+
+    for attempt in range(0, n + 1):
+        try:
+            # If transport is provided (e.g., ASGITransport), no real sockets are used.
+            with httpx.Client(timeout=t, base_url=base_url, transport=transport) as client:
+                r = client.post(url_full, headers=headers, json=payload)
+        except (httpx.TimeoutException, httpx.NetworkError) as exc:
+            if attempt < n:
+                time.sleep(b0 * (2**attempt))
+                continue
+            raise IngestError(f"network/timeout after {attempt} retries") from exc
+
+        # Fast path
+        if r.status_code == 200 and r.text.strip() == "ok":
+            return "ok"
+
+        # Retryable statuses
+        if r.status_code in (429, 500, 502, 503, 504):
+            if attempt < n:
+                time.sleep(b0 * (2**attempt))
+                continue
+            raise IngestError(f"ingest failed with {r.status_code} after {attempt} retries: {r.text}")
+
+        # Non-retryable: raise immediately with details
+        try:
+            detail = r.json()
+        except json.JSONDecodeError:
+            detail = r.text
+        raise IngestError(f"ingest rejected: {r.status_code} {detail}")
+
+    # Should not get here
+    raise IngestError("ingest failed unexpectedly")


### PR DESCRIPTION
…c tests

Adds a new client library `tools/hauski_ingest.py` to facilitate sending events to the Leitstand service from other modules in the HausKI ecosystem.

Key features:
- Configurable via environment variables for URL, token, timeout, and retries.
- Includes exponential backoff for retries on 429/5xx/timeout errors.
- Supports hermetic testing via a custom synchronous `httpx` transport wrapper, allowing in-process tests against the FastAPI app without real network sockets.

Also includes:
- A new hermetic test `tests/test_ingest_client.py`.
- Updated `README.md` with documentation for the new client library and testing approach.