### PR TITLE
feat(api): Add OpenAPI spec, linting, and update docs

### DIFF
--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -1,0 +1,18 @@
+name: openapi-lint
+on:
+  pull_request:
+    paths: ['docs/openapi.yaml']
+  push:
+    paths: ['docs/openapi.yaml']
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Lint OpenAPI (redocly)
+        run: |
+          npx --yes @redocly/cli@1.16.0 lint docs/openapi.yaml

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -1,4 +1,6 @@
 name: openapi-lint
+permissions:
+  contents: read
 on:
   pull_request:
     paths: ['docs/openapi.yaml']

--- a/README.md
+++ b/README.md
@@ -66,28 +66,12 @@ In GitHub Codespaces sollte der Port 8788 veröffentlicht werden, um Anfragen an
 | `LEITSTAND_RATE_LIMIT` | nein    | `60/minute` | Rate-Limit pro Quell-IP (SlowAPI-Format). |
 | `LOG_LEVEL`            | nein    | `INFO`   | Log-Level (z. B. `DEBUG`, `INFO`, `WARNING`). |
 
-## API & Contracts
+## API
 
-### `GET /version`
-* **Header** `X-Auth`: identisch zu den anderen Endpunkten.
-* **Antwort**: `{ "version": "<wert>" }`. Der Wert entspricht der Konstante `VERSION` bzw. der Umgebungsvariablen `LEITSTAND_VERSION`.
+Siehe die OpenAPI-Spezifikation unter [`docs/openapi.yaml`](./docs/openapi.yaml).
 
-### `GET /metrics`
-* **Auth**: Keine. Exponiert Prometheus-Metriken (Request-Latenz, -Zähler etc.).
-
-### Typische Fehlercodes
-* `401 Unauthorized`: Token fehlt oder stimmt nicht.
-* `411 Length Required`: `Content-Length`-Header fehlt.
-* `413 Payload Too Large`: Request-Body überschreitet `LEITSTAND_MAX_BODY`.
-* `429 Too Many Requests`: Rate-Limit aus `LEITSTAND_RATE_LIMIT` erreicht. Die Antwort enthält zusätzlich `Retry-After` sowie die Header `X-RateLimit-Limit` und `X-RateLimit-Remaining` (SlowAPI kümmert sich um die Berechnung dieser Werte). Ein Beispiel für einen Client-Backoff findet sich in [docs/cli-curl.md](docs/cli-curl.md).
-* `503 Service Unavailable`: Schreibzugriff blockiert (`LEITSTAND_LOCK_TIMEOUT` überschritten).
-* `507 Insufficient Storage`: Kein freier Speicherplatz im Zielverzeichnis.
-
-Weitere Beispiele und Details finden sich in der begleitenden Dokumentation:
-
-* [docs/api.md](docs/api.md) – Ausführliche API-Dokumentation.
-* [docs/cli-curl.md](docs/cli-curl.md) – Curl-Beispiele für Health-, Version- und Ingest-Aufrufe.
-* [docs/event-contracts.md](docs/event-contracts.md) – Beschreibung des JSONL-Speicherlayouts und referenziertes Schema.
+> **Deprecation (6 Monate):** Domainspezifische Endpoints (`/ingest/aussen`, …) sind veraltet.
+> Bitte auf `POST /v1/ingest` migrieren. Die Domain wird per `event.domain` oder `?domain=aussen` bestimmt.
 
 ## Datenspeicherung
 * Für jede Domain entsteht eine JSONL-Datei im Verzeichnis `LEITSTAND_DATA_DIR`.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: Leitstand Ingest API
+  version: 1.0.0
+paths:
+  /v1/ingest:
+    post:
+      summary: Universal event ingest (JSON or NDJSON)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Event'
+          application/x-ndjson:
+            schema:
+              type: string
+              description: NDJSON stream of Event objects (one per line)
+      responses:
+        '202':
+          description: Accepted
+components:
+  schemas:
+    Event:
+      type: object
+      required: [ts, type, source]
+      additionalProperties: true


### PR DESCRIPTION
- Adds a new OpenAPI v3 specification at `docs/openapi.yaml` to serve as the single source of truth for API documentation.
- Introduces a new GitHub Actions workflow (`.github/workflows/openapi-lint.yml`) to automatically lint the OpenAPI specification using Redocly CLI on every push and pull request.
- Updates `README.md` to remove outdated, manual API descriptions and replace them with a link to the new OpenAPI file.
- Includes a deprecation notice in `README.md` for older, domain-specific endpoints, guiding users to migrate to the new `/v1/ingest` endpoint.