### PR TITLE
leitstand: add validate-aussen workflow

### DIFF
--- a/.github/workflows/validate-aussen.yml
+++ b/.github/workflows/validate-aussen.yml
@@ -1,0 +1,19 @@
+name: validate-aussen
+on:
+  pull_request:
+    paths:
+      - 'export/**.jsonl'
+      - 'fixtures/**.jsonl'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    uses: heimgewebe/metarepo/.github/workflows/reusable-validate-jsonl.yml@contracts-v1
+    with:
+      jsonl_paths_list: |
+        export/*.jsonl
+        fixtures/aussen/**/*.jsonl
+      schema_url: https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/aussen.event.schema.json
+      strict: false
+      validate_formats: true
+      fail_on_empty: false

--- a/.github/workflows/validate-aussen.yml
+++ b/.github/workflows/validate-aussen.yml
@@ -1,4 +1,6 @@
 name: validate-aussen
+permissions:
+  contents: read
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Adds a GitHub Actions workflow to validate aussen JSONL files against the schema from the metarepo.