### PR TITLE
feat(client): add Rust leitstand_producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Siehe die OpenAPI-Spezifikation unter [`docs/openapi.yaml`](./docs/openapi.yaml)
 > **Deprecation (6 Monate):** Domainspezifische Endpoints (`/ingest/aussen`, …) sind veraltet.
 > Bitte auf `POST /v1/ingest` migrieren. Die Domain wird per `event.domain` oder `?domain=aussen` bestimmt.
 
+## Clients
+- **Rust (Stub):** `clients/rust/leitstand_producer`
+  - Blocking (default) und optional `async` Feature.
+  - Beispiel: `cargo run --example send` (läuft gegen `POST /v1/ingest`).
+
 ## Datenspeicherung
 * Für jede Domain entsteht eine JSONL-Datei im Verzeichnis `LEITSTAND_DATA_DIR`.
 * Der Dateiname entspricht der Domain (`<domain>.jsonl`). Extrem lange Domains werden automatisch gekürzt und erhalten einen 8-stelligen Hash-Suffix (z. B. `very-long…-1a2b3c4d.jsonl`), um Dateisystemlimits einzuhalten.

--- a/clients/rust/leitstand_producer/.gitignore
+++ b/clients/rust/leitstand_producer/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/clients/rust/leitstand_producer/Cargo.toml
+++ b/clients/rust/leitstand_producer/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "leitstand_producer"
+version = "0.0.1"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Minimal client to send events to leitstand /v1/ingest"
+repository = "https://github.com/heimgewebe/leitstand"
+
+[features]
+default = ["blocking"]
+blocking = ["reqwest/blocking", "serde_json"]
+async = ["reqwest/json", "tokio", "serde_json", "futures-util", "bytes"]
+
+[dependencies]
+reqwest = { version = "0.12", default-features = true, features = ["json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", optional = true }
+thiserror = "1"
+tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
+futures-util = { version = "0.3", optional = true }
+bytes = { version = "1", optional = true }

--- a/clients/rust/leitstand_producer/examples/send.rs
+++ b/clients/rust/leitstand_producer/examples/send.rs
@@ -1,0 +1,21 @@
+use leitstand_producer::ProducerClient;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct MyEvent {
+ ts: String,
+ source: &'static str,
+ value: i32,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+ let client = ProducerClient::new("http://localhost:7070");
+ let e = MyEvent {
+ ts: "2025-01-01T12:00:00Z".into(),
+ source: "example",
+ value: 42,
+ };
+ client.send_one(&e)?;
+ println!("sent");
+ Ok(())
+}

--- a/clients/rust/leitstand_producer/src/lib.rs
+++ b/clients/rust/leitstand_producer/src/lib.rs
@@ -1,0 +1,112 @@
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ProducerError {
+    #[error("http error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+#[derive(Clone, Debug)]
+pub struct ProducerClient {
+    base_url: String,
+    #[cfg(feature = "blocking")]
+    client: reqwest::blocking::Client,
+    #[cfg(feature = "async")]
+    async_client: reqwest::Client,
+}
+
+impl ProducerClient {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            #[cfg(feature = "blocking")]
+            client: reqwest::blocking::Client::new(),
+            #[cfg(feature = "async")]
+            async_client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[cfg(feature = "blocking")]
+impl ProducerClient {
+    pub fn send_one<T: Serialize>(&self, event: &T) -> Result<(), ProducerError> {
+        let line = serde_json::to_string(event)? + "\n";
+        let url = format!("{}/v1/ingest", self.base_url.trim_end_matches('/'));
+        self.client
+            .post(&url)
+            .header(reqwest::header::CONTENT_TYPE, "application/x-ndjson")
+            .body(line)
+            .send()?
+            .error_for_status()?;
+        Ok(())
+    }
+
+    pub fn send_iter<T, I>(&self, events: I) -> Result<(), ProducerError>
+    where
+        T: Serialize,
+        I: IntoIterator<Item = T>,
+    {
+        let mut ndjson = String::new();
+        for e in events {
+            ndjson.push_str(&serde_json::to_string(&e)?);
+            ndjson.push('\n');
+        }
+        let url = format!("{}/v1/ingest", self.base_url.trim_end_matches('/'));
+        self.client
+            .post(&url)
+            .header(reqwest::header::CONTENT_TYPE, "application/x-ndjson")
+            .body(ndjson)
+            .send()?
+            .error_for_status()?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "async")]
+mod r#async {
+    use super::{ProducerClient, ProducerError};
+    use bytes::Bytes;
+    use futures_util::stream::{Stream, StreamExt};
+    use reqwest::Body;
+    use serde::Serialize;
+
+    impl ProducerClient {
+        pub async fn send_one_async<T: Serialize>(&self, event: &T) -> Result<(), ProducerError> {
+            let line = serde_json::to_string(event)? + "\n";
+            let url = format!("{}/v1/ingest", self.base_url.trim_end_matches('/'));
+            self.async_client
+                .post(&url)
+                .header(reqwest::header::CONTENT_TYPE, "application/x-ndjson")
+                .body(line)
+                .send()
+                .await?
+                .error_for_status()?;
+            Ok(())
+        }
+
+        pub async fn send_iter_async<T, S>(&self, events: S) -> Result<(), ProducerError>
+        where
+            T: Serialize,
+            S: Stream<Item = T> + Send + Sync + 'static,
+        {
+            let url = format!("{}/v1/ingest", self.base_url.trim_end_matches('/'));
+            let body = Body::wrap_stream(events.map(|item| -> Result<Bytes, _> {
+                let mut line = serde_json::to_vec(&item)?;
+                line.push(b'\n');
+                Ok(line.into())
+            }));
+
+            self.async_client
+                .post(&url)
+                .header(reqwest::header::CONTENT_TYPE, "application/x-ndjson")
+                .body(body)
+                .send()
+                .await?
+                .error_for_status()?;
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
Adds a minimal Rust client for sending events to the /v1/ingest endpoint.

The client supports both blocking and async operations, and can send single events or streams of events as NDJSON.

Includes an example application and documentation.