### PR TITLE
feat(api): Document domain parameter for /v1/ingest

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -13,6 +13,14 @@ paths:
     post:
       summary: Universal ingest endpoint
       operationId: ingestEvent
+      description: Domain must be specified either via query parameter or as a field in the payload.
+      parameters:
+        - name: domain
+          in: query
+          description: Target domain for the event. Can also be supplied in the payload.
+          required: false
+          schema:
+            type: string
       security:
         - XAuth: []
       requestBody:


### PR DESCRIPTION
The new OpenAPI entry for `/v1/ingest` no longer advertises any way to provide the required domain (no query parameter, no body property). However, the handler still rejects requests that lack a domain, raising HTTPException(status_code=400, detail="domain must be specified via query or payload").

A client generated from this spec will omit the domain field and will therefore fail every call with a 400 response.

This commit reintroduces the domain parameter and documents how it must be supplied so the spec matches the actual API.