### PR TITLE
Make debug mode configurable

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,10 +35,11 @@ MAX_PAYLOAD_SIZE: Final[int] = int(os.getenv("CHRONIK_MAX_BODY", str(1024 * 1024
 LOCK_TIMEOUT: Final[int] = int(os.getenv("CHRONIK_LOCK_TIMEOUT", "30"))
 RATE_LIMIT: Final[str] = os.getenv("CHRONIK_RATE_LIMIT", "60/minute")
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+DEBUG_MODE = os.getenv("CHRONIK_DEBUG", "").lower() in {"1", "true", "yes", "on"}
 logging.basicConfig(level=LOG_LEVEL)
 logger = logging.getLogger("chronik")
 
-app = FastAPI(title="chronik-ingest")
+app = FastAPI(title="chronik-ingest", debug=DEBUG_MODE)
 
 DATA: Final = DATA_DIR
 

--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ MAX_PAYLOAD_SIZE: Final[int] = int(os.getenv("CHRONIK_MAX_BODY", str(1024 * 1024
 LOCK_TIMEOUT: Final[int] = int(os.getenv("CHRONIK_LOCK_TIMEOUT", "30"))
 RATE_LIMIT: Final[str] = os.getenv("CHRONIK_RATE_LIMIT", "60/minute")
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
-DEBUG_MODE = os.getenv("CHRONIK_DEBUG", "").lower() in {"1", "true", "yes", "on"}
+DEBUG_MODE: Final[bool] = os.getenv("CHRONIK_DEBUG", "").lower() in {"1", "true", "yes", "on"}
 logging.basicConfig(level=LOG_LEVEL)
 logger = logging.getLogger("chronik")
 


### PR DESCRIPTION
## Summary
- make FastAPI debug mode configurable via the CHRONIK_DEBUG environment variable
- default to debug disabled to avoid exposing stack traces in production

## Testing
- python -m pytest tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69282318b6b8832ca9ec722577c71c6f)