### PR TITLE
Sync API docs with current ingest endpoints

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -32,7 +32,7 @@ curl -X POST "http://localhost:8788/v1/ingest?domain=example.com" \
 ```bash
 http POST :8788/v1/ingest \
     domain==service.internal \
-    event:=\"deploy\" status:=\"success\" X-Auth:${CHRONIK_TOKEN}
+    event=deploy status=success X-Auth:${CHRONIK_TOKEN}
 ```
 
 ### `POST /ingest/{domain}` (deprecated)

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,7 +16,7 @@ Zentraler Ingest-Endpunkt, der JSON-Objekte, Arrays oder NDJSON entgegennimmt. D
 |----------------|--------------|
 | Methode        | `POST` |
 | Pfadparameter  | keine |
-| Query-Parameter| `domain` (optional) – Ziel-Domain; wird in Kleinbuchstaben umgewandelt und muss die FQDN-Regeln erfüllen |
+| Query-Parameter| `domain` (optional) – Ziel-Domain; wird in Kleinbuchstaben umgewandelt und muss die FQDN-Regeln erfüllen (siehe Abschnitt "Fehlerfälle" zur Domain-Validierung) |
 | Header         | `Content-Type: application/json` **oder** `Content-Type: application/x-ndjson`; `X-Auth: <token>` (Pflicht). |
 | Request-Body   | **JSON:** Objekt oder Array von Objekten. **NDJSON:** Zeilenweise JSON-Objekte (`\n`-getrennt); leere Zeilen werden ignoriert. Für jedes Objekt wird ein Feld `domain` ergänzt, falls es fehlt. Optionales Feld `summary` darf max. 500 Zeichen lang sein. |
 | Antwort        | `202 Accepted` (Text: `ok`) bei Erfolg. Fehlerhafte Eingaben erzeugen u. a. `400 invalid json/invalid ndjson/invalid payload/domain must be specified ...`, falsche Authentifizierung `401 unauthorized`, fehlende Länge `411 length required`, zu große Payload `413 payload too large`, falscher Content-Type `415 unsupported content-type`, zu lange Summary `422 summary too long (max 500)`, Rate-Limit `429 too many requests`, Platzmangel `507 insufficient storage`. |

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,22 +5,48 @@ Dieses Dokument beschreibt die HTTP-Schnittstelle des Chronik-Ingest-Dienstes im
 ## Übersicht
 * Basis-URL: `http://<host>:<port>` (Standard-Port 8788)
 * Authentifizierung: Verpflichtender Header `X-Auth` mit dem Wert aus `CHRONIK_TOKEN`
-* Datenformat: JSON bzw. JSON Lines
+* Datenformat: JSON bzw. Newline Delimited JSON (NDJSON)
 * OpenAPI/Swagger: Automatisch unter `/docs` (Swagger UI) bzw. `/openapi.json` verfügbar
 
 ## Endpunkte
-### `POST /ingest/{domain}`
-Übernimmt beliebige JSON-Payloads und speichert sie domain-spezifisch.
+### `POST /v1/ingest`
+Zentraler Ingest-Endpunkt, der JSON-Objekte, Arrays oder NDJSON entgegennimmt. Die Domain kann über den Query-Parameter `domain` oder über das Feld `domain` im ersten Objekt mitgeliefert werden.
 
 | Eigenschaft    | Beschreibung |
 |----------------|--------------|
 | Methode        | `POST` |
-| Pfadparameter  | `domain` – wird in Kleinbuchstaben umgewandelt und muss den folgenden FQDN-Regeln entsprechen:<ul><li>Gesamtlänge maximal 253 Zeichen.</li><li>Labels (Teile zwischen Punkten) dürfen 1 bis 63 Zeichen lang sein.</li><li>Labels dürfen nur aus Kleinbuchstaben, Ziffern und Bindestrichen (`-`) bestehen.</li><li>Labels dürfen nicht mit einem Bindestrich beginnen oder enden.</li></ul> |
-| Header         | `Content-Type: application/json`; `X-Auth: <token>` (Pflicht). |
-| Request-Body   | Gültiges JSON-Dokument. Einzelne Objekte erhalten automatisch ein Feld `domain`, sofern es fehlt. |
-| Antwort        | `200 OK` (Text: `ok`) bei Erfolg. Fehlerhafte Eingaben erzeugen `400 invalid domain` / `400 invalid json`, fehlende Authentifizierung `401 unauthorized`. Bei gesetztem Rate-Limit werden zusätzlich die Header `X-RateLimit-Limit` und `X-RateLimit-Remaining` übertragen; bei `429 Too Many Requests` kommt `Retry-After` hinzu. |
+| Pfadparameter  | keine |
+| Query-Parameter| `domain` (optional) – Ziel-Domain; wird in Kleinbuchstaben umgewandelt und muss die FQDN-Regeln erfüllen |
+| Header         | `Content-Type: application/json` **oder** `Content-Type: application/x-ndjson`; `X-Auth: <token>` (Pflicht). |
+| Request-Body   | **JSON:** Objekt oder Array von Objekten. **NDJSON:** Zeilenweise JSON-Objekte (`\n`-getrennt); leere Zeilen werden ignoriert. Für jedes Objekt wird ein Feld `domain` ergänzt, falls es fehlt. Optionales Feld `summary` darf max. 500 Zeichen lang sein. |
+| Antwort        | `202 Accepted` (Text: `ok`) bei Erfolg. Fehlerhafte Eingaben erzeugen u. a. `400 invalid json/invalid ndjson/invalid payload/domain must be specified ...`, falsche Authentifizierung `401 unauthorized`, fehlende Länge `411 length required`, zu große Payload `413 payload too large`, falscher Content-Type `415 unsupported content-type`, zu lange Summary `422 summary too long (max 500)`, Rate-Limit `429 too many requests`, Platzmangel `507 insufficient storage`. |
 
 #### Beispiel-Requests
+```bash
+curl -X POST "http://localhost:8788/v1/ingest?domain=example.com" \
+     -H "Content-Type: application/json" \
+     -H "X-Auth: ${CHRONIK_TOKEN}" \
+     -d '{"event": "deploy", "status": "success"}'
+```
+
+```bash
+http POST :8788/v1/ingest \
+    domain==service.internal \
+    event:=\"deploy\" status:=\"success\" X-Auth:${CHRONIK_TOKEN}
+```
+
+### `POST /ingest/{domain}` (deprecated)
+Frühere Variante, die weiterhin unterstützt wird. Die Domain wird im Pfad angegeben; der Endpunkt ist als veraltet markiert und sollte durch `/v1/ingest` ersetzt werden.
+
+| Eigenschaft    | Beschreibung |
+|----------------|--------------|
+| Methode        | `POST` |
+| Pfadparameter  | `domain` – wird in Kleinbuchstaben umgewandelt und muss den FQDN-Regeln entsprechen |
+| Header         | `Content-Type: application/json`; `X-Auth: <token>` (Pflicht). |
+| Request-Body   | JSON-Objekt oder Array aus Objekten. Jedes Objekt erhält automatisch das Feld `domain`, sofern es fehlt. Optionales Feld `summary` darf max. 500 Zeichen lang sein. |
+| Antwort        | `202 Accepted` (Text: `ok`) bei Erfolg. Fehlerhafte Eingaben erzeugen `400 invalid json/invalid payload/domain mismatch`, falsche Authentifizierung `401 unauthorized`, fehlende Länge `411 length required`, zu große Payload `413 payload too large`, Rate-Limit `429 too many requests`, Platzmangel `507 insufficient storage`. |
+
+#### Beispiel-Request
 ```bash
 curl -X POST "http://localhost:8788/ingest/example.com" \
      -H "Content-Type: application/json" \
@@ -28,29 +54,29 @@ curl -X POST "http://localhost:8788/ingest/example.com" \
      -d '{"event": "deploy", "status": "success"}'
 ```
 
-```bash
-http POST :8788/ingest/service.internal event:=\
-    "deploy" status:=\"success\" X-Auth:${CHRONIK_TOKEN}
-```
-
 ### `GET /health`
-* **Header** `X-Auth`: muss ebenfalls dem Wert von `CHRONIK_TOKEN` entsprechen.
+* **Header** `X-Auth`: muss dem Wert von `CHRONIK_TOKEN` entsprechen.
 * **Antwort**: `{ "status": "ok" }`. Kann ohne Request-Body abgefragt werden.
 
 ### `GET /version`
-* **Header** `X-Auth`: identisch zu den anderen Endpunkten.
+* **Header** `X-Auth`: nicht erforderlich.
 * **Antwort**: `{ "version": "<wert>" }`. Der Wert entspricht der Konstante `VERSION` bzw. der Umgebungsvariablen `CHRONIK_VERSION`.
 
 #### Fehlerfälle
-| Status | Detail              | Ursache |
-|--------|---------------------|---------|
-| 400    | `invalid domain`    | Domain verletzt das erlaubte Namensschema |
-| 400    | `invalid json`      | Request-Body ist kein gültiges UTF-8/JSON |
-| 400    | `invalid payload`   | JSON ist kein Objekt/Array aus Objekten bzw. enthält ungültige Domains |
-| 400    | `domain mismatch`   | Eingebettete `domain` unterscheidet sich von der Pfad-Domain |
-| 401    | `unauthorized`      | Header `X-Auth` fehlt oder stimmt nicht |
-| 411    | `length required`   | `Content-Length`-Header fehlt |
-| 413    | `payload too large` | Payload überschreitet 1 MiB |
+| Status | Detail                         | Ursache |
+|--------|--------------------------------|---------|
+| 400    | `invalid domain`               | Domain verletzt das erlaubte Namensschema |
+| 400    | `invalid json` / `invalid ndjson` | Request-Body ist kein gültiges UTF-8/JSON bzw. NDJSON |
+| 400    | `invalid payload`              | JSON ist kein Objekt/Array aus Objekten bzw. enthält ungültige Domains |
+| 400    | `domain mismatch`              | Eingebettete `domain` unterscheidet sich von der Pfad-/Query-Domain |
+| 400    | `domain must be specified via query or payload` | Bei `/v1/ingest` fehlt die Domain sowohl in Query als auch im ersten Objekt |
+| 401    | `unauthorized`                 | Header `X-Auth` fehlt oder stimmt nicht |
+| 411    | `length required`              | `Content-Length`-Header fehlt |
+| 413    | `payload too large`            | Payload überschreitet 1 MiB |
+| 415    | `unsupported content-type`     | Content-Type ist weder JSON noch NDJSON |
+| 422    | `summary too long (max 500)`   | Feld `summary` überschreitet 500 Zeichen |
+| 429    | `too many requests`            | Rate-Limit überschritten |
+| 507    | `insufficient storage`         | Beim Schreiben nicht genug Speicherplatz |
 
 ## Datenpersistenz
 Alle Requests werden in Domain-spezifischen JSONL-Dateien gespeichert. Der Dateiname leitet sich aus der Domain ab (`<domain>.jsonl`) und wird nur bei extrem langen Domains mit einem 8-stelligen SHA-Suffix gekürzt. Jede Zeile repräsentiert eine Payload als JSON-String.

--- a/docs/api.md
+++ b/docs/api.md
@@ -44,7 +44,7 @@ Frühere Variante, die weiterhin unterstützt wird. Die Domain wird im Pfad ange
 | Pfadparameter  | `domain` – wird in Kleinbuchstaben umgewandelt und muss den FQDN-Regeln entsprechen |
 | Header         | `Content-Type: application/json`; `X-Auth: <token>` (Pflicht). |
 | Request-Body   | JSON-Objekt oder Array aus Objekten. Jedes Objekt erhält automatisch das Feld `domain`, sofern es fehlt. Optionales Feld `summary` darf max. 500 Zeichen lang sein. |
-| Antwort        | `202 Accepted` (Text: `ok`) bei Erfolg. Fehlerhafte Eingaben erzeugen `400 invalid json/invalid payload/domain mismatch`, falsche Authentifizierung `401 unauthorized`, fehlende Länge `411 length required`, zu große Payload `413 payload too large`, Rate-Limit `429 too many requests`, Platzmangel `507 insufficient storage`. |
+| Antwort        | `202 Accepted` (Text: `ok`) bei Erfolg. Fehlerhafte Eingaben erzeugen `400 invalid json/invalid payload/domain mismatch`, falsche Authentifizierung `401 unauthorized`, fehlende Länge `411 length required`, zu große Payload `413 payload too large`, zu lange Summary `422 summary too long (max 500)`, Rate-Limit `429 too many requests`, Platzmangel `507 insufficient storage`. |
 
 #### Beispiel-Request
 ```bash

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,7 +5,7 @@ Dieses Dokument beschreibt die HTTP-Schnittstelle des Chronik-Ingest-Dienstes im
 ## Übersicht
 * Basis-URL: `http://<host>:<port>` (Standard-Port 8788)
 * Authentifizierung: Verpflichtender Header `X-Auth` mit dem Wert aus `CHRONIK_TOKEN`
-* Datenformat: JSON bzw. Newline Delimited JSON (NDJSON)
+* Datenformat: JSON bzw. Newline-Delimited JSON (NDJSON)
 * OpenAPI/Swagger: Automatisch unter `/docs` (Swagger UI) bzw. `/openapi.json` verfügbar
 
 ## Endpunkte

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -158,4 +158,5 @@ components:
         summary:
           type: string
           description: Optional summary (maximum 500 characters).
+          maxLength: 500
       additionalProperties: true

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -150,7 +150,11 @@ components:
   schemas:
     Event:
       type: object
-      description: Generic event payload. Additional fields are preserved.
+      description: |
+        Generic event payload. Additional fields are preserved.
+        No fields are unconditionally required. The `domain` field is required in the payload only
+        when not supplied via the `domain` query parameter on /v1/ingest.
+      required: []
       properties:
         domain:
           type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Chronik API
-  version: 0.1.0
+  version: 1.0.0
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT
@@ -13,11 +13,14 @@ paths:
     post:
       summary: Universal ingest endpoint
       operationId: ingestEvent
-      description: Domain must be specified either via query parameter or as a field in the payload.
+      description: |
+        Accepts JSON payloads either as a single object, an array of objects, or newline-delimited JSON.
+        The target domain can be supplied via the `domain` query parameter or as the `domain` field on the first
+        object in the payload.
       parameters:
         - name: domain
           in: query
-          description: Target domain for the event. Can also be supplied in the payload.
+          description: Optional target domain for the event. If omitted, the first payload object must contain `domain`.
           required: false
           schema:
             type: string
@@ -28,41 +31,116 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Event'
+              oneOf:
+                - $ref: '#/components/schemas/Event'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/Event'
+          application/x-ndjson:
+            schema:
+              type: string
+              description: Newline-delimited JSON objects. Empty lines are ignored.
       responses:
         '202':
-          description: Accepted
+          description: Accepted. Body contains plain text `ok`.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ok
         '400':
-          description: Bad request
+          description: Bad request (invalid domain, JSON, payload, or missing domain information).
         '401':
-          description: Unauthorized
+          description: Unauthorized (missing or invalid `X-Auth` header).
+        '411':
+          description: Content-Length header missing.
+        '413':
+          description: Payload too large.
+        '415':
+          description: Unsupported content-type.
+        '422':
+          description: Semantic validation failed (e.g. summary too long).
+        '429':
+          description: Too many requests (rate limited).
+        '507':
+          description: Insufficient storage.
   /ingest/{domain}:
     post:
       deprecated: true
       summary: Deprecated ingest endpoint
       operationId: ingestEventDeprecated
-      security:
-        - XAuth: []
-      description: "Ersetzt durch **POST /v1/ingest** (Ablauf: 6 Monate nach Merge)."
+      description: Replaced by **POST /v1/ingest**.
       parameters:
         - in: path
           name: domain
           required: true
           schema:
             type: string
+      security:
+        - XAuth: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Event'
+              oneOf:
+                - $ref: '#/components/schemas/Event'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/Event'
       responses:
         '202':
-          description: Accepted (deprecated)
+          description: Accepted (deprecated). Body contains plain text `ok`.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ok
         '400':
-          description: Bad request
+          description: Bad request (invalid domain, JSON, or payload).
         '401':
-          description: Unauthorized
+          description: Unauthorized (missing or invalid `X-Auth` header).
+        '411':
+          description: Content-Length header missing.
+        '413':
+          description: Payload too large.
+        '429':
+          description: Too many requests (rate limited).
+        '507':
+          description: Insufficient storage.
+  /health:
+    get:
+      summary: Health check
+      description: Returns `{"status": "ok"}` when the service is ready.
+      security:
+        - XAuth: []
+      responses:
+        '200':
+          description: Service healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+        '401':
+          description: Unauthorized (missing or invalid `X-Auth` header).
+  /version:
+    get:
+      summary: Service version
+      description: Returns the current Chronik version string.
+      responses:
+        '200':
+          description: Version information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
 components:
   securitySchemes:
     XAuth:
@@ -72,13 +150,12 @@ components:
   schemas:
     Event:
       type: object
-      required: [ts, kind, payload]
+      description: Generic event payload. Additional fields are preserved.
       properties:
-        ts:
+        domain:
           type: string
-          format: date-time
-        kind:
+          description: Domain associated with the event. Required unless supplied via query parameter on /v1/ingest.
+        summary:
           type: string
-        payload:
-          type: object
-          additionalProperties: true
+          description: Optional summary (maximum 500 characters).
+      additionalProperties: true


### PR DESCRIPTION
## Summary
- update api.md to describe v1 ingest flow, deprecated path, auth, and error scenarios
- refresh OpenAPI spec with current endpoints, accepted content types, and responses

## Testing
- not run (docs-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692826b49010832cad3ca05285e52d12)