### PR TITLE
Fix YAML description quoting in health endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -111,7 +111,7 @@ paths:
   /health:
     get:
       summary: Health check
-      description: Returns `{"status": "ok"}` when the service is ready.
+      description: "Returns `{\"status\": \"ok\"}` when the service is ready."
       security:
         - XAuth: []
       responses:


### PR DESCRIPTION
## Summary
- quote the health check description string to avoid YAML parsing errors

## Testing
- python - <<'PY'
import yaml
with open('docs/openapi.yaml') as f:
    yaml.safe_load(f)
print('ok')
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69283d23a66c832c8b4200c93e46ffa3)