### PR TITLE
Harden heimgewebe command dispatch workflow

### DIFF
--- a/.github/workflows/heimgewebe-command-dispatch.yml
+++ b/.github/workflows/heimgewebe-command-dispatch.yml
@@ -6,8 +6,8 @@ on:
 
 permissions:
   contents: read
-  issues: read
-  pull-requests: read
+  issues: write          # wir posten bei ungültigen Kommandos einen Kommentar
+  pull-requests: write   # dito
 
 jobs:
   dispatch:
@@ -15,93 +15,125 @@ jobs:
     runs-on: ubuntu-latest
 
     # Nur auf PR-Kommentare reagieren, die @heimgewebe/ enthalten
+    # und von jemandem kommen, der mindestens Collaborator ist
     if: >
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '@heimgewebe/')
+      contains(github.event.comment.body, '@heimgewebe/') &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
 
     steps:
       - name: Kontext anzeigen (Debug)
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           echo "Repository: ${{ github.repository }}"
           echo "PR:        #${{ github.event.issue.number }}"
           echo "Author:    ${{ github.event.comment.user.login }}"
+          echo "Assoc:     ${{ github.event.comment.author_association }}"
           echo "Comment:"
           echo "----------"
-          printf '%s\n' "${{ github.event.comment.body }}"
+          # Kommentartext nur über Env-Var, um CodeQL zufrieden zu stellen
+          printf '%s\n' "$COMMENT_BODY"
           echo "----------"
 
-      - name: Heimgewebe-Kommando parsen
+      - name: Heimgewebe-Kommando parsen und validieren
         id: parse
         env:
-          COMMENT_BODY: "${{ github.event.comment.body }}"
-          REPOSITORY: "${{ github.repository }}"
-          ISSUE_NUMBER: "${{ github.event.issue.number }}"
-          COMMENT_AUTHOR: "${{ github.event.comment.user.login }}"
+          COMMENT_BODY:    ${{ github.event.comment.body }}
+          REPOSITORY:      ${{ github.repository }}
+          ISSUE_NUMBER:    ${{ github.event.issue.number }}
+          COMMENT_AUTHOR:  ${{ github.event.comment.user.login }}
+          # Whitelist der erlaubten Ziel-Repos in der Org heimgewebe
+          ALLOWED_TARGET_REPOS: "sichter,wgx,heimgeist,metarepo,hausKI,semantAH,heimlern,chronik,leitstand,tools"
+          # Whitelist der erlaubten Kommandos
+          ALLOWED_COMMANDS: "quick,deep"
         run: |
           python << 'PY'
-          import os, json, re, sys
+          import os, json, re
 
           body = os.environ["COMMENT_BODY"]
           repo = os.environ["REPOSITORY"]
           issue_number = int(os.environ["ISSUE_NUMBER"])
           author = os.environ["COMMENT_AUTHOR"]
 
-          # Muster: @heimgewebe/<zielrepo> /kommando [arg…]
+          allowed_repos = {r.strip() for r in os.environ.get("ALLOWED_TARGET_REPOS", "").split(",") if r.strip()}
+          allowed_commands = {c.strip() for c in os.environ.get("ALLOWED_COMMANDS", "").split(",") if c.strip()}
+
           pattern = re.compile(r"@heimgewebe/([a-zA-Z0-9_-]+)\s+/(\S+)(.*)")
           m = pattern.search(body)
-          if not m:
-              print("Kein gültiges Heimgewebe-Kommando gefunden.")
-              # Kein Fehler -> Job wird einfach beendet
-              sys.exit(0)
 
-          target_repo = m.group(1)
-          command = m.group(2)
-          args_raw = m.group(3).strip()
-
-          payload = {
-              "version": 1,
-              "source_repository": repo,
-              "source_issue_number": issue_number,
-              "source_comment_author": author,
-              "raw_comment": body,
-              "target_repo": target_repo,
-              "command": command,
-              "args": args_raw,
+          result = {
+              "found": "false",
+              "invalid_reason": "",
+              "target_repo": "",
+              "payload_json": "",
           }
 
-          print("Erkannter Target-Repo:", target_repo)
-          print("Kommando:", command)
-          print("Argumente:", args_raw)
+          if not m:
+              # gar kein passendes Muster
+              result["invalid_reason"] = "no_match"
+          else:
+              target_repo = m.group(1)
+              command = m.group(2)
+              args_raw = (m.group(3) or "").strip()
 
-          # Payload für nächste Steps ablegen
-          with open("command-payload.json", "w", encoding="utf-8") as f:
-              json.dump(payload, f)
+              # Argumente hart begrenzen, um Unfug zu reduzieren
+              if len(args_raw) > 256:
+                  args_raw = args_raw[:256] + " …(gekürzt)…"
 
-          # GITHUB_OUTPUT setzen
+              if target_repo not in allowed_repos:
+                  result["invalid_reason"] = "target_repo_not_allowed"
+                  result["target_repo"] = target_repo
+              elif command not in allowed_commands:
+                  result["invalid_reason"] = "command_not_allowed"
+              else:
+                  payload = {
+                      "version": 1,
+                      "source_repository": repo,
+                      "source_issue_number": issue_number,
+                      "source_comment_author": author,
+                      "raw_comment": body,
+                      "target_repo": target_repo,
+                      "command": command,
+                      "args": args_raw,
+                  }
+                  result["found"] = "true"
+                  result["target_repo"] = target_repo
+                  result["payload_json"] = json.dumps(payload, ensure_ascii=False)
+
+          # Outputs für nachfolgende Steps setzen
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
-              f.write(f"target_repo={target_repo}\n")
+              for key, value in result.items():
+                  # keine Zeilenumbrüche, damit GitHub-Outputs sauber bleiben
+                  v_str = str(value).replace("%", "%25").replace("\n", " ").replace("\r", " ")
+                  f.write(f"{key}={v_str}\n")
           PY
 
-      - name: Payload als Artefakt anzeigen
+      - name: Payload im Log anzeigen
+        if: steps.parse.outputs.found == 'true'
+        env:
+          PAYLOAD_JSON: ${{ steps.parse.outputs.payload_json }}
         run: |
-          echo "command-payload.json:"
-          cat command-payload.json
+          echo "Heimgewebe-Command-Payload (JSON):"
+          printf '%s\n' "$PAYLOAD_JSON"
 
       - name: Repository Dispatch an Ziel-Repo senden
-        if: steps.parse.outputs.target_repo != ''
+        if: steps.parse.outputs.found == 'true'
         uses: actions/github-script@v7
         env:
-          AUTOBOT_TOKEN: ${{ secrets.HEIMGEWEBE_AUTOBOT_TOKEN }}
+          HEIMGEWEBE_AUTOBOT_TOKEN: ${{ secrets.HEIMGEWEBE_AUTOBOT_TOKEN }}
+          PAYLOAD_JSON:            ${{ steps.parse.outputs.payload_json }}
         with:
-          github-token: ${{ env.AUTOBOT_TOKEN }}
+          github-token: ${{ env.HEIMGEWEBE_AUTOBOT_TOKEN }}
           script: |
-            const fs = require('fs');
-            const path = 'command-payload.json';
-            const payload = JSON.parse(fs.readFileSync(path, 'utf8'));
-
+            const payload = JSON.parse(process.env.PAYLOAD_JSON || '{}');
             const targetRepo = payload.target_repo;
             if (!targetRepo) {
-              core.info('Kein target_repo gefunden – breche ab.');
+              core.info('Kein target_repo im Payload gefunden – breche ab.');
               return;
             }
 
@@ -115,3 +147,26 @@ jobs:
             });
 
             core.info('repository_dispatch gesendet.');
+
+      - name: Ungültiges Heimgewebe-Kommando zurückmelden
+        if: steps.parse.outputs.found != 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const reason = '${{ steps.parse.outputs.invalid_reason }}';
+            let msg = 'Ich habe deinen Heimgewebe-Befehl nicht verstanden oder er ist nicht erlaubt. ' +
+                      'Bitte prüfe die Schreibweise (z. B. `@heimgewebe/sichter /quick`).';
+
+            if (reason === 'target_repo_not_allowed') {
+              msg += ' (Ziel-Repo ist nicht in der erlaubten Liste.)';
+            } else if (reason === 'command_not_allowed') {
+              msg += ' (Dieses Kommando ist in diesem Kontext nicht erlaubt.)';
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: msg,
+            });


### PR DESCRIPTION
## Summary
- harden the Heimgewebe dispatch workflow with whitelist validation, author checks, and safe comment handling
- provide user feedback for invalid commands and send payload inline without temporary files

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929e6afbaa8832ca48ed8ef631715c3)