### PR TITLE
Add httpx to runtime requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]>=0.27
 filelock>=3.13
 prometheus-fastapi-instrumentator>=6.1,<7
 slowapi>=0.1.8,<0.2
+httpx>=0.27


### PR DESCRIPTION
## Summary
- add httpx as a runtime dependency so FastAPI TestClient and ingest helpers work without extras

## Testing
- pip install -r requirements.txt (fails due to proxy restrictions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69391d9b22bc832c9c9c7c6acdb51355)