### PR TITLE
Improve SlowAPI rate limit error message fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,8 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from slowapi.util import get_remote_address
 
+import slowapi_compat  # noqa: F401  (triggers RateLimitItem patch on import)
+
 from storage import (
     DomainError,
     StorageError,

--- a/app.py
+++ b/app.py
@@ -16,12 +16,13 @@ from fastapi.responses import JSONResponse, PlainTextResponse
 from filelock import FileLock, Timeout
 from prometheus_fastapi_instrumentator import Instrumentator
 from starlette.concurrency import run_in_threadpool
+
+import slowapi_compat  # noqa: F401  (triggers RateLimitItem patch on import)
+
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from slowapi.util import get_remote_address
-
-import slowapi_compat  # noqa: F401  (triggers RateLimitItem patch on import)
 
 from storage import (
     DomainError,

--- a/check_slowapi.py
+++ b/check_slowapi.py
@@ -1,7 +1,7 @@
-from slowapi.errors import RateLimitExceeded
-from limits import RateLimitItemPerMinute
+import slowapi_compat  # noqa: F401
 
-import slowapi_compat
+from limits import RateLimitItemPerMinute
+from slowapi.errors import RateLimitExceeded
 
 limit = RateLimitItemPerMinute(1)
 try:

--- a/check_slowapi.py
+++ b/check_slowapi.py
@@ -1,6 +1,8 @@
 from slowapi.errors import RateLimitExceeded
 from limits import RateLimitItemPerMinute
 
+import slowapi_compat
+
 limit = RateLimitItemPerMinute(1)
 try:
     raise RateLimitExceeded(limit)

--- a/slowapi_compat.py
+++ b/slowapi_compat.py
@@ -11,8 +11,8 @@ versions diverge.
 from limits import RateLimitItem
 
 
-def ensure_rate_limit_error_message() -> None:
-    """Add compatibility properties expected by SlowAPI's exceptions."""
+def patch_rate_limit_item() -> None:
+    """Patch RateLimitItem with properties expected by SlowAPI's exceptions."""
 
     if not hasattr(RateLimitItem, "error_message"):
         RateLimitItem.error_message = property(  # type: ignore[attr-defined]
@@ -24,4 +24,4 @@ def ensure_rate_limit_error_message() -> None:
 
 
 # Apply the patch immediately for any importers.
-ensure_rate_limit_error_message()
+patch_rate_limit_item()

--- a/slowapi_compat.py
+++ b/slowapi_compat.py
@@ -1,0 +1,27 @@
+"""Compatibility helpers for SlowAPI / limits.
+
+The upstream ``slowapi.RateLimitExceeded`` currently expects the provided
+``RateLimitItem`` to expose an ``error_message`` attribute. Recent versions of
+``limits`` no longer define this attribute, which causes an ``AttributeError``
+as soon as the exception is instantiated. We patch the base class once on
+import so that rate-limit handling remains stable even when the dependency
+versions diverge.
+"""
+
+from limits import RateLimitItem
+
+
+def ensure_rate_limit_error_message() -> None:
+    """Add compatibility properties expected by SlowAPI's exceptions."""
+
+    if not hasattr(RateLimitItem, "error_message"):
+        RateLimitItem.error_message = property(  # type: ignore[attr-defined]
+            lambda self: f"Rate limit exceeded: {self}"
+        )
+
+    if not hasattr(RateLimitItem, "limit"):
+        RateLimitItem.limit = property(lambda self: self)  # type: ignore[attr-defined]
+
+
+# Apply the patch immediately for any importers.
+ensure_rate_limit_error_message()

--- a/tests/test_rate_limit_compat.py
+++ b/tests/test_rate_limit_compat.py
@@ -1,7 +1,7 @@
+import slowapi_compat  # noqa: F401
+
 from limits import RateLimitItemPerMinute
 from slowapi.errors import RateLimitExceeded
-
-import slowapi_compat  # noqa: F401
 
 
 def test_rate_limit_exceeded_init_handles_missing_error_message():
@@ -14,3 +14,4 @@ def test_rate_limit_exceeded_init_handles_missing_error_message():
 
     assert "1 per 1 minute" in str(exc)
     assert "Rate limit exceeded" in limit.error_message
+    assert limit.limit is limit

--- a/tests/test_rate_limit_compat.py
+++ b/tests/test_rate_limit_compat.py
@@ -1,0 +1,16 @@
+from limits import RateLimitItemPerMinute
+from slowapi.errors import RateLimitExceeded
+
+import slowapi_compat  # noqa: F401
+
+
+def test_rate_limit_exceeded_init_handles_missing_error_message():
+    limit = RateLimitItemPerMinute(1)
+
+    try:
+        exc = RateLimitExceeded(limit)
+    except AttributeError as err:  # pragma: no cover - guards regression
+        raise AssertionError("RateLimitExceeded should not access missing error_message") from err
+
+    assert "1 per 1 minute" in str(exc)
+    assert "Rate limit exceeded" in limit.error_message


### PR DESCRIPTION
## Summary
- return a descriptive fallback error_message on RateLimitItem to satisfy SlowAPI expectations
- extend regression test to assert the fallback message is present

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958cb55d8d4832c9f3ca13bc596e510)