### PR TITLE
Potential fix for code scanning alert no. 52: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ai-context-guard.yml
+++ b/.github/workflows/ai-context-guard.yml
@@ -1,5 +1,8 @@
 name: ai-context guard
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/heimgewebe/chronik/security/code-scanning/52](https://github.com/heimgewebe/chronik/security/code-scanning/52)

In general, the fix is to define a `permissions` block that restricts the `GITHUB_TOKEN` to the minimal rights required. For this workflow, the jobs only need to read the repository contents to check out code and run Python validation scripts. They do not push commits, modify PRs, or interact with other GitHub resources, so `contents: read` at the workflow level is sufficient and safest.

The best fix without changing functionality is to add a top-level `permissions` block right after the `name:` (or before `on:`) in `.github/workflows/ai-context-guard.yml`. This will apply to both `repo-root` and `templates` jobs, since neither defines its own `permissions`. The block should be:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or other code changes are required; this is purely a YAML configuration change within the shown file and lines.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
