### PR TITLE
Configure pytest import path and remove sys.path hack

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_event_quality_integration.py
+++ b/tests/test_event_quality_integration.py
@@ -1,28 +1,20 @@
 """Integration tests for event quality, provenance, and retention features."""
 
 import json
-import os
 import pytest
 from fastapi.testclient import TestClient
 
-
-# Set environment variables BEFORE importing app
-os.environ.setdefault("CHRONIK_TOKEN", "test-token")
-os.environ.setdefault("CHRONIK_ENABLE_QUALITY", "1")
-os.environ.setdefault("CHRONIK_ENFORCE_PROVENANCE", "0")
-
-
 @pytest.fixture
-def client():
+def client(monkeypatch, tmp_path):
     """Create test client with token configured."""
+    monkeypatch.setenv("CHRONIK_TOKEN", "test-token")
+    monkeypatch.setenv("CHRONIK_ENABLE_QUALITY", "1")
+    monkeypatch.setenv("CHRONIK_ENFORCE_PROVENANCE", "0")
+    monkeypatch.setenv("CHRONIK_DATA_DIR", str(tmp_path))
+    import storage
+    monkeypatch.setattr(storage, "DATA_DIR", tmp_path)
     from app import app
     return TestClient(app)
-
-
-@pytest.fixture(autouse=True)
-def setup_data_dir(tmp_path, monkeypatch):
-    """Patch storage.DATA_DIR to use tmp_path."""
-    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
 
 
 def test_event_with_quality_markers(client):


### PR DESCRIPTION
### Motivation

- Ensure tests can import top-level modules without adding process-global `sys.path` mutations by configuring the test runner import path.
- Make integration tests deterministic by setting auth/feature environment variables in the fixture before importing the application.
- Ensure per-test isolation of storage by patching `storage.DATA_DIR` before `from app import app` is executed.

### Description

- Add `pytest.ini` with `pythonpath = .` so the repository root is on the import path during tests.
- Remove the previous `sys.path` manipulation from `tests/test_event_quality_integration.py` and the module-level `os.environ` setup.
- Refactor the `client` fixture to accept `monkeypatch` and `tmp_path`, set `CHRONIK_*` env vars, set `CHRONIK_DATA_DIR`, import `storage` and `monkeypatch.setattr(storage, "DATA_DIR", tmp_path)` before importing the app.
- Remove the autouse `setup_data_dir` fixture to avoid double-patching and duplicate Prometheus metric registration.

### Testing

- Ran `pytest -q tests/test_event_quality_integration.py` after the initial change which failed due to missing import errors (ModuleNotFoundError) caused by the absent test import path.
- Added `pytest.ini` and re-ran `pytest -q tests/test_event_quality_integration.py`, which completed successfully with `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ff5365580832c9152133db5f81543)