### PR TITLE
🧪 Add unit tests for storage.list_domains and ignore hidden files

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -363,9 +363,9 @@ def list_domains(prefix: str = "") -> list[str]:
     results = []
     try:
         for entry in os.scandir(DATA_DIR):
-            if not entry.is_file():
-                continue
             name = entry.name
+            if name.startswith(".") or not entry.is_file():
+                continue
             if not FILENAME_RE.fullmatch(name):
                 continue
             if prefix and not name.startswith(prefix):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import storage
 
@@ -31,20 +30,16 @@ def test_list_domains_filtering(mock_data_dir):
     assert storage.list_domains() == ["valid"]
 
 def test_list_domains_prefix(mock_data_dir):
-    """Verify the prefix parameter correctly filters results (case-sensitive)."""
+    """Verify the prefix parameter correctly filters results."""
     (mock_data_dir / "apple.jsonl").touch()
     (mock_data_dir / "apricot.jsonl").touch()
     (mock_data_dir / "banana.jsonl").touch()
-    (mock_data_dir / "Apple.jsonl").touch()
 
     # Empty prefix
-    assert storage.list_domains("") == ["Apple", "apple", "apricot", "banana"]
+    assert storage.list_domains("") == ["apple", "apricot", "banana"]
 
     # Matching prefix
     assert storage.list_domains("ap") == ["apple", "apricot"]
-
-    # Case sensitive prefix
-    assert storage.list_domains("Ap") == ["Apple"]
 
     # Non-matching prefix
     assert storage.list_domains("cherry") == []
@@ -63,6 +58,7 @@ def test_list_domains_os_error(mock_data_dir, monkeypatch):
     def mock_scandir(path):
         raise OSError("Access denied")
 
-    monkeypatch.setattr(os, "scandir", mock_scandir)
+    # Patch storage.os to be more specific
+    monkeypatch.setattr(storage.os, "scandir", mock_scandir)
 
     assert storage.list_domains() == []

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,68 @@
+import os
+import pytest
+import storage
+
+@pytest.fixture
+def mock_data_dir(tmp_path, monkeypatch):
+    """Isolate DATA_DIR for storage tests."""
+    monkeypatch.setattr(storage, "DATA_DIR", tmp_path)
+    return tmp_path
+
+def test_list_domains_empty(mock_data_dir):
+    """Verify it returns an empty list when DATA_DIR is empty."""
+    assert storage.list_domains() == []
+
+def test_list_domains_basic(mock_data_dir):
+    """Verify it lists valid .jsonl files and sorts them."""
+    (mock_data_dir / "zebra.jsonl").touch()
+    (mock_data_dir / "apple.jsonl").touch()
+    (mock_data_dir / "banana.jsonl").touch()
+
+    assert storage.list_domains() == ["apple", "banana", "zebra"]
+
+def test_list_domains_filtering(mock_data_dir):
+    """Verify it ignores directories and files that don't match FILENAME_RE."""
+    (mock_data_dir / "valid.jsonl").touch()
+    (mock_data_dir / "invalid.txt").touch()
+    (mock_data_dir / "no_ext").touch()
+    (mock_data_dir / "subdir.jsonl").mkdir()
+    (mock_data_dir / ".hidden.jsonl").touch() # Should be ignored (starts with dot)
+
+    assert storage.list_domains() == ["valid"]
+
+def test_list_domains_prefix(mock_data_dir):
+    """Verify the prefix parameter correctly filters results (case-sensitive)."""
+    (mock_data_dir / "apple.jsonl").touch()
+    (mock_data_dir / "apricot.jsonl").touch()
+    (mock_data_dir / "banana.jsonl").touch()
+    (mock_data_dir / "Apple.jsonl").touch()
+
+    # Empty prefix
+    assert storage.list_domains("") == ["Apple", "apple", "apricot", "banana"]
+
+    # Matching prefix
+    assert storage.list_domains("ap") == ["apple", "apricot"]
+
+    # Case sensitive prefix
+    assert storage.list_domains("Ap") == ["Apple"]
+
+    # Non-matching prefix
+    assert storage.list_domains("cherry") == []
+
+def test_list_domains_special_chars(mock_data_dir):
+    """Verify it handles allowed special characters in filenames."""
+    # FILENAME_RE: [a-z0-9._-]+
+    names = ["my.domain", "my_domain", "my-domain", "123.456"]
+    for name in names:
+        (mock_data_dir / f"{name}.jsonl").touch()
+
+    assert storage.list_domains() == sorted(names)
+
+def test_list_domains_os_error(mock_data_dir, monkeypatch):
+    """Verify it returns an empty list and logs an error when os.scandir fails."""
+    def mock_scandir(path):
+        raise OSError("Access denied")
+
+    monkeypatch.setattr(os, "scandir", mock_scandir)
+
+    assert storage.list_domains() == []


### PR DESCRIPTION
- Added comprehensive unit tests in `tests/test_storage.py` covering various scenarios for `list_domains`.
- Modified `storage.list_domains` to explicitly ignore hidden files (starting with `.`) to ensure only valid domain files are returned.
- Verified changes with the new test suite.