### PR TITLE
Revert hoisting of `is_provenance_enforced` and `is_quality_enabled`

### DIFF
--- a/app.py
+++ b/app.py
@@ -385,12 +385,6 @@ def _process_items(items: list[Any], dom: str) -> list[str]:
         logger.warning("empty payload array received", extra={"domain": dom})
         return lines
 
-    # Hoist invariants out of loop
-    # We assume these flags are request-invariant (env vars/settings)
-    # If they ever become dynamic per-item, this hoisting must be reverted.
-    is_provenance_enforced = _is_provenance_enforced()
-    is_quality_enabled = _is_quality_enabled()
-
     # Pre-compute label to prevent label pollution/entropy
     domain_label = _sanitize_metric_label(dom)
 
@@ -400,6 +394,9 @@ def _process_items(items: list[Any], dom: str) -> list[str]:
             raise HTTPException(status_code=400, detail="invalid payload")
 
         normalized = dict(entry)
+
+        is_provenance_enforced = _is_provenance_enforced()
+        is_quality_enabled = _is_quality_enabled()
 
         # 1. Validation & Normalization logic per domain
         if dom == "insights.daily":


### PR DESCRIPTION
In `app.py`, the checks `_is_provenance_enforced()` and `_is_quality_enabled()` were hoisted out of the item processing loop and evaluated per request based on the assumption that they were request invariants. 

As they will become dynamic per-item, this patch reverts the hoisting and moves the function calls back inside the loop over `items`, so they evaluate dynamically per entry. The accompanying comment regarding hoisting was also removed. All tests were executed and passed locally.

---
*PR created automatically by Jules for task [12387100500067933879](https://jules.google.com/task/12387100500067933879) started by @alexdermohr*