### PR TITLE
perf: offload synchronous integrity source loading to threadpool

### DIFF
--- a/integrity.py
+++ b/integrity.py
@@ -149,8 +149,7 @@ class IntegrityManager:
             # Check if it's a file path
             if os.path.exists(self.override):
                 try:
-                    with open(self.override, "r") as f:
-                        data = json.load(f)
+                    data = await run_in_threadpool(self._read_json_file, self.override)
                     logger.info(f"Loaded integrity sources from file: {self.override}")
                     return self._validate_sources_data(data)
                 except Exception as exc:
@@ -186,6 +185,10 @@ class IntegrityManager:
         except Exception as exc:
             logger.error(f"Failed to fetch integrity sources from {self.sources_url}: {exc}")
             return None
+
+    def _read_json_file(self, filepath: str) -> Any:
+        with open(filepath, "r") as f:
+            return json.load(f)
 
     def _validate_sources_data(self, data: Any) -> dict[str, Any] | None:
         """Validate the sources data structure."""

--- a/integrity.py
+++ b/integrity.py
@@ -187,7 +187,7 @@ class IntegrityManager:
             return None
 
     def _read_json_file(self, filepath: str) -> Any:
-        with open(filepath, "r") as f:
+        with open(filepath, "r", encoding="utf-8") as f:
             return json.load(f)
 
     def _validate_sources_data(self, data: Any) -> dict[str, Any] | None:

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -246,3 +246,26 @@ def test_integrity_legacy_payload_type(client, monkeypatch, tmp_path):
     assert repo in repos
     assert repos[repo]["status"] == "OK"
     assert repos[repo]["legacy"] is True
+
+@pytest.mark.asyncio
+async def test_integrity_sources_override_file(tmp_path, monkeypatch):
+    from integrity import IntegrityManager
+
+    override_file = tmp_path / "sources.json"
+    data = {
+        "apiVersion": "integrity.sources.v1",
+        "generated_at": "2023-01-01T00:00:00Z",
+        "sources": [
+            {"repo": "test/repo", "summary_url": "https://example.com/summary.json", "enabled": True}
+        ]
+    }
+    override_file.write_text(json.dumps(data), encoding="utf-8")
+
+    monkeypatch.setenv("INTEGRITY_SOURCES_OVERRIDE", str(override_file))
+
+    manager = IntegrityManager()
+    result = await manager.fetch_sources()
+
+    assert result is not None
+    assert "sources" in result
+    assert result["sources"][0]["repo"] == "test/repo"


### PR DESCRIPTION
- Replaced blocking synchronous `open` and `json.load` in `IntegrityManager.fetch_sources` with `run_in_threadpool`.
- Added `_read_json_file` helper method to facilitate offloading.
- This prevents the asyncio event loop from stalling when loading large integrity source override files.