### PR TITLE
🔒 [security fix] Sanitize X-Request-ID header in logs

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,6 +54,7 @@ from integrity import IntegrityManager
 MAX_PAYLOAD_SIZE: Final[int] = int(
     os.getenv("CHRONIK_MAX_BODY") or str(1024 * 1024)
 )
+MAX_RID_LENGTH: Final[int] = 128
 RATE_LIMIT: Final[str] = os.getenv("CHRONIK_RATE_LIMIT") or "60/minute"
 
 # Provenance enforcement: set to "1" to require provenance fields
@@ -200,7 +201,9 @@ def _get_valid_tokens() -> tuple[str, ...]:
 
 @app.middleware("http")
 async def request_id_logging(request: Request, call_next):
-    rid = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+    raw_rid = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+    # Sanitize to prevent log injection and limit length
+    rid = _METRIC_LABEL_SANITIZER.sub("_", raw_rid)[:MAX_RID_LENGTH]
     start = time.perf_counter()
     # Falls im Handler ein Fehler hochgeht, loggen wir konservativ 500
     status = 500

--- a/tests/test_log_injection.py
+++ b/tests/test_log_injection.py
@@ -1,0 +1,21 @@
+import logging
+import uuid
+import pytest
+from fastapi.testclient import TestClient
+from app import app
+
+def test_log_injection_request_id(caplog):
+    client = TestClient(app)
+    malicious_rid = "123\nERROR: spoofed error message"
+
+    # We need to ensure the logger is at least at INFO level to capture the "access" log
+    with caplog.at_level(logging.INFO, logger="chronik"):
+        response = client.get("/health", headers={"X-Request-ID": malicious_rid, "X-Auth": "test_token"})
+        # Note: /health requires auth. Let's make sure it doesn't fail auth if we want to reach the middleware's finally block properly
+        # Wait, the middleware's finally block ALWAYS runs.
+
+    # Check if the malicious RID is sanitized in the logs
+    log_messages = [rec.request_id for rec in caplog.records if hasattr(rec, "request_id")]
+    expected_rid = "123_ERROR__spoofed_error_message"
+    assert expected_rid in log_messages
+    assert malicious_rid not in log_messages

--- a/tests/test_log_injection.py
+++ b/tests/test_log_injection.py
@@ -7,17 +7,17 @@ def test_log_injection_request_id(caplog, monkeypatch):
     monkeypatch.setenv("CHRONIK_TOKEN", "test_token")
     monkeypatch.setenv("CHRONIK_INTEGRITY_ENABLED", "0")
 
-    client = TestClient(app)
     malicious_rid = "123\nERROR: spoofed error message"
 
-    # We need to ensure the logger is at least at INFO level to capture the "access" log
-    with caplog.at_level(logging.INFO, logger="chronik"):
-        # Send request so middleware logs the sanitized request_id
-        response = client.get(
-            "/health",
-            headers={"X-Request-ID": malicious_rid, "X-Auth": "test_token"},
-        )
-        assert response.status_code in (200, 401, 403)
+    with TestClient(app) as client:
+        # We need to ensure the logger is at least at INFO level to capture the "access" log
+        with caplog.at_level(logging.INFO, logger="chronik"):
+            # Send request so middleware logs the sanitized request_id
+            response = client.get(
+                "/health",
+                headers={"X-Request-ID": malicious_rid, "X-Auth": "test_token"},
+            )
+            assert response.status_code in (200, 401, 403)
 
     # Check if the malicious RID is sanitized in the logs
     log_messages = [rec.request_id for rec in caplog.records if hasattr(rec, "request_id")]

--- a/tests/test_log_injection.py
+++ b/tests/test_log_injection.py
@@ -1,18 +1,23 @@
 import logging
-import uuid
-import pytest
 from fastapi.testclient import TestClient
 from app import app
 
-def test_log_injection_request_id(caplog):
+def test_log_injection_request_id(caplog, monkeypatch):
+    # Ensure deterministic environment for auth and disable integrity background logic
+    monkeypatch.setenv("CHRONIK_TOKEN", "test_token")
+    monkeypatch.setenv("CHRONIK_INTEGRITY_ENABLED", "0")
+
     client = TestClient(app)
     malicious_rid = "123\nERROR: spoofed error message"
 
     # We need to ensure the logger is at least at INFO level to capture the "access" log
     with caplog.at_level(logging.INFO, logger="chronik"):
-        response = client.get("/health", headers={"X-Request-ID": malicious_rid, "X-Auth": "test_token"})
-        # Note: /health requires auth. Let's make sure it doesn't fail auth if we want to reach the middleware's finally block properly
-        # Wait, the middleware's finally block ALWAYS runs.
+        # Send request so middleware logs the sanitized request_id
+        response = client.get(
+            "/health",
+            headers={"X-Request-ID": malicious_rid, "X-Auth": "test_token"},
+        )
+        assert response.status_code in (200, 401, 403)
 
     # Check if the malicious RID is sanitized in the logs
     log_messages = [rec.request_id for rec in caplog.records if hasattr(rec, "request_id")]


### PR DESCRIPTION
This commit addresses a log injection vulnerability where the `X-Request-ID` header was logged without sanitization.

- Implemented sanitization using `_METRIC_LABEL_SANITIZER` (alphanumeric, dots, dashes, underscores).
- Enforced a maximum length of 128 characters for `request_id` via `MAX_RID_LENGTH`.
- Added a regression test in `tests/test_log_injection.py`.