### PR TITLE
chore: replace broad Exception with OSError in storage file operations

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -185,7 +185,7 @@ def _safe_open_read(target_path: Path) -> Iterator:
         )
         try:
             fh = os.fdopen(fd, "rb")
-        except Exception:
+        except OSError:
             os.close(fd)
             raise
         with fh:
@@ -248,7 +248,7 @@ def _locked_open(target_path: Path, mode: str) -> Iterator:
                 )
                 try:
                     fh = os.fdopen(fd, py_mode, encoding=encoding)
-                except Exception:
+                except OSError:
                     os.close(fd)
                     raise
                 with fh:


### PR DESCRIPTION
In `storage.py`, changed two occurrences of `except Exception:` to `except OSError:` when calling `os.fdopen`. This ensures we catch specific I/O related errors while avoiding catching unrelated exceptions, improving code health and predictability. Both sites correctly handle closing the file descriptor if the wrapper fails to initialize.