### PR TITLE
🧪 [testing improvement] add unit tests for patch_rate_limit_item

### DIFF
--- a/tests/test_slowapi_compat_unit.py
+++ b/tests/test_slowapi_compat_unit.py
@@ -2,12 +2,13 @@ import importlib
 import sys
 import types
 from contextlib import contextmanager
-from unittest.mock import patch
 
 @contextmanager
 def isolated_slowapi_compat_import(mock_limits_module):
     """Context manager to import slowapi_compat in an isolated environment."""
-    # Store original state
+    # Store original state and presence
+    had_slowapi_compat = "slowapi_compat" in sys.modules
+    had_limits = "limits" in sys.modules
     original_slowapi_compat = sys.modules.get("slowapi_compat")
     original_limits = sys.modules.get("limits")
 
@@ -24,10 +25,11 @@ def isolated_slowapi_compat_import(mock_limits_module):
         # Restore original state or clean up
         if "slowapi_compat" in sys.modules:
             del sys.modules["slowapi_compat"]
-        if original_slowapi_compat:
+
+        if had_slowapi_compat:
             sys.modules["slowapi_compat"] = original_slowapi_compat
 
-        if original_limits:
+        if had_limits:
             sys.modules["limits"] = original_limits
         elif "limits" in sys.modules:
             del sys.modules["limits"]

--- a/tests/test_slowapi_compat_unit.py
+++ b/tests/test_slowapi_compat_unit.py
@@ -9,7 +9,7 @@ def get_isolated_slowapi_compat():
 
     # Use patch.dict to safely modify sys.modules only during the import
     with patch.dict(sys.modules, {"limits": mock_limits}):
-        # Force a reload of the module to ensure it picks up the mock
+        # Force a fresh load of the module
         if "slowapi_compat" in sys.modules:
             del sys.modules["slowapi_compat"]
 
@@ -28,11 +28,8 @@ def test_patch_rate_limit_item_adds_missing_attributes():
     with patch.object(slowapi_compat, "RateLimitItem", FakeRateLimitItem):
         slowapi_compat.patch_rate_limit_item()
 
-        assert hasattr(FakeRateLimitItem, "error_message")
-        assert hasattr(FakeRateLimitItem, "limit")
-
         item = FakeRateLimitItem()
-        # Test the property behavior
+        # Verify behavioral correctness, not just existence
         assert item.error_message == "Rate limit exceeded: 1 per minute"
         assert item.limit is item
 
@@ -51,3 +48,21 @@ def test_patch_rate_limit_item_respects_existing_attributes():
 
         assert FakeRateLimitItem.error_message == "custom message"
         assert FakeRateLimitItem.limit == "custom limit"
+
+
+def test_patch_rate_limit_item_is_idempotent():
+    """Test that calling patch_rate_limit_item multiple times is safe."""
+    slowapi_compat = get_isolated_slowapi_compat()
+
+    class FakeRateLimitItem:
+        def __str__(self):
+            return "1 per minute"
+
+    with patch.object(slowapi_compat, "RateLimitItem", FakeRateLimitItem):
+        # Apply patch twice
+        slowapi_compat.patch_rate_limit_item()
+        slowapi_compat.patch_rate_limit_item()
+
+        item = FakeRateLimitItem()
+        assert item.error_message == "Rate limit exceeded: 1 per minute"
+        assert item.limit is item

--- a/tests/test_slowapi_compat_unit.py
+++ b/tests/test_slowapi_compat_unit.py
@@ -1,49 +1,81 @@
 import importlib
 import sys
-from unittest.mock import MagicMock, patch
+import types
+from contextlib import contextmanager
+from unittest.mock import patch
 
-def get_isolated_slowapi_compat():
-    """Import slowapi_compat in an isolated environment with mocked limits."""
-    # Mock limits module
-    mock_limits = MagicMock()
+@contextmanager
+def isolated_slowapi_compat_import(mock_limits_module):
+    """Context manager to import slowapi_compat in an isolated environment."""
+    # Store original state
+    original_slowapi_compat = sys.modules.get("slowapi_compat")
+    original_limits = sys.modules.get("limits")
 
-    # Use patch.dict to safely modify sys.modules only during the import
-    with patch.dict(sys.modules, {"limits": mock_limits}):
-        # Force a fresh load of the module
+    try:
+        # Set up mocks in sys.modules
+        sys.modules["limits"] = mock_limits_module
         if "slowapi_compat" in sys.modules:
             del sys.modules["slowapi_compat"]
 
-        return importlib.import_module("slowapi_compat")
+        # Import the module
+        module = importlib.import_module("slowapi_compat")
+        yield module
+    finally:
+        # Restore original state or clean up
+        if "slowapi_compat" in sys.modules:
+            del sys.modules["slowapi_compat"]
+        if original_slowapi_compat:
+            sys.modules["slowapi_compat"] = original_slowapi_compat
+
+        if original_limits:
+            sys.modules["limits"] = original_limits
+        elif "limits" in sys.modules:
+            del sys.modules["limits"]
+
+
+def create_fake_limits_module(rate_limit_item_class):
+    """Create a real module object for 'limits'."""
+    mock_limits = types.ModuleType("limits")
+    mock_limits.RateLimitItem = rate_limit_item_class
+    return mock_limits
 
 
 def test_patch_rate_limit_item_adds_missing_attributes():
     """Test that missing attributes are correctly added to RateLimitItem."""
-    slowapi_compat = get_isolated_slowapi_compat()
 
     class FakeRateLimitItem:
         def __str__(self):
             return "1 per minute"
 
-    # Patch the reference in the isolated module
-    with patch.object(slowapi_compat, "RateLimitItem", FakeRateLimitItem):
+    # Ensure it doesn't have the attributes initially
+    assert not hasattr(FakeRateLimitItem, "error_message")
+    assert not hasattr(FakeRateLimitItem, "limit")
+
+    mock_limits = create_fake_limits_module(FakeRateLimitItem)
+
+    with isolated_slowapi_compat_import(mock_limits) as slowapi_compat:
+        # The module calls patch_rate_limit_item() on import,
+        # but we call it explicitly to be sure we are testing the function logic.
         slowapi_compat.patch_rate_limit_item()
 
         item = FakeRateLimitItem()
-        # Verify behavioral correctness, not just existence
+        # Verify behavioral correctness
         assert item.error_message == "Rate limit exceeded: 1 per minute"
         assert item.limit is item
 
 
 def test_patch_rate_limit_item_respects_existing_attributes():
     """Test that existing attributes are not overwritten by the patch."""
-    slowapi_compat = get_isolated_slowapi_compat()
 
     class FakeRateLimitItem:
         error_message = "custom message"
         limit = "custom limit"
+        def __str__(self):
+            return "1 per minute"
 
-    # Patch the reference in the isolated module
-    with patch.object(slowapi_compat, "RateLimitItem", FakeRateLimitItem):
+    mock_limits = create_fake_limits_module(FakeRateLimitItem)
+
+    with isolated_slowapi_compat_import(mock_limits) as slowapi_compat:
         slowapi_compat.patch_rate_limit_item()
 
         assert FakeRateLimitItem.error_message == "custom message"
@@ -52,13 +84,14 @@ def test_patch_rate_limit_item_respects_existing_attributes():
 
 def test_patch_rate_limit_item_is_idempotent():
     """Test that calling patch_rate_limit_item multiple times is safe."""
-    slowapi_compat = get_isolated_slowapi_compat()
 
     class FakeRateLimitItem:
         def __str__(self):
             return "1 per minute"
 
-    with patch.object(slowapi_compat, "RateLimitItem", FakeRateLimitItem):
+    mock_limits = create_fake_limits_module(FakeRateLimitItem)
+
+    with isolated_slowapi_compat_import(mock_limits) as slowapi_compat:
         # Apply patch twice
         slowapi_compat.patch_rate_limit_item()
         slowapi_compat.patch_rate_limit_item()

--- a/tests/test_slowapi_compat_unit.py
+++ b/tests/test_slowapi_compat_unit.py
@@ -1,0 +1,43 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+# Mock 'limits' before importing slowapi_compat to avoid ModuleNotFoundError
+mock_limits = MagicMock()
+if "limits" not in sys.modules:
+    sys.modules["limits"] = mock_limits
+
+import slowapi_compat
+
+
+def test_patch_rate_limit_item_adds_missing_attributes():
+    """Test that missing attributes are correctly added to RateLimitItem."""
+
+    class FakeRateLimitItem:
+        def __str__(self):
+            return "1 per minute"
+
+    # Patch the reference in the module we are testing
+    with patch("slowapi_compat.RateLimitItem", FakeRateLimitItem):
+        slowapi_compat.patch_rate_limit_item()
+
+        assert hasattr(FakeRateLimitItem, "error_message")
+        assert hasattr(FakeRateLimitItem, "limit")
+
+        item = FakeRateLimitItem()
+        # Test the property behavior
+        assert item.error_message == "Rate limit exceeded: 1 per minute"
+        assert item.limit is item
+
+
+def test_patch_rate_limit_item_respects_existing_attributes():
+    """Test that existing attributes are not overwritten by the patch."""
+
+    class FakeRateLimitItem:
+        error_message = "custom message"
+        limit = "custom limit"
+
+    with patch("slowapi_compat.RateLimitItem", FakeRateLimitItem):
+        slowapi_compat.patch_rate_limit_item()
+
+        assert FakeRateLimitItem.error_message == "custom message"
+        assert FakeRateLimitItem.limit == "custom limit"

--- a/tests/test_slowapi_compat_unit.py
+++ b/tests/test_slowapi_compat_unit.py
@@ -1,23 +1,33 @@
+import importlib
 import sys
 from unittest.mock import MagicMock, patch
 
-# Mock 'limits' before importing slowapi_compat to avoid ModuleNotFoundError
-mock_limits = MagicMock()
-if "limits" not in sys.modules:
-    sys.modules["limits"] = mock_limits
+def get_isolated_slowapi_compat():
+    """Import slowapi_compat in an isolated environment with mocked limits."""
+    # Mock limits module
+    mock_limits = MagicMock()
 
-import slowapi_compat
+    # Use patch.dict to safely modify sys.modules only during the import
+    with patch.dict(sys.modules, {"limits": mock_limits}):
+        # Force a reload of the module to ensure it picks up the mock
+        if "slowapi_compat" in sys.modules:
+            del sys.modules["slowapi_compat"]
+
+        module = importlib.import_module("slowapi_compat")
+        importlib.reload(module)
+        return module
 
 
 def test_patch_rate_limit_item_adds_missing_attributes():
     """Test that missing attributes are correctly added to RateLimitItem."""
+    slowapi_compat = get_isolated_slowapi_compat()
 
     class FakeRateLimitItem:
         def __str__(self):
             return "1 per minute"
 
-    # Patch the reference in the module we are testing
-    with patch("slowapi_compat.RateLimitItem", FakeRateLimitItem):
+    # Patch the reference in the isolated module
+    with patch.object(slowapi_compat, "RateLimitItem", FakeRateLimitItem):
         slowapi_compat.patch_rate_limit_item()
 
         assert hasattr(FakeRateLimitItem, "error_message")
@@ -31,12 +41,14 @@ def test_patch_rate_limit_item_adds_missing_attributes():
 
 def test_patch_rate_limit_item_respects_existing_attributes():
     """Test that existing attributes are not overwritten by the patch."""
+    slowapi_compat = get_isolated_slowapi_compat()
 
     class FakeRateLimitItem:
         error_message = "custom message"
         limit = "custom limit"
 
-    with patch("slowapi_compat.RateLimitItem", FakeRateLimitItem):
+    # Patch the reference in the isolated module
+    with patch.object(slowapi_compat, "RateLimitItem", FakeRateLimitItem):
         slowapi_compat.patch_rate_limit_item()
 
         assert FakeRateLimitItem.error_message == "custom message"

--- a/tests/test_slowapi_compat_unit.py
+++ b/tests/test_slowapi_compat_unit.py
@@ -13,9 +13,7 @@ def get_isolated_slowapi_compat():
         if "slowapi_compat" in sys.modules:
             del sys.modules["slowapi_compat"]
 
-        module = importlib.import_module("slowapi_compat")
-        importlib.reload(module)
-        return module
+        return importlib.import_module("slowapi_compat")
 
 
 def test_patch_rate_limit_item_adds_missing_attributes():


### PR DESCRIPTION
This change adds a new unit test file `tests/test_slowapi_compat_unit.py` to verify the functionality of `patch_rate_limit_item` in `slowapi_compat.py`.

The new tests:
- Verify that `error_message` and `limit` properties are correctly added to `RateLimitItem` when they are missing.
- Ensure that existing attributes are not overwritten by the patch.
- Use mocking to avoid hard dependencies on `limits` or `slowapi` in the test environment.
- Confirm the behavior of the added properties (string formatting and self-reference).

The testing gap for this public function is now addressed, ensuring that compatibility with `slowapi` remains stable across dependency versions.