### PR TITLE
chore: add local validation command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 PORT := $(if $(CHRONIK_PORT),$(CHRONIK_PORT),8788)
 AUTH_TOKEN := $(if $(CHRONIK_TOKEN),$(CHRONIK_TOKEN))
 
-.PHONY: dev ingest-test ensure-token
+.PHONY: dev ingest-test ensure-token validate-local
 
 dev:
 	uvicorn app:app --reload --port $(PORT)
+
+validate-local:
+	./scripts/validate-local.sh
 
 ingest-test: ensure-token
 	curl --fail-with-body -sS -X POST "http://localhost:$(PORT)/v1/ingest?domain=aussen" \

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Events haben definierte TTLs basierend auf Event-Typ (konfigurierbar in `config/
 * Rate-Limits & Locks: Bei hohem Traffic liefert der Dienst `429` mitsamt `Retry-After` sowie `X-RateLimit-*`. Wenn ein Lock nicht rechtzeitig frei wird, antwortet die API mit `503 lock timeout`.
 
 ## Entwicklung & Tests
+* One-Command-Validierung: `make validate-local` oder direkt `./scripts/validate-local.sh`. Der Befehl richtet/aktualisiert `.venv`, führt `pytest -q` aus und prüft hermetisch `/health`, `/version`, `POST /v1/ingest?domain=agent.ledger` sowie `/v1/events` gegen ein temporäres `CHRONIK_DATA_DIR`.
 * Formatierung: Standard Python Code-Formatierung (z. B. `black`) kann verwendet werden.
 * Tests: Für die API können `pytest`-basierte Tests oder Integrationstests mit `httpx` genutzt werden.
 * **API /v1/latest:** Der Endpoint `/v1/latest` gibt den letzten Log-Eintrag zurück (standardmäßig als Wrapper mit `domain`, `received_at`, `payload`). Mit `?unwrap=1` kann direkt das innere Payload-Objekt angefordert werden.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Events haben definierte TTLs basierend auf Event-Typ (konfigurierbar in `config/
 * Rate-Limits & Locks: Bei hohem Traffic liefert der Dienst `429` mitsamt `Retry-After` sowie `X-RateLimit-*`. Wenn ein Lock nicht rechtzeitig frei wird, antwortet die API mit `503 lock timeout`.
 
 ## Entwicklung & Tests
-* One-Command-Validierung: `make validate-local` oder direkt `./scripts/validate-local.sh`. Der Befehl richtet/aktualisiert `.venv`, führt `pytest -q` aus und prüft hermetisch `/health`, `/version`, `POST /v1/ingest?domain=agent.ledger` sowie `/v1/events` gegen ein temporäres `CHRONIK_DATA_DIR`.
+* One-Command-Validierung: `make validate-local` oder direkt `./scripts/validate-local.sh`. Der Befehl richtet/aktualisiert `.venv`, führt `pytest -q` aus und prüft ohne laufenden Server `/health`, `/version`, `POST /v1/ingest?domain=agent.ledger` sowie `/v1/events` gegen ein temporäres `CHRONIK_DATA_DIR`.
 * Formatierung: Standard Python Code-Formatierung (z. B. `black`) kann verwendet werden.
 * Tests: Für die API können `pytest`-basierte Tests oder Integrationstests mit `httpx` genutzt werden.
 * **API /v1/latest:** Der Endpoint `/v1/latest` gibt den letzten Log-Eintrag zurück (standardmäßig als Wrapper mit `domain`, `received_at`, `payload`). Mit `?unwrap=1` kann direkt das innere Payload-Objekt angefordert werden.

--- a/scripts/setup-venv.sh
+++ b/scripts/setup-venv.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Prüfen, ob das .venv-Verzeichnis bereits existiert.
-# Wenn nicht, wird es erstellt und die Abhängigkeiten installiert.
+# Ensure the local virtual environment exists and matches the current
+# runtime/development requirements. Reinstalling requirements on every run keeps
+# this script useful after dependency changes instead of only on first checkout.
 if [ ! -d ".venv" ]; then
-  echo "INFO: .venv-Verzeichnis nicht gefunden. Erstelle es und installiere Abhängigkeiten..."
+  echo "INFO: .venv-Verzeichnis nicht gefunden. Erstelle es..."
   python3 -m venv .venv
-  . .venv/bin/activate
-  python3 -m pip install --upgrade pip setuptools wheel || true
-  pip install -r requirements.txt
-  if [ -f "requirements-dev.txt" ]; then
-    echo "INFO: Installiere zusätzliche Entwicklungsabhängigkeiten..."
-    pip install -r requirements-dev.txt
-  fi
 else
-  echo "INFO: .venv-Verzeichnis bereits vorhanden. Überspringe die Erstellung."
+  echo "INFO: .venv-Verzeichnis bereits vorhanden. Prüfe Abhängigkeiten..."
+fi
+
+. .venv/bin/activate
+python3 -m pip install --upgrade pip setuptools wheel || true
+python3 -m pip install -r requirements.txt
+if [ -f "requirements-dev.txt" ]; then
+  echo "INFO: Installiere/aktualisiere zusätzliche Entwicklungsabhängigkeiten..."
+  python3 -m pip install -r requirements-dev.txt
 fi

--- a/scripts/validate-local.sh
+++ b/scripts/validate-local.sh
@@ -19,11 +19,13 @@ export CHRONIK_DATA_DIR="$TMP_DATA_DIR"
 
 ./.venv/bin/python - <<'PY'
 import os
+import re
 from fastapi.testclient import TestClient
 from app import app
 
-TOKEN = os.environ["CHRONIK_TOKEN"].split(",", 1)[0].strip()
-headers = {"X-Auth": TOKEN}
+TOKENS = [token.strip() for token in re.split(r"[,\n]+", os.environ["CHRONIK_TOKEN"]) if token.strip()]
+assert TOKENS, "CHRONIK_TOKEN produced no usable token"
+headers = {"X-Auth": TOKENS[0]}
 client = TestClient(app)
 
 health = client.get("/health", headers=headers)

--- a/scripts/validate-local.sh
+++ b/scripts/validate-local.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT_DIR"
+
+./scripts/setup-venv.sh
+
+TMP_DATA_DIR=$(mktemp -d)
+cleanup() {
+  rm -rf "$TMP_DATA_DIR"
+}
+trap cleanup EXIT
+
+export CHRONIK_TOKEN="${CHRONIK_TOKEN:-dev}"
+export CHRONIK_DATA_DIR="$TMP_DATA_DIR"
+
+./.venv/bin/python -m pytest -q
+
+./.venv/bin/python - <<'PY'
+import os
+from fastapi.testclient import TestClient
+from app import app
+
+TOKEN = os.environ["CHRONIK_TOKEN"].split(",", 1)[0].strip()
+headers = {"X-Auth": TOKEN}
+client = TestClient(app)
+
+health = client.get("/health", headers=headers)
+assert health.status_code == 200, health.text
+
+version = client.get("/version", headers=headers)
+assert version.status_code == 200, version.text
+
+event = {
+    "schema_version": "agent-ledger.v0",
+    "event_id": "01JZ0000000000000000000000",
+    "kind": "agent.run.completed",
+    "ts": "2026-07-02T12:00:00Z",
+    "source": {
+        "repo": "heimgewebe/grabowski",
+        "component": "grabowski",
+        "run_id": "local-validation-smoke",
+    },
+    "subject": {
+        "repo": "heimgewebe/chronik",
+        "branch": "local-validation",
+        "head": "local",
+    },
+    "trust_tier": "declared",
+    "status": "active",
+    "caused_by": [],
+    "evidence_refs": ["local-validation"],
+    "data": {"result": "completed"},
+}
+
+ingest = client.post(
+    "/v1/ingest?domain=agent.ledger",
+    json=event,
+    headers=headers,
+)
+assert ingest.status_code == 202, ingest.text
+
+events = client.get(
+    "/v1/events?domain=agent.ledger&limit=10",
+    headers=headers,
+)
+assert events.status_code == 200, events.text
+body = events.json()
+assert body["meta"]["count"] == 1, body
+assert body["events"][0]["payload"]["kind"] == "agent.run.completed", body
+
+print("local validation smoke ok")
+PY


### PR DESCRIPTION
## Summary

Adds a one-command local validation path for Chronik readiness.

## Changes

- adds `scripts/validate-local.sh`
- adds `make validate-local`
- makes `scripts/setup-venv.sh` update dependencies even when `.venv` already exists
- documents local validation in README

## Validation

- `./scripts/validate-local.sh`
- `make validate-local`

Both commands run pytest and smoke `/health`, `/version`, `POST /v1/ingest?domain=agent.ledger`, and `/v1/events` against a temporary `CHRONIK_DATA_DIR`.