### PR TITLE
docs: define agent run event v0

### DIFF
--- a/docs/chronik/agent-ledger-v0-plan.md
+++ b/docs/chronik/agent-ledger-v0-plan.md
@@ -230,6 +230,7 @@ Umfang:
 - Kausalitäts-Cardinality
 - Redaction-Allow-List
 - drei Beispiel-Events: started, completed, blocked
+- Contract-Seam: [`agent-run-event-v0.md`](agent-run-event-v0.md) und [`agent-run-event-v0.schema.json`](agent-run-event-v0.schema.json)
 
 Akzeptanzkriterium:
 

--- a/docs/chronik/agent-run-event-v0.md
+++ b/docs/chronik/agent-run-event-v0.md
@@ -1,0 +1,91 @@
+# Agent Run Event v0
+
+Status: draft
+Domain: `agent.ledger`
+Schema: [`agent-run-event-v0.schema.json`](agent-run-event-v0.schema.json)
+
+## These / Antithese / Synthese
+
+**These:** `agent.run.*` ist der kleinste sinnvolle Ledger-Schnitt: Er zeigt, wann ein Agentenlauf begann, endete oder blockierte.
+
+**Antithese:** Schon hier droht Logging-Inflation. Wenn das Event Rohlogs, Prompts oder Reviewtexte enthält, wird Chronik zur zweiten Ablage statt zur Zeitachse.
+
+**Synthese:** v0 erlaubt nur drei Eventarten, kleine Payloads, stabile Evidence-Referenzen und harte Cardinality-Grenzen. Alles andere bleibt außerhalb des Contracts.
+
+## Ingest-Domain
+
+Agent-Run-Events werden nach Chronik über diese Domain geschrieben:
+
+```text
+POST /v1/ingest?domain=agent.ledger
+```
+
+Die Domain ist bewusst **nicht** Teil des Event-Payloads. Chronik setzt die Storage-Domain im Envelope.
+
+## Erlaubte Kinds
+
+- `agent.run.started`
+- `agent.run.completed`
+- `agent.run.blocked`
+
+## Pflichtfelder
+
+| Feld | Bedeutung |
+|---|---|
+| `schema_version` | exakt `agent-run-event.v0` |
+| `event_id` | ULID oder deterministischer `sha256:<hex>` |
+| `kind` | eine der drei erlaubten Eventarten |
+| `ts` | UTC-Zeitpunkt mit `Z` |
+| `source` | erzeugendes Repo, Komponente, Run-ID |
+| `subject` | Zielrepo und optional Branch/Head |
+| `trust_tier` | `observed`, `declared`, `inferred` |
+| `status` | `active`, `superseded`, `corrected` |
+| `caused_by` | maximal drei auslösende Event-IDs |
+| `evidence_refs` | maximal fünf stabile Belegreferenzen |
+| `data` | erlaubte Kurzpayload-Felder |
+
+## Redaction-Allow-List
+
+`data` darf nur diese Felder enthalten:
+
+- `result`
+- `blocker_code`
+- `summary`
+- `duration_ms`
+
+Nicht erlaubt sind Rohlogs, Prompts, Tooloutputs, Secrets, Tokens, PII oder vollständige Review-Kommentare. Das ist keine Stilfrage, sondern Brandschutz. Papier brennt langsam; JSONL brennt rekursiv.
+
+## Kausalität
+
+`caused_by` darf nur gesetzt werden, wenn der Producer die auslösenden Event-IDs explizit erhalten hat, etwa aus Task-Payload, Run-Metadaten oder Environment.
+
+Grenzen:
+
+- `caused_by`: maximal 3 IDs
+- `evidence_refs`: maximal 5 Einträge
+- keine eingebetteten Belegtexte
+- keine rekursive Graph-Expansion im Event
+
+## Status und Korrektur
+
+`trust_tier` beschreibt Herkunftsqualität. `status` beschreibt den Lebenszustand des Events.
+
+Wenn `status` den Wert `corrected` hat, muss `corrects` mindestens eine alte Event-ID enthalten.
+
+## Beispiele
+
+Gültige Beispiele liegen unter:
+
+- `tests/fixtures/agent-ledger/agent-run-started.v0.json`
+- `tests/fixtures/agent-ledger/agent-run-completed.v0.json`
+- `tests/fixtures/agent-ledger/agent-run-blocked.v0.json`
+
+## Nicht-Ziele
+
+- keine PR-Events
+- keine Review-Finding-Events
+- keine Bureau-Claim-Events
+- keine Outbox-Implementierung
+- keine Runtime-Validierung in `app.py`
+
+Dieser Contract ist ein Validierungsseam für die nächsten Schritte, nicht bereits der nächste Schritt selbst.

--- a/docs/chronik/agent-run-event-v0.schema.json
+++ b/docs/chronik/agent-run-event-v0.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/chronik/agent-run-event-v0.schema.json",
+  "title": "Chronik Agent Run Event v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_id",
+    "kind",
+    "ts",
+    "source",
+    "subject",
+    "trust_tier",
+    "status",
+    "caused_by",
+    "evidence_refs",
+    "data"
+  ],
+  "properties": {
+    "schema_version": {"const": "agent-run-event.v0"},
+    "event_id": {"$ref": "#/definitions/event_id"},
+    "kind": {
+      "enum": ["agent.run.started", "agent.run.completed", "agent.run.blocked"]
+    },
+    "ts": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "component", "run_id"],
+      "properties": {
+        "repo": {"type": "string", "minLength": 1, "maxLength": 200},
+        "component": {"type": "string", "minLength": 1, "maxLength": 80},
+        "run_id": {"type": "string", "minLength": 1, "maxLength": 160}
+      }
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo"],
+      "properties": {
+        "repo": {"type": "string", "minLength": 1, "maxLength": 200},
+        "branch": {"type": "string", "minLength": 1, "maxLength": 200},
+        "head": {"type": "string", "minLength": 1, "maxLength": 80}
+      }
+    },
+    "trust_tier": {"enum": ["observed", "declared", "inferred"]},
+    "status": {"enum": ["active", "superseded", "corrected"]},
+    "corrects": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": {"$ref": "#/definitions/event_id"}
+    },
+    "caused_by": {
+      "type": "array",
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": {"$ref": "#/definitions/event_id"}
+    },
+    "evidence_refs": {
+      "type": "array",
+      "maxItems": 5,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1, "maxLength": 240}
+    },
+    "data": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "result": {"enum": ["started", "completed", "blocked"]},
+        "blocker_code": {"type": "string", "minLength": 1, "maxLength": 80},
+        "summary": {"type": "string", "minLength": 1, "maxLength": 500},
+        "duration_ms": {"type": "integer", "minimum": 0}
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"status": {"const": "corrected"}}},
+      "then": {"required": ["corrects"]}
+    }
+  ],
+  "definitions": {
+    "event_id": {
+      "type": "string",
+      "pattern": "^(?:[0-9A-HJKMNP-TV-Z]{26}|sha256:[a-f0-9]{64})$"
+    }
+  }
+}

--- a/tests/fixtures/agent-ledger/agent-run-blocked.v0.json
+++ b/tests/fixtures/agent-ledger/agent-run-blocked.v0.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "agent-run-event.v0",
+  "event_id": "01JZ0000000000000000000002",
+  "kind": "agent.run.blocked",
+  "ts": "2026-07-02T12:10:00Z",
+  "source": {
+    "repo": "heimgewebe/grabowski",
+    "component": "grabowski",
+    "run_id": "run-20260702-121000"
+  },
+  "subject": {
+    "repo": "heimgewebe/chronik",
+    "branch": "docs/agent-run-v0",
+    "head": "a44965d"
+  },
+  "trust_tier": "declared",
+  "status": "active",
+  "caused_by": [],
+  "evidence_refs": ["local-run:run-20260702-121000"],
+  "data": {
+    "result": "blocked",
+    "blocker_code": "missing-consumer-view",
+    "summary": "Producer integration is blocked until a consumer view exists."
+  }
+}

--- a/tests/fixtures/agent-ledger/agent-run-completed.v0.json
+++ b/tests/fixtures/agent-ledger/agent-run-completed.v0.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "agent-run-event.v0",
+  "event_id": "01JZ0000000000000000000001",
+  "kind": "agent.run.completed",
+  "ts": "2026-07-02T12:05:00Z",
+  "source": {
+    "repo": "heimgewebe/grabowski",
+    "component": "grabowski",
+    "run_id": "run-20260702-120000"
+  },
+  "subject": {
+    "repo": "heimgewebe/chronik",
+    "branch": "docs/agent-run-v0",
+    "head": "a44965d"
+  },
+  "trust_tier": "declared",
+  "status": "active",
+  "caused_by": ["01JZ0000000000000000000000"],
+  "evidence_refs": ["github-pr:heimgewebe/chronik#193"],
+  "data": {
+    "result": "completed",
+    "duration_ms": 300000,
+    "summary": "Local validation readiness completed."
+  }
+}

--- a/tests/fixtures/agent-ledger/agent-run-started.v0.json
+++ b/tests/fixtures/agent-ledger/agent-run-started.v0.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "agent-run-event.v0",
+  "event_id": "01JZ0000000000000000000000",
+  "kind": "agent.run.started",
+  "ts": "2026-07-02T12:00:00Z",
+  "source": {
+    "repo": "heimgewebe/grabowski",
+    "component": "grabowski",
+    "run_id": "run-20260702-120000"
+  },
+  "subject": {
+    "repo": "heimgewebe/chronik",
+    "branch": "docs/agent-run-v0",
+    "head": "a44965d"
+  },
+  "trust_tier": "declared",
+  "status": "active",
+  "caused_by": [],
+  "evidence_refs": ["local-run:run-20260702-120000"],
+  "data": {
+    "result": "started"
+  }
+}

--- a/tests/test_agent_run_event_v0_contract.py
+++ b/tests/test_agent_run_event_v0_contract.py
@@ -1,0 +1,75 @@
+import copy
+import json
+from pathlib import Path
+
+import jsonschema
+from jsonschema import Draft7Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "docs" / "chronik" / "agent-run-event-v0.schema.json"
+FIXTURE_DIR = ROOT / "tests" / "fixtures" / "agent-ledger"
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def schema():
+    loaded = load_json(SCHEMA_PATH)
+    Draft7Validator.check_schema(loaded)
+    return loaded
+
+
+def assert_invalid(instance, loaded_schema):
+    try:
+        jsonschema.validate(instance, loaded_schema)
+    except jsonschema.exceptions.ValidationError:
+        return
+    raise AssertionError("instance unexpectedly validated")
+
+
+def test_agent_run_event_v0_schema_is_strict():
+    loaded_schema = schema()
+    assert loaded_schema["additionalProperties"] is False
+    assert loaded_schema["properties"]["source"]["additionalProperties"] is False
+    assert loaded_schema["properties"]["subject"]["additionalProperties"] is False
+    assert loaded_schema["properties"]["data"]["additionalProperties"] is False
+    assert loaded_schema["properties"]["caused_by"]["maxItems"] == 3
+    assert loaded_schema["properties"]["evidence_refs"]["maxItems"] == 5
+
+
+def test_agent_run_event_v0_fixtures_validate():
+    loaded_schema = schema()
+    fixtures = sorted(FIXTURE_DIR.glob("agent-run-*.v0.json"))
+    assert fixtures
+    for fixture in fixtures:
+        jsonschema.validate(load_json(fixture), loaded_schema)
+
+
+def test_agent_run_event_v0_rejects_extra_data_fields():
+    loaded_schema = schema()
+    event = load_json(FIXTURE_DIR / "agent-run-completed.v0.json")
+    event["data"]["raw"] = "no"
+    assert_invalid(event, loaded_schema)
+
+
+def test_agent_run_event_v0_rejects_excessive_causality():
+    loaded_schema = schema()
+    event = load_json(FIXTURE_DIR / "agent-run-completed.v0.json")
+    event["caused_by"] = [
+        "01JZ0000000000000000000000",
+        "01JZ0000000000000000000001",
+        "01JZ0000000000000000000002",
+        "01JZ0000000000000000000003",
+    ]
+    assert_invalid(event, loaded_schema)
+
+
+def test_agent_run_event_v0_requires_corrects_for_corrected_status():
+    loaded_schema = schema()
+    event = copy.deepcopy(load_json(FIXTURE_DIR / "agent-run-completed.v0.json"))
+    event["status"] = "corrected"
+    assert_invalid(event, loaded_schema)
+    event["corrects"] = ["01JZ0000000000000000000000"]
+    jsonschema.validate(event, loaded_schema)


### PR DESCRIPTION
## Summary

Defines the narrow `agent.run.*` event contract for Agent Ledger v0 without adding runtime validation or producer integration.

## Changes

- adds `docs/chronik/agent-run-event-v0.md`
- adds `docs/chronik/agent-run-event-v0.schema.json`
- adds three valid fixtures for started/completed/blocked events
- adds schema tests for strictness, valid fixtures, redaction boundary, cardinality and corrected status
- links the contract seam from the minimal ledger plan

## Validation

- `./.venv/bin/python -m pytest tests/test_agent_run_event_v0_contract.py -q`
- `make validate-local`

Results: 5 contract tests passed; full local validation passed with 210 tests and the existing TestClient deprecation warning.