### PR TITLE
feat: add local spool prototype

### DIFF
--- a/docs/chronik/agent-run-event-v0.md
+++ b/docs/chronik/agent-run-event-v0.md
@@ -3,6 +3,7 @@
 Status: draft
 Domain: `agent.ledger`
 Schema: [`agent-run-event-v0.schema.json`](agent-run-event-v0.schema.json)
+Outbox helper: `python -m tools.chronik_outbox`
 
 ## These / Antithese / Synthese
 
@@ -72,6 +73,24 @@ Grenzen:
 
 Wenn `status` den Wert `corrected` hat, muss `corrects` mindestens eine alte Event-ID enthalten.
 
+## Lokaler Outbox-Prototyp
+
+`tools.chronik_outbox` stellt einen lokalen, producer-agnostischen Prototyp bereit:
+
+```bash
+python -m tools.chronik_outbox --state-root /tmp/chronik-state append tests/fixtures/agent-ledger/agent-run-completed.v0.json
+python -m tools.chronik_outbox --state-root /tmp/chronik-state status
+CHRONIK_TOKEN=dev python -m tools.chronik_outbox --state-root /tmp/chronik-state flush --base-url http://localhost:8788
+python -m tools.chronik_outbox --state-root /tmp/chronik-state compact
+```
+
+Regeln:
+
+- `append` validiert gegen das v0-Schema und schreibt eine JSONL-Datei pro Producer/Run.
+- `flush` sendet an `POST /v1/ingest?domain=agent.ledger` und erstellt ein Receipt.
+- `compact` entfernt nur Dateien, für die ein Flush-Receipt existiert.
+- Kein Agentenlauf darf vom Outbox-Prototyp abhängig werden.
+
 ## Beispiele
 
 Gültige Beispiele liegen unter:
@@ -85,7 +104,7 @@ Gültige Beispiele liegen unter:
 - keine PR-Events
 - keine Review-Finding-Events
 - keine Bureau-Claim-Events
-- keine Outbox-Implementierung
+- keine echte Producer-Integration
 - keine Runtime-Validierung in `app.py`
 
 Dieser Contract ist ein Validierungsseam für die nächsten Schritte, nicht bereits der nächste Schritt selbst.

--- a/tests/test_chronik_outbox.py
+++ b/tests/test_chronik_outbox.py
@@ -1,0 +1,105 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from tools import chronik_outbox
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tests" / "fixtures" / "agent-ledger" / "agent-run-completed.v0.json"
+
+
+def load_event():
+    with FIXTURE.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_append_event_writes_one_run_file(tmp_path):
+    event = load_event()
+    path = chronik_outbox.append_event(event, tmp_path)
+
+    assert path == tmp_path / "grabowski" / "chronik-outbox" / "grabowski_run-20260702-120000.jsonl"
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["kind"] == "agent.run.completed"
+
+
+def test_append_event_rejects_invalid_payload(tmp_path):
+    event = load_event()
+    event["data"]["raw"] = "no"
+
+    with pytest.raises(Exception):
+        chronik_outbox.append_event(event, tmp_path)
+
+
+def test_status_reports_pending_file(tmp_path):
+    event = load_event()
+    path = chronik_outbox.append_event(event, tmp_path)
+
+    entries = chronik_outbox.status(tmp_path)
+
+    assert len(entries) == 1
+    assert entries[0].path == path
+    assert entries[0].events == 1
+    assert entries[0].bytes > 0
+    assert entries[0].flushed is False
+
+
+def test_flush_file_posts_agent_ledger_domain_and_writes_receipt(tmp_path):
+    event = load_event()
+    path = chronik_outbox.append_event(event, tmp_path)
+    calls = []
+
+    def fake_sender(url, payload, token, timeout):
+        calls.append((url, payload, token, timeout))
+        return 202, "ok"
+
+    receipt = chronik_outbox.flush_file(
+        path,
+        base_url="http://chronik.test",
+        token="secret",
+        timeout=1.5,
+        sender=fake_sender,
+    )
+
+    assert receipt.exists()
+    assert calls[0][0] == "http://chronik.test/v1/ingest?domain=agent.ledger"
+    assert calls[0][1][0]["kind"] == "agent.run.completed"
+    assert calls[0][2] == "secret"
+    assert calls[0][3] == 1.5
+    receipt_body = json.loads(receipt.read_text(encoding="utf-8"))
+    assert receipt_body["domain"] == "agent.ledger"
+    assert receipt_body["event_count"] == 1
+
+
+def test_compact_removes_flushed_files_only(tmp_path):
+    event = load_event()
+    path = chronik_outbox.append_event(event, tmp_path)
+    chronik_outbox.flush_file(
+        path,
+        base_url="http://chronik.test",
+        token="secret",
+        sender=lambda url, payload, token, timeout: (202, "ok"),
+    )
+
+    removed = chronik_outbox.compact(tmp_path)
+
+    assert removed == [path]
+    assert not path.exists()
+    assert chronik_outbox.receipt_path(path).exists()
+
+
+def test_flush_failure_keeps_pending_file_and_no_receipt(tmp_path):
+    event = load_event()
+    path = chronik_outbox.append_event(event, tmp_path)
+
+    with pytest.raises(chronik_outbox.OutboxError):
+        chronik_outbox.flush_file(
+            path,
+            base_url="http://chronik.test",
+            token="secret",
+            sender=lambda url, payload, token, timeout: (503, "down"),
+        )
+
+    assert path.exists()
+    assert not chronik_outbox.receipt_path(path).exists()

--- a/tools/chronik_outbox.py
+++ b/tools/chronik_outbox.py
@@ -1,0 +1,247 @@
+"""Outbox helper for Chronik agent-run events.
+
+This module is producer-agnostic. It validates and stores local
+``agent-run-event.v0`` payloads, can flush them to Chronik, and can compact
+files that already have successful flush receipts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable
+from urllib.parse import urlencode
+
+import httpx
+import jsonschema
+from jsonschema import Draft7Validator
+
+DOMAIN = "agent.ledger"
+DEFAULT_STATE_ROOT = Path(".local/state")
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "docs" / "chronik" / "agent-run-event-v0.schema.json"
+SAFE_PART = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+class OutboxError(RuntimeError):
+    """Raised for expected outbox failures."""
+
+
+@dataclass(frozen=True)
+class OutboxFileStatus:
+    path: Path
+    events: int
+    bytes: int
+    flushed: bool
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_schema() -> dict[str, Any]:
+    schema = load_json(SCHEMA_PATH)
+    Draft7Validator.check_schema(schema)
+    return schema
+
+
+def validate_event(event: dict[str, Any]) -> None:
+    jsonschema.validate(event, load_schema())
+
+
+def safe_part(value: str, label: str) -> str:
+    cleaned = SAFE_PART.sub("_", value.strip()).strip("._-")
+    if not cleaned:
+        raise OutboxError(f"{label} is empty after sanitization")
+    return cleaned[:160]
+
+
+def producer_and_run_id(event: dict[str, Any]) -> tuple[str, str]:
+    try:
+        source = event["source"]
+        component = source["component"]
+        run_id = source["run_id"]
+    except (KeyError, TypeError) as exc:
+        raise OutboxError("event.source.component and event.source.run_id are required") from exc
+    return safe_part(str(component), "producer"), safe_part(str(run_id), "run_id")
+
+
+def outbox_path(event: dict[str, Any], state_root: Path = DEFAULT_STATE_ROOT) -> Path:
+    producer, run_id = producer_and_run_id(event)
+    return state_root / producer / "chronik-outbox" / f"{producer}_{run_id}.jsonl"
+
+
+def receipt_path(path: Path) -> Path:
+    return path.parent / ".flushed" / f"{path.name}.receipt.json"
+
+
+def append_event(event: dict[str, Any], state_root: Path = DEFAULT_STATE_ROOT) -> Path:
+    validate_event(event)
+    path = outbox_path(event, state_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, sort_keys=True, separators=(",", ":")))
+        handle.write("\n")
+    return path
+
+
+def iter_outbox_files(state_root: Path = DEFAULT_STATE_ROOT) -> Iterable[Path]:
+    yield from sorted(state_root.glob("*/chronik-outbox/*.jsonl"))
+
+
+def read_events(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise OutboxError(f"{path}:{line_number}: invalid jsonl") from exc
+            validate_event(event)
+            events.append(event)
+    return events
+
+
+def status(state_root: Path = DEFAULT_STATE_ROOT) -> list[OutboxFileStatus]:
+    entries: list[OutboxFileStatus] = []
+    for path in iter_outbox_files(state_root):
+        event_count = sum(1 for line in path.read_text(encoding="utf-8").splitlines() if line.strip())
+        entries.append(
+            OutboxFileStatus(
+                path=path,
+                events=event_count,
+                bytes=path.stat().st_size,
+                flushed=receipt_path(path).exists(),
+            )
+        )
+    return entries
+
+
+def token_from_env() -> str:
+    token_blob = os.environ.get("CHRONIK_TOKEN", "")
+    tokens = [token.strip() for token in re.split(r"[,\n]+", token_blob) if token.strip()]
+    if not tokens:
+        raise OutboxError("CHRONIK_TOKEN is required for flush")
+    return tokens[0]
+
+
+def post_json(url: str, payload: list[dict[str, Any]], token: str, timeout: float) -> tuple[int, str]:
+    headers = {"Content-Type": "application/json", "X-Auth": token}
+    with httpx.Client(timeout=timeout) as client:
+        response = client.post(url, json=payload, headers=headers)
+    return response.status_code, response.text
+
+
+def flush_file(
+    path: Path,
+    *,
+    base_url: str,
+    token: str | None = None,
+    timeout: float = 5.0,
+    sender: Callable[[str, list[dict[str, Any]], str, float], tuple[int, str]] | None = None,
+) -> Path:
+    events = read_events(path)
+    if not events:
+        raise OutboxError(f"{path} contains no events")
+    resolved_token = token or token_from_env()
+    url = f"{base_url.rstrip('/')}/v1/ingest?{urlencode({'domain': DOMAIN})}"
+    status_code, text = (sender or post_json)(url, events, resolved_token, timeout)
+    if not 200 <= status_code < 300:
+        raise OutboxError(f"flush failed for {path}: HTTP {status_code}: {text}")
+
+    receipt = receipt_path(path)
+    receipt.parent.mkdir(parents=True, exist_ok=True)
+    receipt.write_text(
+        json.dumps(
+            {
+                "domain": DOMAIN,
+                "source_path": str(path),
+                "event_count": len(events),
+                "flushed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "status_code": status_code,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return receipt
+
+
+def flush_all(
+    *,
+    state_root: Path = DEFAULT_STATE_ROOT,
+    base_url: str,
+    token: str | None = None,
+    timeout: float = 5.0,
+    sender: Callable[[str, list[dict[str, Any]], str, float], tuple[int, str]] | None = None,
+) -> list[Path]:
+    receipts: list[Path] = []
+    for path in iter_outbox_files(state_root):
+        if receipt_path(path).exists():
+            continue
+        receipts.append(flush_file(path, base_url=base_url, token=token, timeout=timeout, sender=sender))
+    return receipts
+
+
+def compact(state_root: Path = DEFAULT_STATE_ROOT) -> list[Path]:
+    removed: list[Path] = []
+    for path in iter_outbox_files(state_root):
+        if receipt_path(path).exists():
+            path.unlink()
+            removed.append(path)
+    return removed
+
+
+def print_json(value: Any) -> None:
+    print(json.dumps(value, indent=2, sort_keys=True, default=str))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Chronik agent ledger outbox v0")
+    parser.add_argument("--state-root", default=str(DEFAULT_STATE_ROOT))
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    append_parser = subparsers.add_parser("append")
+    append_parser.add_argument("event_file")
+
+    subparsers.add_parser("status")
+
+    flush_parser = subparsers.add_parser("flush")
+    flush_parser.add_argument("--base-url", default=os.environ.get("CHRONIK_URL", "http://localhost:8788"))
+    flush_parser.add_argument("--timeout", type=float, default=5.0)
+
+    subparsers.add_parser("compact")
+
+    args = parser.parse_args(argv)
+    state_root = Path(args.state_root)
+
+    try:
+        if args.command == "append":
+            path = append_event(load_json(Path(args.event_file)), state_root)
+            print_json({"appended": str(path)})
+        elif args.command == "status":
+            print_json({"files": [entry.__dict__ for entry in status(state_root)]})
+        elif args.command == "flush":
+            receipts = flush_all(state_root=state_root, base_url=args.base_url, timeout=args.timeout)
+            print_json({"receipts": [str(receipt) for receipt in receipts]})
+        elif args.command == "compact":
+            removed = compact(state_root)
+            print_json({"removed": [str(path) for path in removed]})
+    except (OutboxError, jsonschema.exceptions.ValidationError) as exc:
+        print(f"chronik-outbox: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a producer-agnostic local spool prototype for Agent Ledger v0. Validation: make validate-local.