### PR TITLE
feat: add agent run view

### DIFF
--- a/tests/test_agent_ledger_view.py
+++ b/tests/test_agent_ledger_view.py
@@ -78,3 +78,49 @@ def test_format_table_contains_expected_columns():
     assert "blocker_code" in rendered
     assert "heimgewebe/chronik" in rendered
     assert "missing-consumer-view" in rendered
+
+
+def with_run(event, run_id, ts, result, kind=None, blocker_code=""):
+    copied = json.loads(json.dumps(event))
+    copied["source"]["run_id"] = run_id
+    copied["ts"] = ts
+    copied["data"] = {"result": result}
+    if blocker_code:
+        copied["data"]["blocker_code"] = blocker_code
+    if kind is not None:
+        copied["kind"] = kind
+    return copied
+
+
+def test_build_run_view_keeps_distinct_runs_for_one_repo():
+    started = load_fixture("agent-run-started.v0.json")
+    completed = load_fixture("agent-run-completed.v0.json")
+    blocked = load_fixture("agent-run-blocked.v0.json")
+    records = [
+        with_run(started, "run-a", "2026-07-02T12:00:00Z", "started"),
+        with_run(completed, "run-a", "2026-07-02T12:01:00Z", "completed"),
+        with_run(started, "run-b", "2026-07-02T12:02:00Z", "started"),
+        with_run(blocked, "run-b", "2026-07-02T12:03:00Z", "blocked", blocker_code="task-failed"),
+    ]
+
+    repo_rows = agent_ledger_view.build_view(records)
+    run_rows = agent_ledger_view.build_run_view(records)
+
+    assert len(repo_rows) == 1
+    assert repo_rows[0].result == "blocked"
+    assert len(run_rows) == 2
+    assert [(row.run_id, row.result) for row in run_rows] == [
+        ("run-a", "completed"),
+        ("run-b", "blocked"),
+    ]
+    assert run_rows[1].blocker_code == "task-failed"
+
+
+def test_run_view_table_includes_run_id_column():
+    completed = load_fixture("agent-run-completed.v0.json")
+    row = agent_ledger_view.build_run_view([completed])[0]
+
+    rendered = agent_ledger_view.format_table([row])
+
+    assert "run_id" in rendered
+    assert completed["source"]["run_id"] in rendered

--- a/tools/agent_ledger_view.py
+++ b/tools/agent_ledger_view.py
@@ -30,6 +30,17 @@ class AgentRunViewRow:
     ts: str
 
 
+@dataclass(frozen=True)
+class AgentRunLaneRow:
+    repo: str
+    run_id: str
+    branch: str
+    result: str
+    blocker_code: str
+    evidence_ref: str
+    ts: str
+
+
 def parse_ts(value: str) -> datetime:
     if not value.endswith("Z"):
         raise ValueError(f"expected UTC Z timestamp, got {value!r}")
@@ -95,8 +106,42 @@ def build_view(records: Iterable[dict[str, Any]]) -> list[AgentRunViewRow]:
     return [entry[1] for entry in sorted(latest_by_repo.values(), key=lambda item: item[1].repo)]
 
 
-def format_table(rows: list[AgentRunViewRow]) -> str:
+def build_run_view(records: Iterable[dict[str, Any]]) -> list[AgentRunLaneRow]:
+    latest_by_run: dict[tuple[str, str], tuple[datetime, AgentRunLaneRow]] = {}
+    for event in iter_agent_run_events(records):
+        subject = event["subject"]
+        source = event["source"]
+        repo = subject["repo"]
+        run_id = source["run_id"]
+        data = event.get("data", {})
+        evidence_refs = event.get("evidence_refs", [])
+        row = AgentRunLaneRow(
+            repo=repo,
+            run_id=run_id,
+            branch=subject.get("branch", ""),
+            result=data.get("result", ""),
+            blocker_code=data.get("blocker_code", ""),
+            evidence_ref=evidence_refs[0] if evidence_refs else "",
+            ts=event["ts"],
+        )
+        event_ts = parse_ts(event["ts"])
+        key = (repo, run_id)
+        current = latest_by_run.get(key)
+        if current is None or event_ts >= current[0]:
+            latest_by_run[key] = (event_ts, row)
+    return [
+        entry[1]
+        for entry in sorted(
+            latest_by_run.values(),
+            key=lambda item: (item[1].repo, item[1].run_id),
+        )
+    ]
+
+
+def format_table(rows: list[AgentRunViewRow | AgentRunLaneRow]) -> str:
     headers = ["repo", "branch", "result", "blocker_code", "evidence_ref", "ts"]
+    if rows and hasattr(rows[0], "run_id"):
+        headers = ["repo", "run_id", "branch", "result", "blocker_code", "evidence_ref", "ts"]
     values = [[getattr(row, header) for header in headers] for row in rows]
     widths = [len(header) for header in headers]
     for value_row in values:
@@ -114,13 +159,14 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Render the Agent Ledger v0 demo view")
     parser.add_argument("input", nargs="+", help="JSON or JSONL files containing raw events or Chronik /v1/events output")
     parser.add_argument("--format", choices=["table", "json"], default="table")
+    parser.add_argument("--view", choices=["repo", "run"], default="repo")
     args = parser.parse_args(argv)
 
     records: list[dict[str, Any]] = []
     for input_path in args.input:
         records.extend(load_records(Path(input_path)))
 
-    rows = build_view(records)
+    rows = build_run_view(records) if args.view == "run" else build_view(records)
     if args.format == "json":
         print(json.dumps([asdict(row) for row in rows], indent=2, sort_keys=True))
     else:


### PR DESCRIPTION
Adds a run-level Agent Ledger demo view grouped by source.run_id while keeping the existing repo-level view. Validation: make validate-local.