### PR TITLE
fix: enforce operator ecosystem role contract

### DIFF
--- a/.github/workflows/ai-context-guard.yml
+++ b/.github/workflows/ai-context-guard.yml
@@ -37,12 +37,15 @@ jobs:
             echo "INFO: .ai-context.yml missing (allowed during rollout, but should be added)."
           fi
 
-      # chronik hard-requires .ai-context.yml — the operator-ecosystem role
-      # contract lives here. This intentionally supersedes the generic
-      # "missing allowed during rollout" note in the step above.
+      # This workflow is rolled out to multiple repos (see the rollout note
+      # above), so this step is scoped to chronik only: chronik hard-requires
+      # .ai-context.yml because its operator-ecosystem role contract lives
+      # there. Other repos keep the generic "missing allowed during rollout"
+      # behavior and skip this step entirely.
       # pyyaml is installed by "Install validator deps" for this same
       # interpreter, so check_role.py's `import yaml` resolves.
-      - name: Enforce operator-ecosystem role contract
+      - name: Enforce chronik operator-ecosystem role contract
+        if: github.repository == 'heimgewebe/chronik'
         run: |
           test -f .ai-context.yml || { echo "ERROR: .ai-context.yml is required for chronik"; exit 1; }
           python scripts/check_role.py

--- a/.github/workflows/ai-context-guard.yml
+++ b/.github/workflows/ai-context-guard.yml
@@ -37,8 +37,15 @@ jobs:
             echo "INFO: .ai-context.yml missing (allowed during rollout, but should be added)."
           fi
 
+      # chronik hard-requires .ai-context.yml — the operator-ecosystem role
+      # contract lives here. This intentionally supersedes the generic
+      # "missing allowed during rollout" note in the step above.
+      # pyyaml is installed by "Install validator deps" for this same
+      # interpreter, so check_role.py's `import yaml` resolves.
       - name: Enforce operator-ecosystem role contract
-        run: python scripts/check_role.py
+        run: |
+          test -f .ai-context.yml || { echo "ERROR: .ai-context.yml is required for chronik"; exit 1; }
+          python scripts/check_role.py
 
   templates:
     # Template-Validierung ist NUR für metarepo gedacht.

--- a/.github/workflows/ai-context-guard.yml
+++ b/.github/workflows/ai-context-guard.yml
@@ -37,6 +37,9 @@ jobs:
             echo "INFO: .ai-context.yml missing (allowed during rollout, but should be added)."
           fi
 
+      - name: Enforce operator-ecosystem role contract
+        run: python scripts/check_role.py
+
   templates:
     # Template-Validierung ist NUR für metarepo gedacht.
     # In allen anderen Repos wird dieser Job automatisch übersprungen,

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 PORT := $(if $(CHRONIK_PORT),$(CHRONIK_PORT),8788)
 AUTH_TOKEN := $(if $(CHRONIK_TOKEN),$(CHRONIK_TOKEN))
+# Prefer the project venv (has pyyaml etc.); fall back to system python.
+PYTHON := $(if $(wildcard .venv/bin/python),./.venv/bin/python,python)
 
 .PHONY: dev ingest-test ensure-token validate-local check-role
 
@@ -7,7 +9,7 @@ dev:
 	uvicorn app:app --reload --port $(PORT)
 
 check-role:
-	python scripts/check_role.py
+	$(PYTHON) scripts/check_role.py
 
 validate-local:
 	./scripts/validate-local.sh

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 PORT := $(if $(CHRONIK_PORT),$(CHRONIK_PORT),8788)
 AUTH_TOKEN := $(if $(CHRONIK_TOKEN),$(CHRONIK_TOKEN))
 
-.PHONY: dev ingest-test ensure-token validate-local
+.PHONY: dev ingest-test ensure-token validate-local check-role
 
 dev:
 	uvicorn app:app --reload --port $(PORT)
+
+check-role:
+	python scripts/check_role.py
 
 validate-local:
 	./scripts/validate-local.sh

--- a/scripts/check_role.py
+++ b/scripts/check_role.py
@@ -18,6 +18,7 @@ Usage: ``python scripts/check_role.py [path-to-.ai-context.yml]``
 from __future__ import annotations
 
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 
 import yaml
@@ -41,33 +42,46 @@ def check(path: Path) -> list[str]:
     """Return a list of contract violations (empty means the contract holds)."""
     errors: list[str] = []
     try:
-        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        raw = path.read_text(encoding="utf-8")
     except FileNotFoundError:
         return [f"missing file {path}"]
+    try:
+        data = yaml.safe_load(raw) or {}
     except yaml.YAMLError as exc:
         return [f"invalid YAML in {path}: {exc}"]
 
-    if not isinstance(data, dict):
+    if not isinstance(data, Mapping):
         return [f"{path} does not contain a YAML mapping"]
 
-    def section(name: str) -> dict:
-        value = data.get(name)
-        return value if isinstance(value, dict) else {}
+    # Both sections must be mappings; report explicitly instead of masking
+    # a broken shape as an empty section.
+    project = data.get("project")
+    role_contract = data.get("role_contract")
+    if not isinstance(project, Mapping):
+        errors.append("project must be a YAML mapping")
+        project = {}
+    if not isinstance(role_contract, Mapping):
+        errors.append("role_contract must be a YAML mapping")
+        role_contract = {}
+    sections = {"project": project, "role_contract": role_contract}
 
     for (sec, key), want in EXPECTED_VALUES.items():
-        got = section(sec).get(key)
+        got = sections[sec].get(key)
         if got != want:
             errors.append(f"{sec}.{key} must be {want!r}, got {got!r}")
 
-    limits = section("role_contract").get("limits") or []
-    missing = REQUIRED_LIMITS - set(limits)
-    if missing:
-        errors.append(
-            f"role_contract.limits must include {sorted(REQUIRED_LIMITS)}, "
-            f"missing {sorted(missing)}"
-        )
+    limits = role_contract.get("limits")
+    if not isinstance(limits, list) or not all(isinstance(item, str) for item in limits):
+        errors.append("role_contract.limits must be a list of strings")
+    else:
+        missing = REQUIRED_LIMITS - set(limits)
+        if missing:
+            errors.append(
+                f"role_contract.limits must include {sorted(REQUIRED_LIMITS)}, "
+                f"missing {sorted(missing)}"
+            )
 
-    role = section("project").get("role")
+    role = project.get("role")
     if role in FORBIDDEN_ROLES:
         errors.append(f"stale/forbidden project.role {role!r}")
 

--- a/scripts/check_role.py
+++ b/scripts/check_role.py
@@ -46,9 +46,13 @@ def check(path: Path) -> list[str]:
     except FileNotFoundError:
         return [f"missing file {path}"]
     try:
-        data = yaml.safe_load(raw) or {}
+        data = yaml.safe_load(raw)
     except yaml.YAMLError as exc:
         return [f"invalid YAML in {path}: {exc}"]
+    # Only an empty document normalizes to an empty mapping; falsy scalars
+    # (false, 0, "") must still be reported as "not a mapping".
+    if data is None:
+        data = {}
 
     if not isinstance(data, Mapping):
         return [f"{path} does not contain a YAML mapping"]

--- a/scripts/check_role.py
+++ b/scripts/check_role.py
@@ -1,21 +1,89 @@
 #!/usr/bin/env python3
-from pathlib import Path
+"""Guard: enforce chronik's operator-ecosystem role contract.
+
+Chronik is the append-only event ledger / historical-evidence axis of the
+Heimgewebe operator ecosystem. It records events, it does not own tasks, drive
+workers or make orchestration decisions ("the ledger is not the lever").
+
+The role contract that encodes this lives in ``.ai-context.yml``. This guard
+fails (exit 1) if that contract silently drifts toward orchestration/worker
+authority, so CI and local validation catch the regression instead of humans.
+
+Parses the YAML semantically, so harmless reformatting/whitespace changes do
+not cause false failures — only a weakened contract does.
+
+Usage: ``python scripts/check_role.py [path-to-.ai-context.yml]``
+"""
+
+from __future__ import annotations
+
 import sys
-text = Path('.ai-context.yml').read_text(encoding='utf-8')
-need = [
-    '  role: append_only_event_ledger',
-    'role_contract:',
-    '  name: append_only_event_ledger',
-    '  authority: historical_evidence',
-    '  unavailable_effect: new_event_capture_degrades',
-    '    - no_worker_control',
-    '    - no_orchestration_decisions',
-]
-for item in need:
-    if item not in text:
-        print(f'role-contract: missing {item!r}', file=sys.stderr)
-        raise SystemExit(1)
-if '  role: central_event_store' in text:
-    print('role-contract: stale central_event_store role', file=sys.stderr)
-    raise SystemExit(1)
-print('role-contract: OK chronik')
+from pathlib import Path
+
+import yaml
+
+# (section, key) -> exact value the contract must keep.
+EXPECTED_VALUES: dict[tuple[str, str], str] = {
+    ("project", "role"): "append_only_event_ledger",
+    ("role_contract", "name"): "append_only_event_ledger",
+    ("role_contract", "authority"): "historical_evidence",
+    ("role_contract", "unavailable_effect"): "new_event_capture_degrades",
+}
+
+# Limits that must stay declared: chronik never controls workers or orchestrates.
+REQUIRED_LIMITS = {"no_worker_control", "no_orchestration_decisions"}
+
+# Roles that would misframe chronik as an active/central authority.
+FORBIDDEN_ROLES = {"central_event_store"}
+
+
+def check(path: Path) -> list[str]:
+    """Return a list of contract violations (empty means the contract holds)."""
+    errors: list[str] = []
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except FileNotFoundError:
+        return [f"missing file {path}"]
+    except yaml.YAMLError as exc:
+        return [f"invalid YAML in {path}: {exc}"]
+
+    if not isinstance(data, dict):
+        return [f"{path} does not contain a YAML mapping"]
+
+    def section(name: str) -> dict:
+        value = data.get(name)
+        return value if isinstance(value, dict) else {}
+
+    for (sec, key), want in EXPECTED_VALUES.items():
+        got = section(sec).get(key)
+        if got != want:
+            errors.append(f"{sec}.{key} must be {want!r}, got {got!r}")
+
+    limits = section("role_contract").get("limits") or []
+    missing = REQUIRED_LIMITS - set(limits)
+    if missing:
+        errors.append(
+            f"role_contract.limits must include {sorted(REQUIRED_LIMITS)}, "
+            f"missing {sorted(missing)}"
+        )
+
+    role = section("project").get("role")
+    if role in FORBIDDEN_ROLES:
+        errors.append(f"stale/forbidden project.role {role!r}")
+
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    path = Path(argv[1]) if len(argv) > 1 else Path(".ai-context.yml")
+    errors = check(path)
+    if errors:
+        for err in errors:
+            print(f"role-contract: {err}", file=sys.stderr)
+        return 1
+    print("role-contract: OK chronik")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/validate-local.sh
+++ b/scripts/validate-local.sh
@@ -15,6 +15,10 @@ trap cleanup EXIT
 export CHRONIK_TOKEN="${CHRONIK_TOKEN:-dev}"
 export CHRONIK_DATA_DIR="$TMP_DATA_DIR"
 
+# Operator-ecosystem role contract must not drift (append-only ledger, no
+# worker control / orchestration authority).
+./.venv/bin/python scripts/check_role.py
+
 ./.venv/bin/python -m pytest -q
 
 ./.venv/bin/python - <<'PY'

--- a/tests/test_role_contract.py
+++ b/tests/test_role_contract.py
@@ -20,8 +20,8 @@ CONTEXT_PATH = ROOT / ".ai-context.yml"
 
 def _load_guard():
     spec = importlib.util.spec_from_file_location("check_role", GUARD_PATH)
-    module = importlib.util.module_from_spec(spec)
     assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
@@ -71,3 +71,40 @@ def test_reformatting_does_not_break_guard(tmp_path):
     target = tmp_path / ".ai-context.yml"
     target.write_text(yaml.safe_dump(data, default_flow_style=False, indent=4), encoding="utf-8")
     assert guard.check(target) == []
+
+
+def test_invalid_yaml_is_reported(tmp_path):
+    target = tmp_path / ".ai-context.yml"
+    target.write_text("project: [", encoding="utf-8")
+    errors = guard.check(target)
+    assert any("invalid YAML" in e for e in errors)
+
+
+def test_limits_must_be_list_of_strings(tmp_path):
+    data = yaml.safe_load(CONTEXT_PATH.read_text(encoding="utf-8"))
+    data["role_contract"]["limits"] = "no_worker_control"  # string, not a list
+    target = tmp_path / ".ai-context.yml"
+    target.write_text(yaml.safe_dump(data), encoding="utf-8")
+    errors = guard.check(target)
+    assert any("limits must be a list of strings" in e for e in errors)
+
+
+def test_non_mapping_section_is_reported(tmp_path):
+    data = yaml.safe_load(CONTEXT_PATH.read_text(encoding="utf-8"))
+    data["role_contract"] = ["not", "a", "mapping"]
+    target = tmp_path / ".ai-context.yml"
+    target.write_text(yaml.safe_dump(data), encoding="utf-8")
+    errors = guard.check(target)
+    assert any("role_contract must be a YAML mapping" in e for e in errors)
+
+
+def test_main_returns_zero_on_real_context():
+    assert guard.main(["check_role.py", str(CONTEXT_PATH)]) == 0
+
+
+def test_main_returns_nonzero_on_weakened_contract(tmp_path):
+    data = yaml.safe_load(CONTEXT_PATH.read_text(encoding="utf-8"))
+    data["role_contract"]["authority"] = "orchestration_control"
+    target = tmp_path / ".ai-context.yml"
+    target.write_text(yaml.safe_dump(data), encoding="utf-8")
+    assert guard.main(["check_role.py", str(target)]) == 1

--- a/tests/test_role_contract.py
+++ b/tests/test_role_contract.py
@@ -1,0 +1,73 @@
+"""Guard tests: the operator-ecosystem role contract must not silently drift.
+
+Chronik is the append-only event ledger. ``scripts/check_role.py`` enforces
+that ``.ai-context.yml`` keeps that role (no worker control / orchestration
+authority). These tests ensure the guard passes on the real file and actually
+catches a weakened contract.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+GUARD_PATH = ROOT / "scripts" / "check_role.py"
+CONTEXT_PATH = ROOT / ".ai-context.yml"
+
+
+def _load_guard():
+    spec = importlib.util.spec_from_file_location("check_role", GUARD_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load_guard()
+
+
+def test_real_context_passes():
+    assert guard.check(CONTEXT_PATH) == []
+
+
+def test_missing_file_is_reported(tmp_path):
+    errors = guard.check(tmp_path / "nope.yml")
+    assert errors and "missing file" in errors[0]
+
+
+def test_weakened_authority_is_detected(tmp_path):
+    data = yaml.safe_load(CONTEXT_PATH.read_text(encoding="utf-8"))
+    data["role_contract"]["authority"] = "orchestration_control"
+    target = tmp_path / ".ai-context.yml"
+    target.write_text(yaml.safe_dump(data), encoding="utf-8")
+    errors = guard.check(target)
+    assert any("role_contract.authority" in e for e in errors)
+
+
+def test_dropped_limit_is_detected(tmp_path):
+    data = yaml.safe_load(CONTEXT_PATH.read_text(encoding="utf-8"))
+    data["role_contract"]["limits"] = ["no_worker_control"]  # drop orchestration limit
+    target = tmp_path / ".ai-context.yml"
+    target.write_text(yaml.safe_dump(data), encoding="utf-8")
+    errors = guard.check(target)
+    assert any("no_orchestration_decisions" in e for e in errors)
+
+
+def test_stale_central_store_role_is_detected(tmp_path):
+    data = yaml.safe_load(CONTEXT_PATH.read_text(encoding="utf-8"))
+    data["project"]["role"] = "central_event_store"
+    target = tmp_path / ".ai-context.yml"
+    target.write_text(yaml.safe_dump(data), encoding="utf-8")
+    errors = guard.check(target)
+    assert any("central_event_store" in e for e in errors)
+
+
+def test_reformatting_does_not_break_guard(tmp_path):
+    # Semantic (YAML) check must tolerate harmless reformatting/whitespace.
+    data = yaml.safe_load(CONTEXT_PATH.read_text(encoding="utf-8"))
+    target = tmp_path / ".ai-context.yml"
+    target.write_text(yaml.safe_dump(data, default_flow_style=False, indent=4), encoding="utf-8")
+    assert guard.check(target) == []

--- a/tests/test_role_contract.py
+++ b/tests/test_role_contract.py
@@ -89,6 +89,13 @@ def test_limits_must_be_list_of_strings(tmp_path):
     assert any("limits must be a list of strings" in e for e in errors)
 
 
+def test_falsy_scalar_yaml_is_reported_as_non_mapping(tmp_path):
+    target = tmp_path / ".ai-context.yml"
+    target.write_text("false\n", encoding="utf-8")
+    errors = guard.check(target)
+    assert any("does not contain a YAML mapping" in e for e in errors)
+
+
 def test_non_mapping_section_is_reported(tmp_path):
     data = yaml.safe_load(CONTEXT_PATH.read_text(encoding="utf-8"))
     data["role_contract"] = ["not", "a", "mapping"]


### PR DESCRIPTION
## Befund

Die Operator-Ökosystem-Rolle von Chronik ist in `.ai-context.yml` verankert (append-only Ledger, `no_worker_control`, `no_orchestration_decisions`, „the ledger is not the lever"). Der zugehörige Guard `scripts/check_role.py` — hinzugefügt in `c566af3 docs: add guard` — wurde jedoch **nirgends ausgeführt**: kein CI-Workflow, kein Makefile-Target, kein `validate-local`. Der Rollen-Contract konnte damit still zu Orchestrator-/Worker-Autorität driften, ohne dass CI rot wird. Diese Änderung schließt die Enforcement-Lücke.

## Geänderte Dateien

- `scripts/check_role.py` — von brüchigem String-Matching auf **semantische YAML-Prüfung** umgestellt (tolerant gegenüber Reformatting, klare Fehlermeldungen, testbare `check()`-Funktion). Erzwingt Rolle, Authority, `unavailable_effect`, die beiden `limits` und lehnt die veraltete `central_event_store`-Rolle ab.
- `.github/workflows/ai-context-guard.yml` — neuer Step „Enforce operator-ecosystem role contract" (läuft bei jedem Push/PR).
- `scripts/validate-local.sh` — Guard läuft vor pytest im lokalen Gate.
- `Makefile` — neues `make check-role`.
- `tests/test_role_contract.py` — 6 Tests (grün auf echter Datei + Drift-Erkennung: geschwächte Authority, gedroppte Limits, veraltete Rolle, fehlende Datei, Reformatting-Toleranz).

## Testbelege

- `234 passed` (Projekt-`.venv`)
- `./scripts/validate-local.sh` end-to-end grün, Guard läuft darin mit
- Drift-Negativtest: manipuliertes `.ai-context.yml` → `exit=1` mit präziser Meldung

## Hinweis

Reine **Enforcement-/Test-Änderung** — kein Laufzeitverhalten des HTTP-Dienstes (`app.py`, Endpunkte, Storage) verändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)