### PR TITLE
feat: define runtime lens evidence bridge

### DIFF
--- a/docs/chronik/runtime-lens-evidence-bridge-v1.md
+++ b/docs/chronik/runtime-lens-evidence-bridge-v1.md
@@ -37,10 +37,11 @@ kind           = runtime.lens.observation
 domain         = runtime.lens
 ```
 
-The payload has five authority-bearing sections:
+The event has a Chronik-compatible `source` provenance object plus five authority-bearing sections:
 
 | Section | Role | Boundary |
 |---|---|---|
+| `source` | producer repository, component and run identity | transport provenance only |
 | `code_evidence` | RepoBrief snapshot identity and citations | code evidence only |
 | `runtime_evidence` | observed runtime source, timestamp and provenance | runtime observation only |
 | `drift` | relation between code identity and runtime identity | observation, not verdict |
@@ -59,7 +60,7 @@ Allowed runtime evidence sources are deliberately coarse:
 - `manual_observation`
 - `grabowski_receipt`
 
-Every runtime evidence item must have:
+The top-level `source.repo`, `source.component` and `event_id` fields deliberately satisfy Chronik strict provenance enforcement. Every runtime evidence item must have:
 
 - `observed_at` as UTC timestamp;
 - `authority_label` as `observed_runtime`, `declared_runtime`, or `inferred_runtime`;

--- a/docs/chronik/runtime-lens-evidence-bridge-v1.md
+++ b/docs/chronik/runtime-lens-evidence-bridge-v1.md
@@ -1,0 +1,142 @@
+# Runtime-Lens Evidence Bridge v1
+
+Status: accepted
+Bureau task: `RPU-V1-T017`
+Schema: [`runtime-lens-observation-v1.schema.json`](runtime-lens-observation-v1.schema.json)
+Domain: `runtime.lens`
+
+## Dialectic
+
+**Thesis:** Agents need one small bridge between RepoBrief code citations and runtime observations. Otherwise every drift claim gets reconstructed ad hoc from logs, screenshots, service status, and snapshot metadata.
+
+**Antithesis:** If the bridge is too strong, RepoBrief quietly becomes runtime authority and Chronik becomes an operations lever. That would collapse separate evidence layers into a false verdict path.
+
+**Synthesis:** Chronik may store a bounded `runtime.lens.observation` event. The event links code evidence to runtime evidence, labels both authority sources, and records drift only as an observation. It must not restart services, deploy, read secrets, mutate Git, approve changes, or claim correctness.
+
+## Purpose
+
+The bridge answers one narrow question:
+
+> What code snapshot was cited, what runtime observation was seen, and what drift relationship was observed between them?
+
+It does not answer:
+
+- whether the code is correct;
+- whether the runtime is healthy enough for production;
+- whether tests are sufficient;
+- whether a pull request is merge-ready;
+- whether a deployment is safe.
+
+## Event shape
+
+A valid bridge event uses:
+
+```text
+schema_version = runtime-lens-observation.v1
+kind           = runtime.lens.observation
+domain         = runtime.lens
+```
+
+The payload has five authority-bearing sections:
+
+| Section | Role | Boundary |
+|---|---|---|
+| `code_evidence` | RepoBrief snapshot identity and citations | code evidence only |
+| `runtime_evidence` | observed runtime source, timestamp and provenance | runtime observation only |
+| `drift` | relation between code identity and runtime identity | observation, not verdict |
+| `authority` | fixed labels for code/runtime/verdict authority | verdict authority is `none` |
+| `boundary` | forbidden actions for RepoBrief and Chronik | prevents authority smuggling |
+
+## Runtime evidence sources
+
+Allowed runtime evidence sources are deliberately coarse:
+
+- `service_status`
+- `service_log_excerpt`
+- `deployment_identity`
+- `health_endpoint`
+- `metrics_snapshot`
+- `manual_observation`
+- `grabowski_receipt`
+
+Every runtime evidence item must have:
+
+- `observed_at` as UTC timestamp;
+- `authority_label` as `observed_runtime`, `declared_runtime`, or `inferred_runtime`;
+- at least one provenance anchor: `artifact_sha256`, `command_sha256`, `receipt_sha256`, or `uri`;
+- a bounded summary.
+
+## Drift semantics
+
+`drift.status` is intentionally not a pass/fail field.
+
+| Value | Meaning |
+|---|---|
+| `aligned_observed` | code and runtime identity appeared aligned in the cited observation |
+| `drift_observed` | a mismatch was observed |
+| `unknown` | evidence was present but insufficient |
+| `not_checked` | the event records inputs but no drift check |
+
+`drift.basis` names the observed relation, such as `commit_identity_match`, `commit_identity_mismatch`, `runtime_newer_than_snapshot`, `snapshot_newer_than_runtime`, or `inconclusive`.
+
+## Authority rules
+
+### RepoBrief may provide
+
+- snapshot stem;
+- repository identity;
+- commit identity;
+- manifest hash;
+- cited file ranges;
+- source content hashes.
+
+### RepoBrief must not provide
+
+- service restart;
+- deploy;
+- systemd mutation;
+- secret read;
+- runtime write;
+- Git mutation;
+- PR merge.
+
+### Chronik may provide
+
+- append-only event storage;
+- queryable event history;
+- bounded historical views.
+
+### Chronik must not provide
+
+- task dispatch;
+- approval decision;
+- service restart;
+- deploy;
+- correctness verdict.
+
+## Non-claims
+
+A valid `runtime.lens.observation` event does not establish:
+
+- `runtime_correctness`
+- `code_correctness`
+- `test_sufficiency`
+- `review_completeness`
+- `merge_readiness`
+- `security_correctness`
+- `regression_absence`
+- `deployment_safety`
+
+## Example
+
+See [`tests/fixtures/runtime-lens/runtime-lens-observation.v1.json`](../../tests/fixtures/runtime-lens/runtime-lens-observation.v1.json).
+
+## Consequence
+
+The bridge is useful when agents need to say, with bounded evidence:
+
+> This RepoBrief snapshot says X at commit C; this runtime observation says service S ran identity R at time T; the identity relation was observed as D.
+
+The bridge is unsafe if used to say:
+
+> Therefore the runtime is correct, the deployment is good, or the PR may be merged.

--- a/docs/chronik/runtime-lens-observation-v1.schema.json
+++ b/docs/chronik/runtime-lens-observation-v1.schema.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/chronik/runtime-lens-observation-v1.schema.json",
+  "title": "Chronik Runtime-Lens Observation v1",
+  "description": "A bounded Chronik observation that links RepoBrief code evidence to runtime evidence without turning either side into a correctness verdict.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_id",
+    "kind",
+    "ts",
+    "producer",
+    "subject",
+    "code_evidence",
+    "runtime_evidence",
+    "drift",
+    "authority",
+    "boundary",
+    "non_claims"
+  ],
+  "properties": {
+    "schema_version": {"const": "runtime-lens-observation.v1"},
+    "event_id": {"$ref": "#/definitions/event_id"},
+    "kind": {"const": "runtime.lens.observation"},
+    "ts": {"$ref": "#/definitions/utc_second"},
+    "producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "component", "run_id"],
+      "properties": {
+        "repo": {"type": "string", "minLength": 1, "maxLength": 200},
+        "component": {"type": "string", "minLength": 1, "maxLength": 120},
+        "run_id": {"type": "string", "minLength": 1, "maxLength": 160},
+        "version": {"type": "string", "minLength": 1, "maxLength": 80}
+      }
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["system", "repo"],
+      "properties": {
+        "system": {"type": "string", "minLength": 1, "maxLength": 120},
+        "repo": {"type": "string", "minLength": 1, "maxLength": 200},
+        "service": {"type": "string", "minLength": 1, "maxLength": 160},
+        "environment": {"type": "string", "minLength": 1, "maxLength": 120},
+        "runtime_id": {"type": "string", "minLength": 1, "maxLength": 200}
+      }
+    },
+    "code_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["authority_label", "snapshot", "citations"],
+      "properties": {
+        "authority_label": {"const": "repobrief_snapshot"},
+        "snapshot": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["stem", "repo", "commit", "manifest_sha256"],
+          "properties": {
+            "stem": {"type": "string", "minLength": 1, "maxLength": 180},
+            "repo": {"type": "string", "minLength": 1, "maxLength": 200},
+            "commit": {"type": "string", "pattern": "^[0-9a-f]{7,40}$"},
+            "manifest_sha256": {"$ref": "#/definitions/sha256_hex"},
+            "generated_at": {"$ref": "#/definitions/utc_second"}
+          }
+        },
+        "citations": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 8,
+          "items": {"$ref": "#/definitions/code_citation"}
+        }
+      }
+    },
+    "runtime_evidence": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "items": {"$ref": "#/definitions/runtime_observation"}
+    },
+    "drift": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "basis", "summary"],
+      "properties": {
+        "status": {
+          "enum": ["aligned_observed", "drift_observed", "unknown", "not_checked"]
+        },
+        "basis": {
+          "enum": [
+            "commit_identity_match",
+            "commit_identity_mismatch",
+            "runtime_newer_than_snapshot",
+            "snapshot_newer_than_runtime",
+            "missing_runtime_evidence",
+            "missing_code_evidence",
+            "inconclusive",
+            "none"
+          ]
+        },
+        "summary": {"type": "string", "minLength": 1, "maxLength": 500}
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code_authority", "runtime_authority", "verdict_authority"],
+      "properties": {
+        "code_authority": {"const": "RepoBrief snapshot is code-evidence authority only"},
+        "runtime_authority": {"const": "Runtime source is observation authority only"},
+        "verdict_authority": {"const": "none"}
+      }
+    },
+    "boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo_brief_forbidden_actions", "chronik_forbidden_actions"],
+      "properties": {
+        "repo_brief_forbidden_actions": {
+          "type": "array",
+          "minItems": 5,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "service_restart",
+              "deploy",
+              "systemd_mutation",
+              "secret_read",
+              "runtime_write",
+              "git_mutation",
+              "pr_merge"
+            ]
+          }
+        },
+        "chronik_forbidden_actions": {
+          "type": "array",
+          "minItems": 3,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "task_dispatch",
+              "approval_decision",
+              "service_restart",
+              "deploy",
+              "correctness_verdict"
+            ]
+          }
+        }
+      }
+    },
+    "non_claims": {
+      "type": "array",
+      "minItems": 6,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "runtime_correctness",
+          "code_correctness",
+          "test_sufficiency",
+          "review_completeness",
+          "merge_readiness",
+          "security_correctness",
+          "regression_absence",
+          "deployment_safety"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "event_id": {
+      "type": "string",
+      "pattern": "^([0-9A-HJKMNP-TV-Z]{26}|sha256:[0-9a-f]{64})$"
+    },
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "utc_second": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+    },
+    "code_citation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ref", "source_file", "line_start", "line_end", "content_sha256"],
+      "properties": {
+        "ref": {"type": "string", "minLength": 1, "maxLength": 240},
+        "source_file": {"type": "string", "minLength": 1, "maxLength": 260},
+        "line_start": {"type": "integer", "minimum": 1},
+        "line_end": {"type": "integer", "minimum": 1},
+        "content_sha256": {"$ref": "#/definitions/sha256_hex"}
+      }
+    },
+    "runtime_observation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_type", "observed_at", "authority_label", "provenance", "summary"],
+      "properties": {
+        "source_type": {
+          "enum": [
+            "service_status",
+            "service_log_excerpt",
+            "deployment_identity",
+            "health_endpoint",
+            "metrics_snapshot",
+            "manual_observation",
+            "grabowski_receipt"
+          ]
+        },
+        "observed_at": {"$ref": "#/definitions/utc_second"},
+        "authority_label": {
+          "enum": ["observed_runtime", "declared_runtime", "inferred_runtime"]
+        },
+        "provenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "properties": {
+            "artifact_sha256": {"$ref": "#/definitions/sha256_hex"},
+            "command_sha256": {"$ref": "#/definitions/sha256_hex"},
+            "receipt_sha256": {"$ref": "#/definitions/sha256_hex"},
+            "uri": {"type": "string", "minLength": 1, "maxLength": 260}
+          }
+        },
+        "summary": {"type": "string", "minLength": 1, "maxLength": 500}
+      }
+    }
+  }
+}

--- a/docs/chronik/runtime-lens-observation-v1.schema.json
+++ b/docs/chronik/runtime-lens-observation-v1.schema.json
@@ -10,7 +10,7 @@
     "event_id",
     "kind",
     "ts",
-    "producer",
+    "source",
     "subject",
     "code_evidence",
     "runtime_evidence",
@@ -24,7 +24,7 @@
     "event_id": {"$ref": "#/definitions/event_id"},
     "kind": {"const": "runtime.lens.observation"},
     "ts": {"$ref": "#/definitions/utc_second"},
-    "producer": {
+    "source": {
       "type": "object",
       "additionalProperties": false,
       "required": ["repo", "component", "run_id"],
@@ -119,7 +119,8 @@
       "properties": {
         "repo_brief_forbidden_actions": {
           "type": "array",
-          "minItems": 5,
+          "minItems": 7,
+          "maxItems": 7,
           "uniqueItems": true,
           "items": {
             "enum": [
@@ -135,7 +136,8 @@
         },
         "chronik_forbidden_actions": {
           "type": "array",
-          "minItems": 3,
+          "minItems": 5,
+          "maxItems": 5,
           "uniqueItems": true,
           "items": {
             "enum": [
@@ -151,7 +153,8 @@
     },
     "non_claims": {
       "type": "array",
-      "minItems": 6,
+      "minItems": 8,
+      "maxItems": 8,
       "uniqueItems": true,
       "items": {
         "enum": [

--- a/docs/event-contracts.md
+++ b/docs/event-contracts.md
@@ -81,6 +81,21 @@ Nach der Verarbeitung durch den Dienst wird die Zeile in `aussen.jsonl` so ausse
 {"event": "deploy", "status": "success", "domain": "aussen"}
 ```
 
+## Schema: `runtime-lens-observation.v1` (Chronik-local contract)
+
+Chronik defines a bounded Runtime-Lens observation contract under
+`docs/chronik/runtime-lens-observation-v1.schema.json`. It links RepoBrief
+snapshot citations to runtime observations without granting verdict authority to
+either side. See `docs/chronik/runtime-lens-evidence-bridge-v1.md`.
+
+Key boundaries:
+
+- RepoBrief is code-evidence authority only.
+- Runtime sources are observation authority only.
+- `authority.verdict_authority` is always `none`.
+- The event does not permit service restart, deploy, systemd mutation, secret
+  read, runtime write, task dispatch, approval decision or correctness verdict.
+
 ## Schema: `heimgeist.self_state.snapshot` (Mirror)
 
 Chronik spiegelt das kanonische Schema aus dem Metarepo:

--- a/docs/reports/rpu-v1-t017-runtime-lens-bridge-self-review.md
+++ b/docs/reports/rpu-v1-t017-runtime-lens-bridge-self-review.md
@@ -19,6 +19,12 @@ Changed surfaces:
 
 ## Review findings
 
+### Material findings fixed
+
+- The draft used `producer`, but Chronik strict provenance validates `source.repo` and `source.component`; the event now uses the live-compatible `source` object.
+- Boundary arrays previously allowed omission of named forbidden actions; exact full-set cardinalities are now required.
+- `non_claims` previously allowed omission of two declared safeguards; all eight are now required.
+
 ### Accepted
 
 - The schema requires explicit runtime evidence source, timestamp and provenance anchor.
@@ -49,10 +55,9 @@ This change does not add:
 
 ## Validation
 
-- `python3 -m pytest -q tests/test_runtime_lens_observation_contract.py`: 6 passed.
-- `python3 -m pytest -q`: failed with system Python before collection because project dependencies such as `filelock` and `limits` were missing.
-- `.venv/bin/python -m pytest -q`: 251 passed, 1 warning.
-- `make validate-local`: passed; includes `251 passed, 1 warning` and local validation smoke.
+- `/home/alex/repos/chronik/.venv/bin/python -m pytest -q`: 253 passed, 1 warning.
+- `/home/alex/repos/chronik/.venv/bin/python scripts/check_role.py`: role-contract OK.
+- The fixture passes `validate_provenance(..., strict=True)`.
 - `git diff --check`: passed.
 
 ## Does not establish

--- a/docs/reports/rpu-v1-t017-runtime-lens-bridge-self-review.md
+++ b/docs/reports/rpu-v1-t017-runtime-lens-bridge-self-review.md
@@ -1,0 +1,67 @@
+# RPU-V1-T017 Runtime-Lens Bridge Self-Review
+
+Status: review-ready
+Task: `RPU-V1-T017`
+Repo: `heimgewebe/chronik`
+Branch: `feat/runtime-lens-evidence-bridge-v1`
+
+## Scope checked
+
+This change defines a Chronik-local Runtime-Lens observation bridge between RepoBrief code evidence and runtime observations.
+
+Changed surfaces:
+
+- `docs/chronik/runtime-lens-evidence-bridge-v1.md`
+- `docs/chronik/runtime-lens-observation-v1.schema.json`
+- `tests/fixtures/runtime-lens/runtime-lens-observation.v1.json`
+- `tests/test_runtime_lens_observation_contract.py`
+- `docs/event-contracts.md`
+
+## Review findings
+
+### Accepted
+
+- The schema requires explicit runtime evidence source, timestamp and provenance anchor.
+- RepoBrief authority is constrained to snapshot/code evidence.
+- Runtime evidence authority is constrained to observation only.
+- `authority.verdict_authority` is fixed to `none`.
+- The schema rejects extra fields and action-smuggling values.
+- Drift may be reported as `drift_observed`, but the event still cannot become a correctness verdict.
+
+### Risks
+
+- This is a contract/documentation slice, not an ingest endpoint specialization. Chronik still accepts generic payloads at the storage layer.
+- The schema is Chronik-local for now. It is not yet promoted to a metarepo canonical contract.
+- A future producer must be tested separately against the same schema before writing real events.
+
+### Boundary check
+
+This change does not add:
+
+- service restart;
+- deploy;
+- systemd mutation;
+- secret read;
+- runtime write;
+- Git mutation beyond this repository change;
+- PR merge authority;
+- correctness verdict authority.
+
+## Validation
+
+- `python3 -m pytest -q tests/test_runtime_lens_observation_contract.py`: 6 passed.
+- `python3 -m pytest -q`: failed with system Python before collection because project dependencies such as `filelock` and `limits` were missing.
+- `.venv/bin/python -m pytest -q`: 251 passed, 1 warning.
+- `make validate-local`: passed; includes `251 passed, 1 warning` and local validation smoke.
+- `git diff --check`: passed.
+
+## Does not establish
+
+- runtime correctness;
+- code correctness;
+- test sufficiency;
+- review completeness;
+- merge readiness;
+- security correctness;
+- deployment safety;
+- metarepo contract promotion.

--- a/tests/fixtures/runtime-lens/runtime-lens-observation.v1.json
+++ b/tests/fixtures/runtime-lens/runtime-lens-observation.v1.json
@@ -3,7 +3,7 @@
   "event_id": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "kind": "runtime.lens.observation",
   "ts": "2026-07-09T16:00:00Z",
-  "producer": {
+  "source": {
     "repo": "heimgewebe/chronik",
     "component": "runtime-lens-bridge-doc",
     "run_id": "RPU-V1-T017"
@@ -61,13 +61,16 @@
       "deploy",
       "systemd_mutation",
       "secret_read",
-      "runtime_write"
+      "runtime_write",
+      "git_mutation",
+      "pr_merge"
     ],
     "chronik_forbidden_actions": [
       "task_dispatch",
       "approval_decision",
       "service_restart",
-      "correctness_verdict"
+      "correctness_verdict",
+      "deploy"
     ]
   },
   "non_claims": [
@@ -76,6 +79,8 @@
     "test_sufficiency",
     "review_completeness",
     "merge_readiness",
-    "security_correctness"
+    "security_correctness",
+    "regression_absence",
+    "deployment_safety"
   ]
 }

--- a/tests/fixtures/runtime-lens/runtime-lens-observation.v1.json
+++ b/tests/fixtures/runtime-lens/runtime-lens-observation.v1.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "runtime-lens-observation.v1",
+  "event_id": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "kind": "runtime.lens.observation",
+  "ts": "2026-07-09T16:00:00Z",
+  "producer": {
+    "repo": "heimgewebe/chronik",
+    "component": "runtime-lens-bridge-doc",
+    "run_id": "RPU-V1-T017"
+  },
+  "subject": {
+    "system": "grabowski",
+    "repo": "heimgewebe/grabowski",
+    "service": "grabowski-mcp",
+    "environment": "heim-pc",
+    "runtime_id": "2761100fb1df-srcset2d962b393f71-locke6664d600b6c-contracta3fdd357e5a7"
+  },
+  "code_evidence": {
+    "authority_label": "repobrief_snapshot",
+    "snapshot": {
+      "stem": "grabowski-main-20260709-000000",
+      "repo": "heimgewebe/grabowski",
+      "commit": "2761100fb1df8eee6779e19d3a0b692092e491ac",
+      "manifest_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "generated_at": "2026-07-09T15:50:00Z"
+    },
+    "citations": [
+      {
+        "ref": "repobrief://snapshot/grabowski-main-20260709-000000/range/src/grabowski_mcp.py:L10-L30",
+        "source_file": "src/grabowski_mcp.py",
+        "line_start": 10,
+        "line_end": 30,
+        "content_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      }
+    ]
+  },
+  "runtime_evidence": [
+    {
+      "source_type": "deployment_identity",
+      "observed_at": "2026-07-09T15:59:00Z",
+      "authority_label": "observed_runtime",
+      "provenance": {
+        "receipt_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      },
+      "summary": "Observed runtime release id and source identity match the cited RepoBrief commit."
+    }
+  ],
+  "drift": {
+    "status": "aligned_observed",
+    "basis": "commit_identity_match",
+    "summary": "Code snapshot and runtime identity align for this observation; no correctness verdict is implied."
+  },
+  "authority": {
+    "code_authority": "RepoBrief snapshot is code-evidence authority only",
+    "runtime_authority": "Runtime source is observation authority only",
+    "verdict_authority": "none"
+  },
+  "boundary": {
+    "repo_brief_forbidden_actions": [
+      "service_restart",
+      "deploy",
+      "systemd_mutation",
+      "secret_read",
+      "runtime_write"
+    ],
+    "chronik_forbidden_actions": [
+      "task_dispatch",
+      "approval_decision",
+      "service_restart",
+      "correctness_verdict"
+    ]
+  },
+  "non_claims": [
+    "runtime_correctness",
+    "code_correctness",
+    "test_sufficiency",
+    "review_completeness",
+    "merge_readiness",
+    "security_correctness"
+  ]
+}

--- a/tests/test_runtime_lens_observation_contract.py
+++ b/tests/test_runtime_lens_observation_contract.py
@@ -1,0 +1,81 @@
+import copy
+import json
+from pathlib import Path
+
+import jsonschema
+from jsonschema import Draft7Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "docs" / "chronik" / "runtime-lens-observation-v1.schema.json"
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "runtime-lens" / "runtime-lens-observation.v1.json"
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def schema():
+    loaded = load_json(SCHEMA_PATH)
+    Draft7Validator.check_schema(loaded)
+    return loaded
+
+
+def assert_invalid(instance, loaded_schema):
+    try:
+        jsonschema.validate(instance, loaded_schema)
+    except jsonschema.exceptions.ValidationError:
+        return
+    raise AssertionError("instance unexpectedly validated")
+
+
+def test_runtime_lens_observation_schema_is_strict_and_bounded():
+    loaded_schema = schema()
+    assert loaded_schema["additionalProperties"] is False
+    assert loaded_schema["properties"]["producer"]["additionalProperties"] is False
+    assert loaded_schema["properties"]["subject"]["additionalProperties"] is False
+    assert loaded_schema["properties"]["code_evidence"]["additionalProperties"] is False
+    assert loaded_schema["properties"]["runtime_evidence"]["maxItems"] == 8
+    assert loaded_schema["properties"]["code_evidence"]["properties"]["citations"]["maxItems"] == 8
+    assert loaded_schema["properties"]["authority"]["properties"]["verdict_authority"]["const"] == "none"
+
+
+def test_runtime_lens_fixture_validates():
+    jsonschema.validate(load_json(FIXTURE_PATH), schema())
+
+
+def test_runtime_lens_rejects_correctness_verdict_authority():
+    loaded_schema = schema()
+    event = load_json(FIXTURE_PATH)
+    event["authority"]["verdict_authority"] = "runtime"
+    assert_invalid(event, loaded_schema)
+
+
+def test_runtime_lens_rejects_unprovenanced_runtime_evidence():
+    loaded_schema = schema()
+    event = load_json(FIXTURE_PATH)
+    event["runtime_evidence"][0]["provenance"] = {}
+    assert_invalid(event, loaded_schema)
+
+
+def test_runtime_lens_rejects_action_smuggling_and_extra_fields():
+    loaded_schema = schema()
+    event = load_json(FIXTURE_PATH)
+    event["boundary"]["repo_brief_forbidden_actions"].append("auto_fix")
+    assert_invalid(event, loaded_schema)
+
+    event = load_json(FIXTURE_PATH)
+    event["runtime_evidence"][0]["raw_log"] = "not allowed"
+    assert_invalid(event, loaded_schema)
+
+
+def test_runtime_lens_observation_allows_drift_without_verdict():
+    loaded_schema = schema()
+    event = copy.deepcopy(load_json(FIXTURE_PATH))
+    event["drift"] = {
+        "status": "drift_observed",
+        "basis": "commit_identity_mismatch",
+        "summary": "Runtime identity differed from the cited snapshot; this is an observation only."
+    }
+    jsonschema.validate(event, loaded_schema)
+    assert event["authority"]["verdict_authority"] == "none"

--- a/tests/test_runtime_lens_observation_contract.py
+++ b/tests/test_runtime_lens_observation_contract.py
@@ -32,7 +32,7 @@ def assert_invalid(instance, loaded_schema):
 def test_runtime_lens_observation_schema_is_strict_and_bounded():
     loaded_schema = schema()
     assert loaded_schema["additionalProperties"] is False
-    assert loaded_schema["properties"]["producer"]["additionalProperties"] is False
+    assert loaded_schema["properties"]["source"]["additionalProperties"] is False
     assert loaded_schema["properties"]["subject"]["additionalProperties"] is False
     assert loaded_schema["properties"]["code_evidence"]["additionalProperties"] is False
     assert loaded_schema["properties"]["runtime_evidence"]["maxItems"] == 8
@@ -79,3 +79,25 @@ def test_runtime_lens_observation_allows_drift_without_verdict():
     }
     jsonschema.validate(event, loaded_schema)
     assert event["authority"]["verdict_authority"] == "none"
+
+
+def test_runtime_lens_fixture_satisfies_chronik_strict_provenance():
+    from provenance import validate_provenance
+
+    event = load_json(FIXTURE_PATH)
+    validate_provenance(event, strict=True)
+
+
+def test_runtime_lens_requires_complete_boundaries_and_non_claims():
+    loaded_schema = schema()
+    for section, key in (
+        ("boundary", "repo_brief_forbidden_actions"),
+        ("boundary", "chronik_forbidden_actions"),
+    ):
+        event = load_json(FIXTURE_PATH)
+        event[section][key].pop()
+        assert_invalid(event, loaded_schema)
+
+    event = load_json(FIXTURE_PATH)
+    event["non_claims"].pop()
+    assert_invalid(event, loaded_schema)


### PR DESCRIPTION
## Summary

Implements Bureau task `RPU-V1-T017` by defining a bounded Runtime-Lens evidence bridge in Chronik.

Adds:

- accepted Runtime-Lens bridge document
- strict `runtime-lens-observation.v1` JSON Schema
- validating fixture
- regression tests for strictness, provenance, verdict boundary and action-smuggling rejection
- self-review report
- event-contracts index entry

## Boundary

This is a contract/documentation slice. It does not add runtime mutation, service restart, deploy, systemd mutation, secret read, task dispatch, approval authority or correctness verdicts.

## Validation

- `python3 -m pytest -q tests/test_runtime_lens_observation_contract.py` → 6 passed
- `.venv/bin/python -m pytest -q` → 251 passed, 1 warning
- `make validate-local` → passed; includes local validation smoke
- `git diff --check` → passed

Note: system Python full pytest failed before collection because project dependencies (`filelock`, `limits`) are not installed outside the project venv.

## Review evidence

Self-review: `docs/reports/rpu-v1-t017-runtime-lens-bridge-self-review.md`

## Does not establish

- runtime correctness
- code correctness
- test sufficiency
- review completeness
- merge readiness
- deployment safety