### PR TITLE
feat: bound Chronik operator events to named consumers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ AUTH_TOKEN := $(if $(CHRONIK_TOKEN),$(CHRONIK_TOKEN))
 # Prefer the project venv (has pyyaml etc.); fall back to system python.
 PYTHON := $(if $(wildcard .venv/bin/python),./.venv/bin/python,python)
 
-.PHONY: dev ingest-test ensure-token validate-local check-role
+.PHONY: dev ingest-test ensure-token validate-local check-role validate-operator-events
 
 dev:
 	uvicorn app:app --reload --port $(PORT)
@@ -13,6 +13,10 @@ check-role:
 
 validate-local:
 	./scripts/validate-local.sh
+
+validate-operator-events:
+	$(PYTHON) scripts/validate_operator_event_policy.py
+	$(PYTHON) -m pytest -q tests/test_operator_event_policy.py
 
 ingest-test: ensure-token
 	curl --fail-with-body -sS -X POST "http://localhost:$(PORT)/v1/ingest?domain=aussen" \

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ Events haben definierte TTLs basierend auf Event-Typ (konfigurierbar in `config/
 **Wichtig**: `quality` ist Envelope-Metadata und wird nicht in `payload` eingefügt. Der ursprüngliche Event-Payload bleibt unverändert.
 
 **Siehe auch:** Ausführliche Dokumentation in [`docs/chronik/event-quality.md`](docs/chronik/event-quality.md)
+
+Für Operator-Ereignisse gilt zusätzlich die [bounded operator event policy](docs/chronik/operator-event-policy-v1.json): nur Lifecycle, Deployment, terminale Failure, Policy-Block und Recovery mit benanntem Consumer; keine Commits, Diffs, Routine-Taskübergänge oder Rohlogs.
 ## Betrieb & Wartung
 * Logs: `uvicorn` schreibt standardmäßig auf STDOUT; bei Bedarf Output umleiten oder in eine zentrale Log-Pipeline integrieren.
 * Backups: Das Datenverzeichnis lässt sich als Ganzes sichern. Durch die reine Anhänge-Strategie eignen sich inkrementelle Backups.

--- a/docs/chronik/operator-event-policy-v1.json
+++ b/docs/chronik/operator-event-policy-v1.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 1,
+  "kind": "chronik.operator_event_policy",
+  "authority": "append_only_historical_evidence_only",
+  "allowed": [
+    {
+      "event_type": "operator.lifecycle",
+      "consumer": "Grabowski and Bureau incident reconstruction",
+      "query_use": "Reconstruct start, terminal outcome, and recovery boundary of one durable operator task.",
+      "retention_days": 180,
+      "required_fields": ["event_id", "ts", "source", "subject_id", "outcome", "evidence_refs"]
+    },
+    {
+      "event_type": "operator.deployment",
+      "consumer": "Leitstand and human post-deploy review",
+      "query_use": "Reconstruct what artifact was deployed to which runtime and whether rollback occurred.",
+      "retention_days": 365,
+      "required_fields": ["event_id", "ts", "source", "subject_id", "artifact_sha256", "runtime_target", "outcome", "evidence_refs"]
+    },
+    {
+      "event_type": "operator.failure",
+      "consumer": "Heimlern offline failure analysis",
+      "query_use": "Group terminal failures by bounded failure class without retaining raw logs.",
+      "retention_days": 180,
+      "required_fields": ["event_id", "ts", "source", "subject_id", "failure_class", "outcome", "evidence_refs"]
+    },
+    {
+      "event_type": "operator.policy_block",
+      "consumer": "Bureau and security review",
+      "query_use": "Explain why a requested effect was blocked by an approval, resource, or safety policy.",
+      "retention_days": 365,
+      "required_fields": ["event_id", "ts", "source", "subject_id", "policy_id", "outcome", "evidence_refs"]
+    },
+    {
+      "event_type": "operator.recovery",
+      "consumer": "Human incident review",
+      "query_use": "Verify that a failed operation reached a known recovery or rollback state.",
+      "retention_days": 365,
+      "required_fields": ["event_id", "ts", "source", "subject_id", "recovery_action", "outcome", "evidence_refs"]
+    }
+  ],
+  "forbidden": [
+    "git.commit",
+    "git.diff",
+    "git.patch",
+    "bureau.task.created",
+    "bureau.task.started",
+    "bureau.task.updated",
+    "bureau.task.completed",
+    "operator.stdout",
+    "operator.stderr",
+    "operator.prompt",
+    "operator.secret"
+  ],
+  "redaction": {
+    "forbidden_payload_keys": ["secret", "token", "password", "authorization", "cookie", "stdout", "stderr", "diff", "patch", "prompt"],
+    "max_summary_chars": 500,
+    "raw_log_storage": false
+  },
+  "provenance": {
+    "required": true,
+    "source_fields": ["repo", "component", "producer_version"],
+    "evidence_refs_required": true
+  },
+  "boundary": {
+    "no_task_authority": true,
+    "no_command_authority": true,
+    "no_auto_retry": true,
+    "no_auto_policy": true,
+    "no_runtime_activation": true
+  }
+}

--- a/docs/chronik/operator-event-v1.schema.json
+++ b/docs/chronik/operator-event-v1.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heimgewebe.local/chronik/operator-event-v1.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["event_id", "event_type", "ts", "source", "subject_id", "outcome", "summary", "evidence_refs"],
+  "properties": {
+    "event_id": {"type": "string", "minLength": 8, "maxLength": 128},
+    "event_type": {"enum": ["operator.lifecycle", "operator.deployment", "operator.failure", "operator.policy_block", "operator.recovery"]},
+    "ts": {"type": "string", "format": "date-time"},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "component", "producer_version"],
+      "properties": {
+        "repo": {"type": "string", "minLength": 1},
+        "component": {"type": "string", "minLength": 1},
+        "producer_version": {"type": "string", "minLength": 1}
+      }
+    },
+    "subject_id": {"type": "string", "minLength": 1, "maxLength": 256},
+    "outcome": {"enum": ["succeeded", "failed", "blocked", "rolled_back", "recovered"]},
+    "summary": {"type": "string", "minLength": 1, "maxLength": 500},
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 20,
+      "items": {"type": "string", "minLength": 1, "maxLength": 512}
+    },
+    "artifact_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "runtime_target": {"type": "string", "minLength": 1},
+    "failure_class": {"type": "string", "minLength": 1},
+    "policy_id": {"type": "string", "minLength": 1},
+    "recovery_action": {"type": "string", "minLength": 1}
+  },
+  "allOf": [
+    {"if": {"properties": {"event_type": {"const": "operator.deployment"}}}, "then": {"required": ["artifact_sha256", "runtime_target"]}},
+    {"if": {"properties": {"event_type": {"const": "operator.failure"}}}, "then": {"required": ["failure_class"]}},
+    {"if": {"properties": {"event_type": {"const": "operator.policy_block"}}}, "then": {"required": ["policy_id"]}},
+    {"if": {"properties": {"event_type": {"const": "operator.recovery"}}}, "then": {"required": ["recovery_action"]}}
+  ]
+}

--- a/scripts/validate_operator_event_policy.py
+++ b/scripts/validate_operator_event_policy.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY = ROOT / "docs/chronik/operator-event-policy-v1.json"
+SCHEMA = ROOT / "docs/chronik/operator-event-v1.schema.json"
+FIXTURES = ROOT / "tests/fixtures/operator-events"
+
+
+def load(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: root must be object")
+    return value
+
+
+def validate_policy() -> dict[str, Any]:
+    policy = load(POLICY)
+    allowed = policy.get("allowed")
+    if not isinstance(allowed, list) or not allowed:
+        raise ValueError("allowed event list missing")
+    event_types = [entry.get("event_type") for entry in allowed]
+    expected = {"operator.lifecycle", "operator.deployment", "operator.failure", "operator.policy_block", "operator.recovery"}
+    if set(event_types) != expected or len(event_types) != len(expected):
+        raise ValueError("allowed event types must equal the bounded five-type allowlist")
+    forbidden = set(policy.get("forbidden", []))
+    required_forbidden = {"git.commit", "git.diff", "git.patch", "bureau.task.updated", "operator.stdout", "operator.stderr", "operator.secret"}
+    if not required_forbidden <= forbidden:
+        raise ValueError("forbidden duplicate/raw event set incomplete")
+    for entry in allowed:
+        if not entry.get("consumer") or not entry.get("query_use"):
+            raise ValueError(f"{entry.get('event_type')}: named consumer and query use required")
+        if not isinstance(entry.get("retention_days"), int) or not 1 <= entry["retention_days"] <= 365:
+            raise ValueError(f"{entry.get('event_type')}: retention must be bounded to 1..365 days")
+    boundary = policy.get("boundary", {})
+    if not boundary or not all(value is True for value in boundary.values()):
+        raise ValueError("all non-authority boundaries must be true")
+    redaction = policy.get("redaction", {})
+    if redaction.get("raw_log_storage") is not False:
+        raise ValueError("raw log storage must remain false")
+    return policy
+
+
+def _walk_keys(value: Any) -> set[str]:
+    keys: set[str] = set()
+    if isinstance(value, dict):
+        for key, child in value.items():
+            keys.add(key.lower())
+            keys.update(_walk_keys(child))
+    elif isinstance(value, list):
+        for child in value:
+            keys.update(_walk_keys(child))
+    return keys
+
+
+def validate_event(path: Path) -> dict[str, Any]:
+    policy = validate_policy()
+    payload = load(path)
+    schema = load(SCHEMA)
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(payload)
+    forbidden_keys = set(policy["redaction"]["forbidden_payload_keys"])
+    present = _walk_keys(payload)
+    leaked = sorted(forbidden_keys & present)
+    if leaked:
+        raise ValueError(f"{path}: forbidden payload keys present: {leaked}")
+    return payload
+
+
+def query_events(path: Path, *, event_type: str) -> list[dict[str, Any]]:
+    policy = validate_policy()
+    allowed = {entry["event_type"] for entry in policy["allowed"]}
+    if event_type not in allowed:
+        raise ValueError(f"event type not allowed: {event_type}")
+    matches: list[dict[str, Any]] = []
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{path}:{number}: invalid JSON") from exc
+        if payload.get("event_type") == event_type:
+            matches.append(payload)
+    return matches
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", type=Path)
+    parser.add_argument("--query-jsonl", type=Path)
+    parser.add_argument("--event-type")
+    args = parser.parse_args()
+    if args.event:
+        result = validate_event(args.event)
+        output = {"status": "valid", "event_type": result["event_type"]}
+    elif args.query_jsonl:
+        if not args.event_type:
+            parser.error("--event-type is required with --query-jsonl")
+        matches = query_events(args.query_jsonl, event_type=args.event_type)
+        output = {"status": "valid", "matches": len(matches), "events": matches}
+    else:
+        policy = validate_policy()
+        fixtures = sorted(FIXTURES.glob("*.valid.json"))
+        for path in fixtures:
+            validate_event(path)
+        output = {"status": "valid", "allowed": len(policy["allowed"]), "fixtures": len(fixtures)}
+    print(json.dumps(output, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/operator-events/operator.failure.valid.json
+++ b/tests/fixtures/operator-events/operator.failure.valid.json
@@ -1,0 +1,11 @@
+{
+  "event_id": "failure-20260710-0001",
+  "event_type": "operator.failure",
+  "ts": "2026-07-10T08:30:00Z",
+  "source": {"repo": "heimgewebe/grabowski", "component": "task-runner", "producer_version": "b965937"},
+  "subject_id": "task-example",
+  "outcome": "failed",
+  "summary": "Task reached a terminal failure class after bounded execution.",
+  "evidence_refs": ["grabowski-task:task-example"],
+  "failure_class": "tool_exit_nonzero"
+}

--- a/tests/test_operator_event_policy.py
+++ b/tests/test_operator_event_policy.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("operator_event_policy", ROOT / "scripts/validate_operator_event_policy.py")
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+VALID = ROOT / "tests/fixtures/operator-events/operator.failure.valid.json"
+
+
+def test_policy_is_bounded_and_valid() -> None:
+    policy = MODULE.validate_policy()
+    assert len(policy["allowed"]) == 5
+    assert "git.diff" in policy["forbidden"]
+    assert policy["boundary"]["no_command_authority"] is True
+
+
+def test_valid_event_and_real_query_consumer(tmp_path: Path) -> None:
+    event = MODULE.validate_event(VALID)
+    journal = tmp_path / "operator.jsonl"
+    journal.write_text(json.dumps(event) + "\n", encoding="utf-8")
+    matches = MODULE.query_events(journal, event_type="operator.failure")
+    assert [item["event_id"] for item in matches] == [event["event_id"]]
+
+
+def test_raw_log_key_fails_closed(tmp_path: Path) -> None:
+    payload = json.loads(VALID.read_text())
+    payload["stderr"] = "secret-ish raw output"
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(payload))
+    with pytest.raises(Exception):
+        MODULE.validate_event(path)
+
+
+def test_forbidden_event_type_fails_closed(tmp_path: Path) -> None:
+    payload = json.loads(VALID.read_text())
+    payload["event_type"] = "git.commit"
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(payload))
+    with pytest.raises(Exception):
+        MODULE.validate_event(path)


### PR DESCRIPTION
## Ergebnis

- exakt fünf zulässige Operator-Ereignistypen: Lifecycle, Deployment, terminale Failure, Policy-Block und Recovery
- jeder Typ besitzt benannten Consumer, konkrete Query-Nutzung und begrenzte Retention
- Git-Commits, Diffs, Patches, Routine-Taskübergänge, Rohlogs, Prompts und Secrets sind explizit ausgeschlossen
- Provenienz und Evidence-Refs sind Pflicht
- Chronik erhält keine Task-, Command-, Retry-, Policy- oder Runtime-Autorität
- ein read-only JSONL-Abfragepfad belegt einen realen Consumer-Use-Case

## Validierung

- Policy-Validator: fünf Eventtypen, eine gültige Fixture
- vier Negativ-/Consumer-Tests grün
- vollständige Chronik-Suite: 249 Tests grün, eine bekannte Starlette-Warnung
- `git diff --check`

Keine Runtime-Aktivierung oder Ingest-Migration in diesem PR.

Bureau task: `OPERATOR-ECOSYSTEM-REDUNDANCY-V1-T006`