### PR TITLE
feat: define redacted operator outcome export contract

### DIFF
--- a/docs/README_CONTRACTS.md
+++ b/docs/README_CONTRACTS.md
@@ -13,3 +13,10 @@ This directory contains schemas and documentation defining the interfaces (contr
 ## Event Contracts
 
 See `event-contracts.md` for a detailed list of supported events and their requirements.
+
+## Heimlern operator outcome mirror
+
+`docs/mirrors/heimlern/operator.routing_outcome.v1.schema.json` is an exact,
+digest-pinned validation mirror. Heimlern remains the canonical payload owner;
+Chronik owns only the surrounding historical transport envelope. The adjacent
+`.pin.json` records source repository, revision, path, digest and non-claims.

--- a/docs/chronik/operator-routing-outcome-export-v1.md
+++ b/docs/chronik/operator-routing-outcome-export-v1.md
@@ -1,0 +1,66 @@
+# Operator Routing Outcome Export v1
+
+Status: accepted contract slice  
+Bureau task: `CHRONIK-HEIMLERN-OUTCOME-BRIDGE-V1-T002`  
+Chronik envelope: `chronik.operator-routing-outcome-export.v1`  
+Heimlern payload: `operator.routing_outcome.v1`
+
+## Decision
+
+Chronik owns the append-only transport envelope and historical query path. Heimlern owns the routing-outcome payload and all offline interpretation. Grabowski owns execution receipts and may later produce the redacted source material. None of these roles grants live routing authority.
+
+This separation avoids two competing payload contracts:
+
+- the canonical payload remains in `heimgewebe/heimlern`;
+- Chronik carries an exact, digest-pinned mirror only for local validation;
+- every export names the canonical repository, revision, path and schema digest;
+- consumers reject drift instead of silently accepting a different payload shape.
+
+## Envelope guarantees
+
+A valid export contains:
+
+- deterministic `event_id` derived from canonical export bytes excluding `event_id`;
+- Chronik-compatible `source.repo`, `source.component`, `source.revision` and `source.run_id`;
+- exact Heimlern payload-contract identity;
+- canonical payload SHA-256;
+- observation and export timestamps;
+- digest-bound evidence references;
+- fixed transport-only authority and no-auto-apply boundaries.
+
+The validator checks both schemas, mirror identity, payload digest, event identity, timestamp ordering and a bounded redaction screen. Raw output fields, secret-shaped text and private absolute paths are rejected.
+
+## Freshness rule
+
+Append-only history must not store a mutable `fresh` or `stale` verdict. The envelope records `observed_at` and `exported_at`; `consumer_must_recompute=true` requires Heimlern or another reader to compute freshness against its own review time and policy.
+
+## Mirror rule
+
+`docs/mirrors/heimlern/operator.routing_outcome.v1.schema.json` is byte-identical to:
+
+- repository: `heimgewebe/heimlern`
+- revision: `6d70e4900377c92b540d07bd6b71fe36677c2ba5`
+- path: `contracts/operator.routing_outcome.v1.schema.json`
+- SHA-256: `cff1f19814d33dd0ba084b3b5d9e2d4b6c36b1276dab35c3256912b5c457712d`
+
+The adjacent pin file is authoritative only for the local mirror identity. It does not transfer payload ownership to Chronik and does not refresh automatically.
+
+## Validation
+
+```bash
+scripts/validate_operator_outcome_export.py tests/fixtures/operator-outcome/operator-routing-outcome-export.v1.json
+python -m pytest -q tests/test_operator_outcome_export_contract.py
+```
+
+The fixture at `tests/fixtures/operator-outcome/operator-routing-outcome-export.v1.json` is fixture-equivalent evidence only. It does not prove production samples, runtime deployment, route superiority or permission to apply policy.
+
+## Non-claims
+
+This slice does not establish:
+
+- routing-policy superiority;
+- sufficient production sample size;
+- automatic application permission;
+- Chronik runtime readiness;
+- a live Grabowski producer;
+- Heimlern consumer readiness.

--- a/docs/chronik/operator-routing-outcome-export-v1.schema.json
+++ b/docs/chronik/operator-routing-outcome-export-v1.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heimgewebe.local/chronik/operator-routing-outcome-export-v1.schema.json",
+  "title": "Chronik Operator Routing Outcome Export v1",
+  "description": "A digest-bound Chronik transport envelope around a Heimlern-owned operator.routing_outcome.v1 payload.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_id",
+    "kind",
+    "ts",
+    "source",
+    "payload_contract",
+    "payload_sha256",
+    "payload",
+    "freshness",
+    "evidence_refs",
+    "boundary",
+    "non_claims"
+  ],
+  "properties": {
+    "schema_version": {"const": "chronik.operator-routing-outcome-export.v1"},
+    "event_id": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "kind": {"const": "operator.routing_outcome.exported"},
+    "ts": {"$ref": "#/$defs/utc_second"},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "component", "revision", "run_id"],
+      "properties": {
+        "repo": {"const": "heimgewebe/grabowski"},
+        "component": {"type": "string", "pattern": "^[A-Za-z0-9._-]{1,120}$"},
+        "revision": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "run_id": {"type": "string", "pattern": "^[A-Za-z0-9._:-]{1,160}$"}
+      }
+    },
+    "payload_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owner", "source_repository", "source_revision", "source_path", "sha256"],
+      "properties": {
+        "owner": {"const": "heimgewebe/heimlern"},
+        "source_repository": {"const": "heimgewebe/heimlern"},
+        "source_revision": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "source_path": {"const": "contracts/operator.routing_outcome.v1.schema.json"},
+        "sha256": {"$ref": "#/$defs/sha256_hex"}
+      }
+    },
+    "payload_sha256": {"$ref": "#/$defs/sha256_hex"},
+    "payload": {"type": "object"},
+    "freshness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["observed_at", "exported_at", "consumer_must_recompute"],
+      "properties": {
+        "observed_at": {"$ref": "#/$defs/utc_second"},
+        "exported_at": {"$ref": "#/$defs/utc_second"},
+        "consumer_must_recompute": {"const": true}
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "ref", "sha256"],
+        "properties": {
+          "kind": {"type": "string", "pattern": "^[a-z][a-z0-9._:-]{0,80}$"},
+          "ref": {"type": "string", "minLength": 1, "maxLength": 240},
+          "sha256": {"$ref": "#/$defs/sha256_hex"}
+        }
+      }
+    },
+    "boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["transport_authority", "payload_authority", "routing_authority", "raw_logs_included", "secrets_included", "auto_apply_permitted"],
+      "properties": {
+        "transport_authority": {"const": "chronik_append_only_history"},
+        "payload_authority": {"const": "heimlern_contract_at_pinned_revision"},
+        "routing_authority": {"const": "none"},
+        "raw_logs_included": {"const": false},
+        "secrets_included": {"const": false},
+        "auto_apply_permitted": {"const": false}
+      }
+    },
+    "non_claims": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "routing_policy_superiority",
+          "production_sample_sufficiency",
+          "automatic_application_permission",
+          "chronik_payload_contract_ownership",
+          "runtime_readiness"
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "sha256_hex": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "utc_second": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"}
+  }
+}

--- a/docs/event-contracts.md
+++ b/docs/event-contracts.md
@@ -81,6 +81,16 @@ Nach der Verarbeitung durch den Dienst wird die Zeile in `aussen.jsonl` so ausse
 {"event": "deploy", "status": "success", "domain": "aussen"}
 ```
 
+## Schema: `chronik.operator-routing-outcome-export.v1`
+
+Chronik defines a strict transport envelope for the Heimlern-owned
+`operator.routing_outcome.v1` payload. The envelope binds source identity, the
+pinned payload-contract revision and digest, canonical payload bytes, event
+identity, observation/export timestamps and evidence-reference digests. It
+preserves transport-only authority and rejects raw output, secret-shaped text,
+private absolute paths and automatic application. See
+`docs/chronik/operator-routing-outcome-export-v1.md`.
+
 ## Schema: `runtime-lens-observation.v1` (Chronik-local contract)
 
 Chronik defines a bounded Runtime-Lens observation contract under

--- a/docs/mirrors/heimlern/operator.routing_outcome.v1.pin.json
+++ b/docs/mirrors/heimlern/operator.routing_outcome.v1.pin.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "authority": "mirror_only",
+  "owner": "heimgewebe/heimlern",
+  "source_repository": "heimgewebe/heimlern",
+  "source_revision": "6d70e4900377c92b540d07bd6b71fe36677c2ba5",
+  "source_path": "contracts/operator.routing_outcome.v1.schema.json",
+  "sha256": "cff1f19814d33dd0ba084b3b5d9e2d4b6c36b1276dab35c3256912b5c457712d",
+  "does_not_establish": [
+    "chronik_payload_contract_ownership",
+    "automatic_mirror_refresh",
+    "routing_authority"
+  ]
+}

--- a/docs/mirrors/heimlern/operator.routing_outcome.v1.schema.json
+++ b/docs/mirrors/heimlern/operator.routing_outcome.v1.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heimgewebe.local/heimlern/operator.routing_outcome.v1.schema.json",
+  "title": "Operator Routing Outcome v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "decision_id", "ts", "task_class", "route_used", "outcome", "resolved", "reward", "metrics", "does_not_establish"],
+  "properties": {
+    "version": {"const": "operator.routing_outcome.v1"},
+    "decision_id": {"type": "string", "pattern": "^[A-Za-z0-9._:-]{1,160}$"},
+    "ts": {"type": "string", "format": "date-time"},
+    "task_class": {"type": "string", "pattern": "^[a-z][a-z0-9._-]{0,80}$"},
+    "route_used": {"type": "string", "pattern": "^[a-z][a-z0-9._:-]{0,119}$"},
+    "outcome": {"enum": ["success", "failure", "partial", "unknown"]},
+    "resolved": {"type": "boolean"},
+    "reward": {"type": "number", "minimum": -1.0, "maximum": 1.0},
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["completion_state", "friction_count", "blocked_by_platform_filter", "manual_operator_needed"],
+      "properties": {
+        "completion_state": {"enum": ["completed", "blocked", "deferred", "failed", "unknown"]},
+        "friction_count": {"type": "integer", "minimum": 0},
+        "blocked_by_platform_filter": {"type": "boolean"},
+        "manual_operator_needed": {"type": "boolean"},
+        "ci_state": {"enum": ["pass", "fail", "pending", "not_applicable", "unknown"]},
+        "pr_state": {"enum": ["merged", "open", "closed", "not_applicable", "unknown"]},
+        "elapsed_seconds": {"type": "integer", "minimum": 0},
+        "rework_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "friction": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "surface", "resolved"],
+        "properties": {
+          "kind": {"enum": ["ci_contract", "connector_snapshot", "execution_context", "fail_closed_gate", "network", "operator_bug", "platform_filter", "unknown", "user_input"]},
+          "surface": {"type": "string", "minLength": 1, "maxLength": 160},
+          "operation": {"type": "string", "minLength": 1, "maxLength": 160},
+          "resolved": {"type": "boolean"},
+          "fallback": {"type": "string", "minLength": 1, "maxLength": 500}
+        }
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "ref"],
+        "properties": {
+          "kind": {"type": "string", "pattern": "^[a-z][a-z0-9._:-]{0,80}$"},
+          "ref": {"type": "string", "minLength": 1},
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        }
+      }
+    },
+    "does_not_establish": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+  }
+}

--- a/operator_outcome_export.py
+++ b/operator_outcome_export.py
@@ -1,0 +1,152 @@
+"""Validation helpers for the Chronik/Heimlern outcome export contract.
+
+Chronik owns the transport envelope. The embedded payload remains governed by
+an exact, digest-pinned mirror of Heimlern's operator.routing_outcome.v1 schema.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parent
+ENVELOPE_SCHEMA_PATH = ROOT / "docs/chronik/operator-routing-outcome-export-v1.schema.json"
+PAYLOAD_SCHEMA_PATH = ROOT / "docs/mirrors/heimlern/operator.routing_outcome.v1.schema.json"
+PAYLOAD_PIN_PATH = ROOT / "docs/mirrors/heimlern/operator.routing_outcome.v1.pin.json"
+
+_RAW_KEYS = {"raw_log", "raw_logs", "stdout", "stderr", "command_output", "log_excerpt"}
+_PRIVATE_PATH_RE = re.compile(r"(?:^|[\s\"'])/(?:home|root|Users)/")
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"\b(?:api[_-]?key|token|secret|password)\s*[:=]\s*\S+",
+    re.IGNORECASE,
+)
+_SECRET_PREFIXES = (
+    "Bearer ",
+    "gh" + "p_",
+    "gh" + "o_",
+    "sk" + "-",
+    "AK" + "IA",
+)
+_PRIVATE_KEY_MARKER = "-----BEGIN " + "PRIVATE KEY-----"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def sha256_json(value: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def event_id_for(export: dict[str, Any]) -> str:
+    without_id = dict(export)
+    without_id.pop("event_id", None)
+    return "sha256:" + sha256_json(without_id)
+
+
+def _parse_utc_second(value: str, *, label: str) -> datetime:
+    try:
+        parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be a UTC second timestamp") from exc
+    return parsed
+
+
+def _walk(value: Any, *, path: str = "$"):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            yield path, key, item
+            yield from _walk(item, path=f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            yield from _walk(item, path=f"{path}[{index}]")
+
+
+def _validate_redaction_boundary(export: dict[str, Any]) -> None:
+    for path, key, value in _walk(export):
+        if key.lower() in _RAW_KEYS:
+            raise ValueError(f"raw output field is forbidden at {path}.{key}")
+        if not isinstance(value, str):
+            continue
+        if _PRIVATE_PATH_RE.search(value):
+            raise ValueError(f"private absolute path is forbidden at {path}.{key}")
+        if (
+            _PRIVATE_KEY_MARKER in value
+            or any(prefix in value for prefix in _SECRET_PREFIXES)
+            or _SECRET_ASSIGNMENT_RE.search(value)
+        ):
+            raise ValueError(f"secret-shaped material is forbidden at {path}.{key}")
+
+
+def validate_operator_outcome_export(export: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(export, dict):
+        raise ValueError("operator outcome export must be an object")
+
+    envelope_schema = _load_json(ENVELOPE_SCHEMA_PATH)
+    payload_schema = _load_json(PAYLOAD_SCHEMA_PATH)
+    pin = _load_json(PAYLOAD_PIN_PATH)
+    Draft202012Validator.check_schema(envelope_schema)
+    Draft202012Validator.check_schema(payload_schema)
+    Draft202012Validator(envelope_schema).validate(export)
+
+    if pin.get("authority") != "mirror_only":
+        raise ValueError("Heimlern payload pin must remain mirror_only")
+    expected_non_claims = {
+        "chronik_payload_contract_ownership",
+        "automatic_mirror_refresh",
+        "routing_authority",
+    }
+    if set(pin.get("does_not_establish", [])) != expected_non_claims:
+        raise ValueError("Heimlern payload pin non-claims are incomplete")
+
+    mirror_sha256 = hashlib.sha256(PAYLOAD_SCHEMA_PATH.read_bytes()).hexdigest()
+    if mirror_sha256 != pin["sha256"]:
+        raise ValueError("Heimlern payload mirror digest does not match its pin")
+
+    expected_contract = {
+        "owner": pin["owner"],
+        "source_repository": pin["source_repository"],
+        "source_revision": pin["source_revision"],
+        "source_path": pin["source_path"],
+        "sha256": pin["sha256"],
+    }
+    if export["payload_contract"] != expected_contract:
+        raise ValueError("payload contract identity does not match the pinned Heimlern mirror")
+
+    Draft202012Validator(payload_schema).validate(export["payload"])
+    actual_payload_sha256 = sha256_json(export["payload"])
+    if export["payload_sha256"] != actual_payload_sha256:
+        raise ValueError("payload_sha256 does not match canonical payload bytes")
+    if export["event_id"] != event_id_for(export):
+        raise ValueError("event_id does not match the canonical export identity")
+
+    observed_at = _parse_utc_second(export["freshness"]["observed_at"], label="freshness.observed_at")
+    exported_at = _parse_utc_second(export["freshness"]["exported_at"], label="freshness.exported_at")
+    event_ts = _parse_utc_second(export["ts"], label="ts")
+    if exported_at < observed_at:
+        raise ValueError("freshness.exported_at precedes observed_at")
+    if event_ts != exported_at:
+        raise ValueError("ts must equal freshness.exported_at")
+
+    _validate_redaction_boundary(export)
+    return {
+        "valid": True,
+        "event_id": export["event_id"],
+        "payload_sha256": actual_payload_sha256,
+        "payload_contract_sha256": mirror_sha256,
+        "authority": "transport_only",
+        "consumer_must_recompute_freshness": True,
+    }

--- a/scripts/validate_operator_outcome_export.py
+++ b/scripts/validate_operator_outcome_export.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Validate one Chronik operator outcome export without mutating runtime state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from jsonschema.exceptions import SchemaError, ValidationError  # noqa: E402
+from operator_outcome_export import validate_operator_outcome_export  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", type=Path)
+    args = parser.parse_args()
+    try:
+        value = json.loads(args.path.read_text(encoding="utf-8"))
+        receipt = validate_operator_outcome_export(value)
+    except (OSError, ValueError, json.JSONDecodeError, ValidationError, SchemaError) as exc:
+        print(json.dumps({"valid": False, "error": str(exc)}, sort_keys=True))
+        return 1
+    print(json.dumps(receipt, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/operator-outcome/operator-routing-outcome-export.v1.json
+++ b/tests/fixtures/operator-outcome/operator-routing-outcome-export.v1.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "chronik.operator-routing-outcome-export.v1",
+  "kind": "operator.routing_outcome.exported",
+  "ts": "2026-07-10T22:41:00Z",
+  "source": {
+    "repo": "heimgewebe/grabowski",
+    "component": "operator-outcome-export",
+    "revision": "6a169c5f8f580907b64a51ba797b2d8bcc93b3e0",
+    "run_id": "outcome-export-20260710-001"
+  },
+  "payload_contract": {
+    "owner": "heimgewebe/heimlern",
+    "source_repository": "heimgewebe/heimlern",
+    "source_revision": "6d70e4900377c92b540d07bd6b71fe36677c2ba5",
+    "source_path": "contracts/operator.routing_outcome.v1.schema.json",
+    "sha256": "cff1f19814d33dd0ba084b3b5d9e2d4b6c36b1276dab35c3256912b5c457712d"
+  },
+  "payload_sha256": "c9843409b700342bfeb4539179895547a1a14e168b7dd240ba762aaee61af207",
+  "payload": {
+    "version": "operator.routing_outcome.v1",
+    "decision_id": "grabowski-route-20260710-001",
+    "ts": "2026-07-10T22:40:00Z",
+    "task_class": "contract_slice",
+    "route_used": "typed_tool",
+    "outcome": "success",
+    "resolved": true,
+    "reward": 0.8,
+    "metrics": {
+      "completion_state": "completed",
+      "friction_count": 0,
+      "blocked_by_platform_filter": false,
+      "manual_operator_needed": false,
+      "ci_state": "pass",
+      "pr_state": "merged",
+      "elapsed_seconds": 420,
+      "rework_count": 1
+    },
+    "friction": [],
+    "evidence_refs": [
+      {
+        "kind": "receipt",
+        "ref": "grabowski-task:example-outcome-001",
+        "sha256": "1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    ],
+    "does_not_establish": [
+      "causal_route_superiority",
+      "routing_policy_readiness",
+      "auto_apply_permission"
+    ]
+  },
+  "freshness": {
+    "observed_at": "2026-07-10T22:40:00Z",
+    "exported_at": "2026-07-10T22:41:00Z",
+    "consumer_must_recompute": true
+  },
+  "evidence_refs": [
+    {
+      "kind": "receipt",
+      "ref": "grabowski-task:example-outcome-001",
+      "sha256": "1111111111111111111111111111111111111111111111111111111111111111"
+    }
+  ],
+  "boundary": {
+    "transport_authority": "chronik_append_only_history",
+    "payload_authority": "heimlern_contract_at_pinned_revision",
+    "routing_authority": "none",
+    "raw_logs_included": false,
+    "secrets_included": false,
+    "auto_apply_permitted": false
+  },
+  "non_claims": [
+    "routing_policy_superiority",
+    "production_sample_sufficiency",
+    "automatic_application_permission",
+    "chronik_payload_contract_ownership",
+    "runtime_readiness"
+  ],
+  "event_id": "sha256:e4062c86598a9995552bfeb238705c3ad7c50ec10df93ea2c92ef26a1ddc991c"
+}

--- a/tests/test_operator_outcome_export_contract.py
+++ b/tests/test_operator_outcome_export_contract.py
@@ -1,0 +1,120 @@
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+import operator_outcome_export as contract
+from provenance import validate_provenance
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tests/fixtures/operator-outcome/operator-routing-outcome-export.v1.json"
+
+
+def load_fixture():
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_fixture_validates_and_satisfies_chronik_provenance():
+    export = load_fixture()
+    receipt = contract.validate_operator_outcome_export(export)
+    validate_provenance(export, strict=True)
+    assert receipt["valid"] is True
+    assert receipt["authority"] == "transport_only"
+
+
+def test_payload_mirror_is_exactly_digest_pinned():
+    pin = json.loads(contract.PAYLOAD_PIN_PATH.read_text(encoding="utf-8"))
+    assert hashlib.sha256(contract.PAYLOAD_SCHEMA_PATH.read_bytes()).hexdigest() == pin["sha256"]
+    assert pin["authority"] == "mirror_only"
+
+
+def test_payload_digest_mismatch_is_rejected():
+    export = load_fixture()
+    export["payload"]["reward"] = 0.7
+    with pytest.raises(ValueError, match="payload_sha256"):
+        contract.validate_operator_outcome_export(export)
+
+
+def test_event_identity_mismatch_is_rejected():
+    export = load_fixture()
+    export["event_id"] = "sha256:" + "0" * 64
+    with pytest.raises(ValueError, match="event_id"):
+        contract.validate_operator_outcome_export(export)
+
+
+def test_unpinned_payload_contract_is_rejected():
+    export = load_fixture()
+    export["payload_contract"]["source_revision"] = "0" * 40
+    export["event_id"] = contract.event_id_for(export)
+    with pytest.raises(ValueError, match="pinned Heimlern mirror"):
+        contract.validate_operator_outcome_export(export)
+
+
+def test_raw_output_field_is_rejected_by_owner_payload_schema():
+    export = load_fixture()
+    export["payload"]["raw_log"] = "build output"
+    export["payload_sha256"] = contract.sha256_json(export["payload"])
+    export["event_id"] = contract.event_id_for(export)
+    with pytest.raises(jsonschema.ValidationError):
+        contract.validate_operator_outcome_export(export)
+
+
+def test_secret_shaped_text_and_private_paths_are_rejected():
+    for fallback in ("Authorization: Bearer secret-value", "/home/alex/private/receipt.json"):
+        export = load_fixture()
+        export["payload"]["friction"] = [{
+            "kind": "unknown",
+            "surface": "runtime",
+            "resolved": False,
+            "fallback": fallback,
+        }]
+        export["payload"]["metrics"]["friction_count"] = 1
+        export["payload_sha256"] = contract.sha256_json(export["payload"])
+        export["event_id"] = contract.event_id_for(export)
+        with pytest.raises(ValueError, match="forbidden"):
+            contract.validate_operator_outcome_export(export)
+
+
+def test_future_inverted_freshness_is_rejected_and_status_is_not_persisted():
+    export = load_fixture()
+    assert "status" not in export["freshness"]
+    export["freshness"]["observed_at"] = "2026-07-10T22:42:00Z"
+    export["event_id"] = contract.event_id_for(export)
+    with pytest.raises(ValueError, match="precedes"):
+        contract.validate_operator_outcome_export(export)
+
+
+def test_transport_boundary_cannot_be_upgraded_to_routing_authority():
+    export = copy.deepcopy(load_fixture())
+    export["boundary"]["routing_authority"] = "chronik"
+    export["event_id"] = contract.event_id_for(export)
+    with pytest.raises(jsonschema.ValidationError):
+        contract.validate_operator_outcome_export(export)
+
+
+def test_pin_authority_and_non_claims_are_fail_closed(monkeypatch, tmp_path):
+    pin = json.loads(contract.PAYLOAD_PIN_PATH.read_text(encoding="utf-8"))
+    pin["authority"] = "canonical"
+    bad_pin = tmp_path / "pin.json"
+    bad_pin.write_text(json.dumps(pin), encoding="utf-8")
+    monkeypatch.setattr(contract, "PAYLOAD_PIN_PATH", bad_pin)
+    with pytest.raises(ValueError, match="mirror_only"):
+        contract.validate_operator_outcome_export(load_fixture())
+
+
+def test_cli_emits_machine_readable_validation_receipt():
+    import subprocess
+
+    completed = subprocess.run(
+        [str(ROOT / "scripts/validate_operator_outcome_export.py"), str(FIXTURE)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    receipt = json.loads(completed.stdout)
+    assert receipt["valid"] is True
+    assert receipt["authority"] == "transport_only"


### PR DESCRIPTION
## Summary

- define a Chronik-owned, digest-bound transport envelope around the Heimlern-owned `operator.routing_outcome.v1` payload
- pin an exact mirror of the Heimlern schema by repository, revision, path and SHA-256 without transferring contract ownership
- validate strict Chronik provenance, payload and event digests, timestamp ordering, evidence references and fixed transport-only authority
- reject raw output fields, secret-shaped strings and private absolute paths
- persist observation/export timestamps only; consumers must recompute freshness instead of trusting a stale stored status
- add a machine-readable validator and fixture-equivalent sample

## Validation

- 264 tests passed
- Chronik role contract: OK
- operator outcome fixture validator: valid
- Heimlern mirror SHA-256: `cff1f19814d33dd0ba084b3b5d9e2d4b6c36b1276dab35c3256912b5c457712d`
- JSON schema/pin parse: pass
- `git diff --check`: pass
- runtime mutation attempted: false

Bureau task: `CHRONIK-HEIMLERN-OUTCOME-BRIDGE-V1-T002`

Does not establish a live Grabowski producer, Chronik runtime readiness, Heimlern consumer readiness, routing superiority or auto-apply permission.