### PR TITLE
feat: add local coding memory path

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,15 +40,14 @@ from storage import (
     write_payload,
 )
 from provenance import ProvenanceError, validate_provenance, has_provenance
-from retention import get_ttl_for_event, compute_expiry_date
 from validation import (
     normalize_heimgeist_item,
     parse_iso_ts,
     prewarm_validators,
     validate_insights_daily_payload,
 )
-from quality import compute_signal_strength, compute_completeness
 from integrity import IntegrityManager
+from canonical_ingest import build_envelope
 
 # --- Runtime constants & logging ---
 MAX_PAYLOAD_SIZE: Final[int] = int(
@@ -444,55 +443,27 @@ def _process_items(items: list[Any], dom: str) -> list[str]:
             # Non-strict validation: just log warnings
             validate_provenance(normalized, strict=False)
         
-        # 1c. Compute quality markers (if enabled) - but don't mutate payload
-        quality_meta = None
-        if is_quality_enabled:
-            signal_strength = compute_signal_strength(normalized)
-            completeness = compute_completeness(normalized)
-            quality_meta = {
-                "signal_strength": signal_strength.value,
-                "completeness": completeness,
-            }
-            events_signal_strength.labels(domain=domain_label, signal_strength=quality_meta["signal_strength"]).inc()
-        
-        # 1d. Compute retention metadata
-        # Extract event_type from event itself (not from domain)
-        # Priority: kind > type > event
+        # 1c. Identify the event type for bounded metrics. Canonical quality and
+        # retention metadata are computed once by the shared envelope constructor.
         event_type = normalized.get("kind") or normalized.get("type") or normalized.get("event")
-        
-        # For retention: use event_type if available, otherwise apply default policy
-        # Note: We do NOT use domain as event_type - they serve different purposes
-        retention_event_type = event_type if event_type else "unknown"
-        
-        # For metrics: use domain as fallback to preserve observability
-        # This allows us to see which domains produce events without type fields
         metrics_event_type = event_type if event_type else f"domain.{dom}"
-        
-        # Sanitize for metrics to prevent label pollution/entropy
         event_type_for_metrics = _sanitize_metric_label(metrics_event_type)
-        
-        ttl_days = get_ttl_for_event(retention_event_type)
         received_dt = datetime.now(timezone.utc)
-        expiry_dt = compute_expiry_date(retention_event_type, received_dt)
-        
-        retention_meta = {
-            "ttl_days": ttl_days,
-            "expires_at": expiry_dt.strftime("%Y-%m-%dT%H:%M:%SZ") if expiry_dt else None,
-        }
 
-        # 2. Canonical Wrapping (All domains)
-        # Payload remains unmodified; quality and retention are envelope metadata
-        wrapper = {
-            "domain": dom,
-            "received_at": received_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "payload": normalized,
-            "retention": retention_meta,
-        }
+        # 2. Canonical Wrapping (All domains). API and local importers share
+        # this constructor so receipt hashes and retention metadata do not drift.
+        wrapper = build_envelope(
+            dom,
+            normalized,
+            received_at=received_dt,
+            quality_enabled=is_quality_enabled,
+        )
         
-        # Add quality to wrapper (not payload) if enabled
-        if quality_meta:
-            wrapper["quality"] = quality_meta
-        
+        if is_quality_enabled:
+            events_signal_strength.labels(
+                domain=domain_label,
+                signal_strength=wrapper["quality"]["signal_strength"],
+            ).inc()
         # Track metrics with sanitized labels (both domain and event_type)
         events_ingested_total.labels(domain=domain_label, event_type=event_type_for_metrics).inc()
         

--- a/canonical_ingest.py
+++ b/canonical_ingest.py
@@ -1,0 +1,32 @@
+"""Canonical Chronik envelope construction shared by API and local importers."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from quality import compute_completeness, compute_signal_strength
+from retention import compute_expiry_date, get_ttl_for_event
+
+
+def build_envelope(domain: str, payload: dict[str, Any], *, received_at: datetime | None = None, quality_enabled: bool = True) -> dict[str, Any]:
+    observed = received_at or datetime.now(timezone.utc)
+    if observed.tzinfo is None:
+        raise ValueError("received_at must be timezone-aware")
+    observed = observed.astimezone(timezone.utc)
+    event_type = payload.get("kind") or payload.get("type") or payload.get("event") or "unknown"
+    expiry = compute_expiry_date(str(event_type), observed)
+    wrapper: dict[str, Any] = {
+        "domain": domain,
+        "received_at": observed.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "payload": dict(payload),
+        "retention": {
+            "ttl_days": get_ttl_for_event(str(event_type)),
+            "expires_at": expiry.strftime("%Y-%m-%dT%H:%M:%SZ") if expiry else None,
+        },
+    }
+    if quality_enabled:
+        wrapper["quality"] = {
+            "signal_strength": compute_signal_strength(payload).value,
+            "completeness": compute_completeness(payload),
+        }
+    return wrapper

--- a/coding_memory.py
+++ b/coding_memory.py
@@ -1,0 +1,165 @@
+"""Local, idempotent coding-history import and frozen query receipts."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from jsonschema import Draft7Validator
+
+import storage
+from canonical_ingest import build_envelope
+
+DOMAIN = "agent.ledger"
+SCHEMA_PATH = Path(__file__).resolve().parent / "docs" / "chronik" / "agent-run-event-v0.schema.json"
+DOES_NOT_ESTABLISH = ["current_git_state", "current_ci_state", "current_runtime_state", "safe_retry"]
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def configure_data_dir(path: Path, *, create: bool) -> Path:
+    candidate = path.expanduser()
+    if create:
+        candidate.mkdir(parents=True, exist_ok=True, mode=0o700)
+    resolved = candidate.resolve(strict=not create)
+    if not resolved.is_dir():
+        raise ValueError("Chronik data directory is not a directory")
+    storage.DATA_DIR = resolved
+    return resolved
+
+
+def _validator() -> Draft7Validator:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft7Validator.check_schema(schema)
+    return Draft7Validator(schema)
+
+
+def validate_event(event: dict[str, Any]) -> None:
+    errors = sorted(_validator().iter_errors(event), key=lambda error: list(error.absolute_path))
+    if errors:
+        error = errors[0]
+        path = "/".join(str(part) for part in error.absolute_path) or "<root>"
+        raise ValueError(f"invalid coding event at {path}: {error.message}")
+
+
+def import_events(events: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    values = [dict(event) for event in events]
+    for event in values:
+        validate_event(event)
+    lines = [json.dumps(build_envelope(DOMAIN, event), sort_keys=True, separators=(",", ":"), ensure_ascii=False) for event in values]
+    written, skipped = storage.write_payload_unique(DOMAIN, lines)
+    receipt = {
+        "schema_version": "chronik-import-receipt.v1",
+        "domain": DOMAIN,
+        "event_ids": sorted(event["event_id"] for event in values),
+        "requested": len(values),
+        "imported": written,
+        "skipped_existing": skipped,
+        "recorded_at": utc_now(),
+        "source_sha256": sha256_bytes(b"\n".join(canonical_bytes(event) for event in values)),
+        "historical_only": True,
+        "does_not_establish": DOES_NOT_ESTABLISH,
+    }
+    receipt["receipt_sha256"] = sha256_bytes(canonical_bytes(receipt))
+    return receipt
+
+
+def _records() -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for _, _, line in storage.scan_domain(DOMAIN):
+        try:
+            envelope = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        payload = envelope.get("payload") if isinstance(envelope, dict) else None
+        if not isinstance(payload, dict):
+            continue
+        try:
+            validate_event(payload)
+        except ValueError:
+            continue
+        rows.append({"received_at": envelope.get("received_at"), "payload": payload})
+    return rows
+
+
+def query_history(*, repo: str, component: str | None = None, operation: str | None = None, outcome: str | None = None, since: str | None = None, limit: int = 20) -> dict[str, Any]:
+    if not repo or limit < 1 or limit > 500:
+        raise ValueError("repo and limit 1..500 are required")
+    selected: list[dict[str, Any]] = []
+    for row in _records():
+        event = row["payload"]
+        subject = event["subject"]
+        data = event.get("data", {})
+        if subject.get("repo") != repo:
+            continue
+        if component and subject.get("component") != component:
+            continue
+        if operation and subject.get("operation") != operation:
+            continue
+        actual_outcome = data.get("outcome") or data.get("result")
+        if outcome and actual_outcome != outcome:
+            continue
+        if since and event.get("ts", "") < since:
+            continue
+        selected.append(row)
+    selected.sort(key=lambda row: (row["payload"]["ts"], row["payload"]["event_id"]), reverse=True)
+    selected = selected[:limit]
+    query = {"repo": repo, "component": component, "operation": operation, "outcome": outcome, "since": since, "limit": limit}
+    return {
+        "schema_version": "chronik-coding-history.v1",
+        "query": query,
+        "events": [row["payload"] for row in selected],
+        "event_ids": [row["payload"]["event_id"] for row in selected],
+        "historical_only": True,
+        "does_not_establish": DOES_NOT_ESTABLISH,
+    }
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data); handle.flush(); os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def freeze_history(output: Path, **filters: Any) -> dict[str, Any]:
+    history = query_history(**filters)
+    body = b"".join(canonical_bytes(event) + b"\n" for event in history["events"])
+    _atomic_write(output, body)
+    receipt = {
+        "schema_version": "chronik-history-cohort-receipt.v1",
+        "domain": DOMAIN,
+        "query": history["query"],
+        "event_ids": history["event_ids"],
+        "event_count": len(history["event_ids"]),
+        "cohort_path": str(output),
+        "cohort_sha256": sha256_bytes(body),
+        "query_sha256": sha256_bytes(canonical_bytes(history["query"])),
+        "generated_at": utc_now(),
+        "redaction_contract": "agent-run-event.v0 allow-list",
+        "historical_only": True,
+        "does_not_establish": DOES_NOT_ESTABLISH,
+    }
+    receipt["receipt_sha256"] = sha256_bytes(canonical_bytes(receipt))
+    receipt_path = output.with_suffix(output.suffix + ".receipt.json")
+    _atomic_write(receipt_path, json.dumps(receipt, indent=2, sort_keys=True).encode("utf-8") + b"\n")
+    return receipt

--- a/coding_memory.py
+++ b/coding_memory.py
@@ -31,6 +31,16 @@ def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def _parse_timestamp(value: str, *, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as exc:
+        raise ValueError(f"{field} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
 def configure_data_dir(path: Path, *, create: bool) -> Path:
     candidate = path.expanduser()
     if create:
@@ -54,6 +64,7 @@ def validate_event(event: dict[str, Any]) -> None:
         error = errors[0]
         path = "/".join(str(part) for part in error.absolute_path) or "<root>"
         raise ValueError(f"invalid coding event at {path}: {error.message}")
+    _parse_timestamp(event["ts"], field="ts")
 
 
 def import_events(events: Iterable[dict[str, Any]]) -> dict[str, Any]:
@@ -96,9 +107,14 @@ def _records() -> list[dict[str, Any]]:
     return rows
 
 
-def query_history(*, repo: str, component: str | None = None, operation: str | None = None, outcome: str | None = None, since: str | None = None, limit: int = 20) -> dict[str, Any]:
+def validate_query(*, repo: str, component: str | None = None, operation: str | None = None, outcome: str | None = None, since: str | None = None, limit: int = 20) -> datetime | None:
     if not repo or limit < 1 or limit > 500:
         raise ValueError("repo and limit 1..500 are required")
+    return _parse_timestamp(since, field="since") if since is not None else None
+
+
+def query_history(*, repo: str, component: str | None = None, operation: str | None = None, outcome: str | None = None, since: str | None = None, limit: int = 20) -> dict[str, Any]:
+    since_at = validate_query(repo=repo, component=component, operation=operation, outcome=outcome, since=since, limit=limit)
     selected: list[dict[str, Any]] = []
     for row in _records():
         event = row["payload"]
@@ -113,10 +129,11 @@ def query_history(*, repo: str, component: str | None = None, operation: str | N
         actual_outcome = data.get("outcome") or data.get("result")
         if outcome and actual_outcome != outcome:
             continue
-        if since and event.get("ts", "") < since:
+        event_at = _parse_timestamp(event["ts"], field="ts")
+        if since_at is not None and event_at < since_at:
             continue
-        selected.append(row)
-    selected.sort(key=lambda row: (row["payload"]["ts"], row["payload"]["event_id"]), reverse=True)
+        selected.append({**row, "event_at": event_at})
+    selected.sort(key=lambda row: (row["event_at"], row["payload"]["event_id"]), reverse=True)
     selected = selected[:limit]
     query = {"repo": repo, "component": component, "operation": operation, "outcome": outcome, "since": since, "limit": limit}
     return {

--- a/docs/chronik/agent-run-event-v0.schema.json
+++ b/docs/chronik/agent-run-event-v0.schema.json
@@ -18,10 +18,18 @@
     "data"
   ],
   "properties": {
-    "schema_version": {"const": "agent-run-event.v0"},
-    "event_id": {"$ref": "#/definitions/event_id"},
+    "schema_version": {
+      "const": "agent-run-event.v0"
+    },
+    "event_id": {
+      "$ref": "#/definitions/event_id"
+    },
     "kind": {
-      "enum": ["agent.run.started", "agent.run.completed", "agent.run.blocked"]
+      "enum": [
+        "agent.run.started",
+        "agent.run.completed",
+        "agent.run.blocked"
+      ]
     },
     "ts": {
       "type": "string",
@@ -30,59 +38,169 @@
     "source": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["repo", "component", "run_id"],
+      "required": [
+        "repo",
+        "component",
+        "run_id"
+      ],
       "properties": {
-        "repo": {"type": "string", "minLength": 1, "maxLength": 200},
-        "component": {"type": "string", "minLength": 1, "maxLength": 80},
-        "run_id": {"type": "string", "minLength": 1, "maxLength": 160}
+        "repo": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "component": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "run_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160
+        }
       }
     },
     "subject": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["repo"],
+      "required": [
+        "repo"
+      ],
       "properties": {
-        "repo": {"type": "string", "minLength": 1, "maxLength": 200},
-        "branch": {"type": "string", "minLength": 1, "maxLength": 200},
-        "head": {"type": "string", "minLength": 1, "maxLength": 80}
+        "repo": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "branch": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "head": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "component": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160
+        },
+        "operation": {
+          "enum": [
+            "implement",
+            "review",
+            "merge",
+            "deploy",
+            "runtime_verify",
+            "recovery"
+          ]
+        },
+        "bureau_task_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160
+        },
+        "pr_number": {
+          "type": "integer",
+          "minimum": 1
+        }
       }
     },
-    "trust_tier": {"enum": ["observed", "declared", "inferred"]},
-    "status": {"enum": ["active", "superseded", "corrected"]},
+    "trust_tier": {
+      "enum": [
+        "observed",
+        "declared",
+        "inferred"
+      ]
+    },
+    "status": {
+      "enum": [
+        "active",
+        "superseded",
+        "corrected"
+      ]
+    },
     "corrects": {
       "type": "array",
       "minItems": 1,
       "maxItems": 3,
       "uniqueItems": true,
-      "items": {"$ref": "#/definitions/event_id"}
+      "items": {
+        "$ref": "#/definitions/event_id"
+      }
     },
     "caused_by": {
       "type": "array",
       "maxItems": 3,
       "uniqueItems": true,
-      "items": {"$ref": "#/definitions/event_id"}
+      "items": {
+        "$ref": "#/definitions/event_id"
+      }
     },
     "evidence_refs": {
       "type": "array",
       "maxItems": 5,
       "uniqueItems": true,
-      "items": {"type": "string", "minLength": 1, "maxLength": 240}
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 240
+      }
     },
     "data": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "result": {"enum": ["started", "completed", "blocked"]},
-        "blocker_code": {"type": "string", "minLength": 1, "maxLength": 80},
-        "summary": {"type": "string", "minLength": 1, "maxLength": 500},
-        "duration_ms": {"type": "integer", "minimum": 0}
+        "result": {
+          "enum": [
+            "started",
+            "completed",
+            "blocked"
+          ]
+        },
+        "blocker_code": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        },
+        "duration_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "outcome": {
+          "enum": [
+            "completed",
+            "blocked",
+            "failed",
+            "reverted",
+            "outcome_unknown"
+          ]
+        }
       }
     }
   },
   "allOf": [
     {
-      "if": {"properties": {"status": {"const": "corrected"}}},
-      "then": {"required": ["corrects"]}
+      "if": {
+        "properties": {
+          "status": {
+            "const": "corrected"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "corrects"
+        ]
+      }
     }
   ],
   "definitions": {

--- a/docs/chronik/coding-memory-v1.md
+++ b/docs/chronik/coding-memory-v1.md
@@ -1,0 +1,28 @@
+# Chronik Coding Memory v1
+
+Chronik records a narrow, append-only history of coding and operator outcomes. It is historical evidence, not live Git, CI, runtime or retry truth.
+
+## Local path
+
+```text
+Grabowski task outbox -> tools/coding_memory.py import -> agent.ledger JSONL
+                                              -> query/freeze -> hash-bound cohort receipt
+```
+
+No Plexer, Heimlern, Leitstand or long-running Chronik service is required. API and CLI use the same canonical envelope constructor. Imports are idempotent by `event_id` under the domain file lock.
+
+## Work context
+
+`subject` may carry `repo`, `component`, `operation`, `bureau_task_id` and `pr_number`. `data.outcome` may be `completed`, `blocked`, `failed`, `reverted` or `outcome_unknown`. Payloads remain allow-listed and contain no raw logs, prompts, commands or secrets.
+
+## Frozen history brief
+
+`freeze` writes an exact JSONL cohort and a sibling receipt containing query parameters, event IDs, SHA-256 digests, generation time and the mandatory boundary:
+
+- historical only;
+- does not establish current Git state;
+- does not establish current CI state;
+- does not establish current runtime state;
+- does not establish a safe retry.
+
+A Vibe-Lab experiment may cite the receipt as `chronik:<receipt_sha256>`. It must not copy mutable live-state claims from Chronik or auto-apply a policy.

--- a/storage.py
+++ b/storage.py
@@ -25,6 +25,7 @@ __all__ = [
     "target_filename",
     "safe_target_path",
     "write_payload",
+    "write_payload_unique",
     "read_tail",
     "read_last_line",
     "scan_domain",
@@ -226,6 +227,10 @@ def _locked_open(target_path: Path, mode: str) -> Iterator:
     elif mode == "a":
         flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
         py_mode = "a"
+        encoding = "utf-8"
+    elif mode == "a+":
+        flags = os.O_RDWR | os.O_CREAT | os.O_APPEND
+        py_mode = "a+"
         encoding = "utf-8"
     else:
         raise ValueError(f"unsupported mode: {mode}")
@@ -492,3 +497,55 @@ def write_payload(domain: str, lines: Iterable[str]) -> None:
                 logger.error("disk full", extra={"file": str(target_path)})
                 raise StorageFullError("insufficient storage") from exc
             raise
+
+
+def write_payload_unique(domain: str, lines: Iterable[str], *, identity_key: str = "event_id") -> tuple[int, int]:
+    """Append JSON lines once per payload identity under the domain lock.
+
+    Returns ``(written, skipped)``. Existing malformed lines are preserved but do
+    not participate in identity matching. The lock covers both scan and append.
+    """
+    candidates = list(lines)
+    if not candidates:
+        return 0, 0
+    try:
+        target_path = safe_target_path(domain)
+    except DomainError as exc:
+        raise StorageError("invalid target path") from exc
+
+    parsed: list[tuple[str, str]] = []
+    for line in candidates:
+        try:
+            value = __import__("json").loads(line)
+        except ValueError as exc:
+            raise StorageError("invalid JSON line") from exc
+        identity = value.get("payload", value).get(identity_key) if isinstance(value, dict) else None
+        if not isinstance(identity, str) or not identity:
+            raise StorageError(f"missing {identity_key}")
+        parsed.append((identity, line))
+
+    with _locked_open(target_path, "a+") as fh:
+        fh.seek(0)
+        existing: set[str] = set()
+        for raw in fh:
+            try:
+                value = __import__("json").loads(raw)
+            except ValueError:
+                continue
+            payload = value.get("payload", value) if isinstance(value, dict) else None
+            identity = payload.get(identity_key) if isinstance(payload, dict) else None
+            if isinstance(identity, str):
+                existing.add(identity)
+        written = 0
+        skipped = 0
+        for identity, line in parsed:
+            if identity in existing:
+                skipped += 1
+                continue
+            fh.write(line)
+            fh.write("\n")
+            existing.add(identity)
+            written += 1
+        fh.flush()
+        os.fsync(fh.fileno())
+    return written, skipped

--- a/storage.py
+++ b/storage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import errno
 import hashlib
+import json
 import logging
 import os
 import re
@@ -513,38 +514,53 @@ def write_payload_unique(domain: str, lines: Iterable[str], *, identity_key: str
     except DomainError as exc:
         raise StorageError("invalid target path") from exc
 
-    parsed: list[tuple[str, str]] = []
+    parsed: list[tuple[str, str, bytes]] = []
+    candidate_payloads: dict[str, bytes] = {}
     for line in candidates:
         try:
-            value = __import__("json").loads(line)
-        except ValueError as exc:
+            value = json.loads(line)
+            payload = value.get("payload", value) if isinstance(value, dict) else None
+            identity = payload.get(identity_key) if isinstance(payload, dict) else None
+            canonical_payload = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode("utf-8")
+        except (TypeError, ValueError) as exc:
             raise StorageError("invalid JSON line") from exc
-        identity = value.get("payload", value).get(identity_key) if isinstance(value, dict) else None
         if not isinstance(identity, str) or not identity:
             raise StorageError(f"missing {identity_key}")
-        parsed.append((identity, line))
+        previous = candidate_payloads.get(identity)
+        if previous is not None and previous != canonical_payload:
+            raise StorageError(f"conflicting {identity_key}: {identity}")
+        candidate_payloads.setdefault(identity, canonical_payload)
+        parsed.append((identity, line, canonical_payload))
 
     with _locked_open(target_path, "a+") as fh:
         fh.seek(0)
-        existing: set[str] = set()
+        existing: dict[str, bytes] = {}
         for raw in fh:
             try:
-                value = __import__("json").loads(raw)
-            except ValueError:
+                value = json.loads(raw)
+                payload = value.get("payload", value) if isinstance(value, dict) else None
+                identity = payload.get(identity_key) if isinstance(payload, dict) else None
+                canonical_payload = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode("utf-8")
+            except (TypeError, ValueError):
                 continue
-            payload = value.get("payload", value) if isinstance(value, dict) else None
-            identity = payload.get(identity_key) if isinstance(payload, dict) else None
             if isinstance(identity, str):
-                existing.add(identity)
+                previous = existing.get(identity)
+                if previous is not None and previous != canonical_payload:
+                    raise StorageError(f"conflicting {identity_key}: {identity}")
+                existing.setdefault(identity, canonical_payload)
+        for identity, _, canonical_payload in parsed:
+            previous = existing.get(identity)
+            if previous is not None and previous != canonical_payload:
+                raise StorageError(f"conflicting {identity_key}: {identity}")
         written = 0
         skipped = 0
-        for identity, line in parsed:
+        for identity, line, canonical_payload in parsed:
             if identity in existing:
                 skipped += 1
                 continue
             fh.write(line)
             fh.write("\n")
-            existing.add(identity)
+            existing[identity] = canonical_payload
             written += 1
         fh.flush()
         os.fsync(fh.fileno())

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -1,0 +1,38 @@
+import hashlib, json
+from pathlib import Path
+import coding_memory, storage
+
+def event(event_id="sha256:"+"a"*64, repo="heimgewebe/example", component="api", operation="implement", outcome="completed"):
+    return {"schema_version":"agent-run-event.v0","event_id":event_id,"kind":"agent.run.completed","ts":"2026-07-13T10:00:00Z","source":{"repo":"heimgewebe/grabowski","component":"grabowski","run_id":"task-test-a1"},"subject":{"repo":repo,"component":component,"operation":operation,"bureau_task_id":"CCM-V1-T001","pr_number":1},"trust_tier":"observed","status":"active","caused_by":[],"evidence_refs":["grabowski-task:test"],"data":{"result":"completed","outcome":outcome}}
+
+def setup(tmp_path,monkeypatch):
+    monkeypatch.setattr(storage,"DATA_DIR",tmp_path); return tmp_path
+
+def test_import_is_idempotent_and_uses_canonical_envelope(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); first=coding_memory.import_events([event()]); second=coding_memory.import_events([event()])
+    assert first["imported"]==1 and second["imported"]==0 and second["skipped_existing"]==1
+    row=json.loads((tmp_path/"agent.ledger.jsonl").read_text().splitlines()[0])
+    assert row["domain"]=="agent.ledger" and row["payload"]["subject"]["repo"]=="heimgewebe/example"
+    assert "quality" in row and "retention" in row
+
+def test_query_filters_and_marks_history_only(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); coding_memory.import_events([event(),event("sha256:"+"b"*64,repo="heimgewebe/other")])
+    result=coding_memory.query_history(repo="heimgewebe/example",component="api",operation="implement",outcome="completed")
+    assert result["event_ids"]==["sha256:"+"a"*64]
+    assert result["historical_only"] is True and "current_ci_state" in result["does_not_establish"]
+
+def test_freeze_binds_query_and_bytes(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); coding_memory.import_events([event()]); output=tmp_path/"cohort.jsonl"
+    receipt=coding_memory.freeze_history(output,repo="heimgewebe/example",component=None,operation=None,outcome=None,since=None,limit=20)
+    assert receipt["event_count"]==1
+    assert receipt["cohort_sha256"]==hashlib.sha256(output.read_bytes()).hexdigest()
+    saved=json.loads((tmp_path/"cohort.jsonl.receipt.json").read_text()); assert saved["receipt_sha256"]==receipt["receipt_sha256"]
+
+
+def test_query_cli_missing_data_dir_is_read_only(tmp_path):
+    import subprocess, sys
+    missing = tmp_path / "missing"
+    result = subprocess.run([sys.executable, str(Path(__file__).parents[1] / "tools" / "coding_memory.py"), "--data-dir", str(missing), "query", "--repo", "heimgewebe/example"], text=True, capture_output=True)
+    assert result.returncode == 0
+    assert not missing.exists()
+    assert json.loads(result.stdout)["events"] == []

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -1,9 +1,10 @@
 import hashlib, json
 from pathlib import Path
+import pytest
 import coding_memory, storage
 
-def event(event_id="sha256:"+"a"*64, repo="heimgewebe/example", component="api", operation="implement", outcome="completed"):
-    return {"schema_version":"agent-run-event.v0","event_id":event_id,"kind":"agent.run.completed","ts":"2026-07-13T10:00:00Z","source":{"repo":"heimgewebe/grabowski","component":"grabowski","run_id":"task-test-a1"},"subject":{"repo":repo,"component":component,"operation":operation,"bureau_task_id":"CCM-V1-T001","pr_number":1},"trust_tier":"observed","status":"active","caused_by":[],"evidence_refs":["grabowski-task:test"],"data":{"result":"completed","outcome":outcome}}
+def event(event_id="sha256:"+"a"*64, repo="heimgewebe/example", component="api", operation="implement", outcome="completed", ts="2026-07-13T10:00:00Z"):
+    return {"schema_version":"agent-run-event.v0","event_id":event_id,"kind":"agent.run.completed","ts":ts,"source":{"repo":"heimgewebe/grabowski","component":"grabowski","run_id":"task-test-a1"},"subject":{"repo":repo,"component":component,"operation":operation,"bureau_task_id":"CCM-V1-T001","pr_number":1},"trust_tier":"observed","status":"active","caused_by":[],"evidence_refs":["grabowski-task:test"],"data":{"result":"completed","outcome":outcome}}
 
 def setup(tmp_path,monkeypatch):
     monkeypatch.setattr(storage,"DATA_DIR",tmp_path); return tmp_path
@@ -14,6 +15,28 @@ def test_import_is_idempotent_and_uses_canonical_envelope(tmp_path,monkeypatch):
     row=json.loads((tmp_path/"agent.ledger.jsonl").read_text().splitlines()[0])
     assert row["domain"]=="agent.ledger" and row["payload"]["subject"]["repo"]=="heimgewebe/example"
     assert "quality" in row and "retention" in row
+
+
+def test_import_rejects_divergent_event_id_before_partial_write(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch)
+    with pytest.raises(storage.StorageError, match="conflicting event_id"):
+        coding_memory.import_events([event(), event(repo="heimgewebe/other")])
+    target = tmp_path / "agent.ledger.jsonl"
+    assert not target.exists() or target.read_text() == ""
+
+    coding_memory.import_events([event()])
+    before = target.read_bytes()
+    with pytest.raises(storage.StorageError, match="conflicting event_id"):
+        coding_memory.import_events([event(repo="heimgewebe/other")])
+    assert target.read_bytes() == before
+
+
+def test_query_compares_since_offset_in_utc(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch)
+    coding_memory.import_events([event(ts="2026-07-13T08:30:00Z"), event("sha256:"+"b"*64, ts="2026-07-13T09:30:00Z")])
+    result = coding_memory.query_history(repo="heimgewebe/example", since="2026-07-13T10:00:00+02:00")
+    assert result["event_ids"] == ["sha256:"+"b"*64, "sha256:"+"a"*64]
+
 
 def test_query_filters_and_marks_history_only(tmp_path,monkeypatch):
     setup(tmp_path,monkeypatch); coding_memory.import_events([event(),event("sha256:"+"b"*64,repo="heimgewebe/other")])
@@ -36,3 +59,12 @@ def test_query_cli_missing_data_dir_is_read_only(tmp_path):
     assert result.returncode == 0
     assert not missing.exists()
     assert json.loads(result.stdout)["events"] == []
+
+
+def test_query_cli_validates_filters_without_creating_data_dir(tmp_path):
+    import subprocess, sys
+    missing = tmp_path / "missing"
+    result = subprocess.run([sys.executable, str(Path(__file__).parents[1] / "tools" / "coding_memory.py"), "--data-dir", str(missing), "query", "--repo", "heimgewebe/example", "--limit", "0"], text=True, capture_output=True)
+    assert result.returncode == 2
+    assert "limit 1..500" in result.stderr
+    assert not missing.exists()

--- a/tools/coding_memory.py
+++ b/tools/coding_memory.py
@@ -27,10 +27,13 @@ def main(argv=None):
     args=parser.parse_args(argv)
     try:
         data_path = Path(args.data_dir).expanduser()
+        query_filters = filters(args) if args.command in {"query", "freeze"} else None
+        if query_filters is not None:
+            coding_memory.validate_query(**query_filters)
         if args.command == "query" and not data_path.exists():
             result = {
                 "schema_version": "chronik-coding-history.v1",
-                "query": filters(args),
+                "query": query_filters,
                 "events": [],
                 "event_ids": [],
                 "historical_only": True,
@@ -39,8 +42,8 @@ def main(argv=None):
             print(json.dumps(result,indent=2,sort_keys=True)); return 0
         coding_memory.configure_data_dir(data_path, create=args.command in {"import", "freeze"})
         if args.command=="import": result=coding_memory.import_events(load(args.input))
-        elif args.command=="query": result=coding_memory.query_history(**filters(args))
-        else: result=coding_memory.freeze_history(args.output,**filters(args))
+        elif args.command=="query": result=coding_memory.query_history(**query_filters)
+        else: result=coding_memory.freeze_history(args.output,**query_filters)
     except (OSError,ValueError) as exc:
         print(f"chronik-coding-memory: {exc}",file=sys.stderr); return 2
     print(json.dumps(result,indent=2,sort_keys=True)); return 0

--- a/tools/coding_memory.py
+++ b/tools/coding_memory.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Import, query and freeze Chronik coding history without a network service."""
+from __future__ import annotations
+import argparse, json, sys
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path: sys.path.insert(0,str(ROOT))
+import coding_memory
+
+def load(path: Path):
+    text=path.read_text(encoding="utf-8").strip()
+    if not text: return []
+    if path.suffix==".jsonl": return [json.loads(line) for line in text.splitlines() if line.strip()]
+    value=json.loads(text); return value if isinstance(value,list) else [value]
+
+def filters(args):
+    return {"repo":args.repo,"component":args.component,"operation":args.operation,"outcome":args.outcome,"since":args.since,"limit":args.limit}
+
+def main(argv=None):
+    parser=argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-dir",default=str(Path.home()/".local/state/chronik"))
+    sub=parser.add_subparsers(dest="command",required=True)
+    imp=sub.add_parser("import"); imp.add_argument("input",type=Path)
+    for name in ("query","freeze"):
+        p=sub.add_parser(name); p.add_argument("--repo",required=True); p.add_argument("--component"); p.add_argument("--operation",choices=["implement","review","merge","deploy","runtime_verify","recovery"]); p.add_argument("--outcome",choices=["completed","blocked","failed","reverted","outcome_unknown","started"]); p.add_argument("--since"); p.add_argument("--limit",type=int,default=20)
+        if name=="freeze": p.add_argument("--output",required=True,type=Path)
+    args=parser.parse_args(argv)
+    try:
+        data_path = Path(args.data_dir).expanduser()
+        if args.command == "query" and not data_path.exists():
+            result = {
+                "schema_version": "chronik-coding-history.v1",
+                "query": filters(args),
+                "events": [],
+                "event_ids": [],
+                "historical_only": True,
+                "does_not_establish": coding_memory.DOES_NOT_ESTABLISH,
+            }
+            print(json.dumps(result,indent=2,sort_keys=True)); return 0
+        coding_memory.configure_data_dir(data_path, create=args.command in {"import", "freeze"})
+        if args.command=="import": result=coding_memory.import_events(load(args.input))
+        elif args.command=="query": result=coding_memory.query_history(**filters(args))
+        else: result=coding_memory.freeze_history(args.output,**filters(args))
+    except (OSError,ValueError) as exc:
+        print(f"chronik-coding-memory: {exc}",file=sys.stderr); return 2
+    print(json.dumps(result,indent=2,sort_keys=True)); return 0
+if __name__=="__main__": raise SystemExit(main())


### PR DESCRIPTION
## Scope

- share one canonical API/CLI Chronik envelope
- import `agent.run.*` events locally and idempotently by `event_id`
- query historical coding outcomes by repo, component, operation, outcome and time
- freeze exact JSONL cohorts with SHA-256-bound receipts
- extend the bounded event contract with explicit coding work context

## Boundaries

- historical only; does not establish current Git, CI or runtime state or safe retry
- no Plexer, Heimlern, Leitstand or long-running Chronik service required
- no raw logs, prompts, commands, secrets or full diffs

## Evidence

- full local validation: 268 tests passed
- local health/version/ingest/readback smoke passed
- end-to-end fixture: first import 1, identical retry skipped 1, frozen cohort exactly 1 event

Bureau: CCM-V1-T001