### PR TITLE
fix(ci): restore canonical WGX smoke

### DIFF
--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -1,42 +1,43 @@
-class: python-service
-tasks:
-  smoke: |
-    set -euxo pipefail
-    bash scripts/setup-venv.sh
-    . .venv/bin/activate
-    # Neuer Name (CHRONIK_TOKEN)
-    export CHRONIK_TOKEN="${CHRONIK_TOKEN:-dev}"
-    python3 - <<'PY'
-    from fastapi.testclient import TestClient
-    from app import app
-    from tools.hauski_ingest import ingest_event
+wgx:
+  apiVersion: v1
+  repoKind: python-service
+  tasks:
+    smoke: |
+      set -euxo pipefail
+      bash scripts/setup-venv.sh
+      . .venv/bin/activate
+      export CHRONIK_TOKEN="${CHRONIK_TOKEN:-dev}"
+      python3 - <<'PY'
+      from fastapi.testclient import TestClient
+      from app import app
+      from tools.hauski_ingest import ingest_event
 
-    # Use TestClient's transport for hermetic testing
-    client = TestClient(app)
+      # Use TestClient's transport for hermetic testing
+      client = TestClient(app)
 
-    result = ingest_event(
-        "example.com",
-        {"event": "test", "status": "ok"},
-        url="http://test",
-        transport=client._transport,
-    )
-    print(result)
-    PY
-  guard: |
-    set -euxo pipefail
-    bash scripts/setup-venv.sh
-    . .venv/bin/activate
-    export PYTHONPATH="${PYTHONPATH:-.}:."
-    python3 -m pytest
-  metrics: |
-    set -euxo pipefail
-    if [ -x scripts/wgx-metrics-snapshot.sh ]; then
-      scripts/wgx-metrics-snapshot.sh --json
-    else
-      echo "[wgx.metrics] scripts/wgx-metrics-snapshot.sh fehlt, übersprungen"
-    fi
-  snapshot: |
-    set -euxo pipefail
-    bash scripts/setup-venv.sh
-    . .venv/bin/activate
-    python3 -m pytest -q
+      result = ingest_event(
+          "example.com",
+          {"event": "test", "status": "ok"},
+          url="http://test",
+          transport=client._transport,
+      )
+      print(result)
+      PY
+    guard: |
+      set -euxo pipefail
+      bash scripts/setup-venv.sh
+      . .venv/bin/activate
+      export PYTHONPATH="${PYTHONPATH:-.}:."
+      python3 -m pytest
+    metrics: |
+      set -euxo pipefail
+      if [ -x scripts/wgx-metrics-snapshot.sh ]; then
+        scripts/wgx-metrics-snapshot.sh --json
+      else
+        echo "[wgx.metrics] scripts/wgx-metrics-snapshot.sh fehlt, übersprungen"
+      fi
+    snapshot: |
+      set -euxo pipefail
+      bash scripts/setup-venv.sh
+      . .venv/bin/activate
+      python3 -m pytest -q

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -61,6 +61,23 @@ def test_query_cli_missing_data_dir_is_read_only(tmp_path):
     assert json.loads(result.stdout)["events"] == []
 
 
+def test_query_cli_prefers_repository_module_when_pythonpath_contains_root(tmp_path):
+    import os, subprocess, sys
+    root = Path(__file__).parents[1]
+    missing = tmp_path / "missing"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(root)
+    result = subprocess.run(
+        [sys.executable, str(root / "tools" / "coding_memory.py"), "--data-dir", str(missing), "query", "--repo", "heimgewebe/example"],
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["events"] == []
+    assert not missing.exists()
+
+
 def test_query_cli_validates_filters_without_creating_data_dir(tmp_path):
     import subprocess, sys
     missing = tmp_path / "missing"

--- a/tools/coding_memory.py
+++ b/tools/coding_memory.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 import argparse, json, sys
 from pathlib import Path
 ROOT=Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path: sys.path.insert(0,str(ROOT))
+root_path=str(ROOT)
+if root_path in sys.path: sys.path.remove(root_path)
+sys.path.insert(0,root_path)
 import coding_memory
 
 def load(path: Path):


### PR DESCRIPTION
## Zweck

Schließt `CHRONIK-ECOSYSTEM-CLOSEOUT-V1-T004`: Der wiederverwendbare WGX-Smoke scheiterte dauerhaft, weil der gepinnte WGX-Parser Python-Tokens innerhalb eines vollständig ANSI-C-quotierten Taskwerts als unsicheren Rohcode fehlklassifizierte.

## Systemischer Fix

- WGX PR #640 validiert parsergenerierte Zuweisungen zuerst strukturell und hält Expansionen, Command Substitution, verkettete Shell-Wörter und fehlerhafte Quotes gesperrt.
- WGX PR #641 bindet den wiederverwendbaren Smoke unveränderlich an den gemergten Parserfix `3c2391623a1719ac5f0dd1cda6ba906b94079053`.

## Chronik-Änderungen

- `.wgx/profile.yml` auf die kanonische `wgx.apiVersion`-/`repoKind`-/`tasks`-Struktur migriert; Taskbefehle inhaltlich unverändert.
- `tools/coding_memory.py` priorisiert das Repositorymodul auch dann sicher, wenn `PYTHONPATH` den Repositorypfad bereits enthält. Dadurch importiert das CLI nicht mehr versehentlich sich selbst aus `tools/`.
- Regressionstest für genau diesen Modulschattenfall ergänzt.

## Prüfung

- `WGX_PROFILE_DEPRECATION=error wgx validate --json`: PASS
- maschinenlesbare Taskliste: PASS
- realer WGX-Smoke: PASS
- Coding-Memory-Fokustests: 8/8 bestanden
- vollständiger WGX-Guard: 272 Tests bestanden
- `git diff --check`: PASS

## Grenzen

Die bestehende Starlette-Testclient-Abkündigungswarnung bleibt unverändert. Der PR schwächt keine WGX-Sicherheitsprüfung und verändert keine Chronik-Runtimekonfiguration.