### PR TITLE
Preserve scoped operator target identity

### DIFF
--- a/docs/chronik/agent-run-event-v0.schema.json
+++ b/docs/chronik/agent-run-event-v0.schema.json
@@ -64,9 +64,7 @@
     "subject": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "repo"
-      ],
+      "required": [],
       "properties": {
         "repo": {
           "type": "string",
@@ -106,8 +104,32 @@
         "pr_number": {
           "type": "integer",
           "minimum": 1
+        },
+        "scope": {
+          "enum": [
+            "repository",
+            "host"
+          ]
+        },
+        "host": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
         }
-      }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "repo"
+          ]
+        },
+        {
+          "required": [
+            "scope",
+            "host"
+          ]
+        }
+      ]
     },
     "trust_tier": {
       "enum": [
@@ -183,6 +205,30 @@
             "reverted",
             "outcome_unknown"
           ]
+        },
+        "operation": {
+          "enum": [
+            "implement",
+            "review",
+            "merge",
+            "deploy",
+            "runtime_verify",
+            "recovery",
+            "other"
+          ]
+        },
+        "task_class": {
+          "enum": [
+            "coding",
+            "review",
+            "merge",
+            "deploy",
+            "runtime_verify",
+            "recovery",
+            "maintenance",
+            "diagnostic",
+            "other"
+          ]
         }
       }
     }
@@ -200,6 +246,87 @@
         "required": [
           "corrects"
         ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "subject": {
+            "properties": {
+              "scope": {
+                "const": "repository"
+              }
+            },
+            "required": [
+              "scope"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "subject": {
+            "required": [
+              "repo"
+            ],
+            "not": {
+              "required": [
+                "host"
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "subject": {
+            "properties": {
+              "scope": {
+                "const": "host"
+              }
+            },
+            "required": [
+              "scope"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "subject": {
+            "required": [
+              "host"
+            ],
+            "not": {
+              "required": [
+                "repo"
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "subject": {
+            "required": [
+              "scope"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "data": {
+            "required": [
+              "operation",
+              "task_class"
+            ]
+          }
+        }
       }
     }
   ],

--- a/tests/test_grabowski_outbox_import.py
+++ b/tests/test_grabowski_outbox_import.py
@@ -168,3 +168,35 @@ def test_import_outbox_cli_returns_nonzero_on_any_invalid_source(tmp_path):
 
     assert result.returncode == 2
     assert json.loads(result.stdout)["errors"]
+
+
+def test_import_preserves_repository_target_identity(tmp_path, monkeypatch):
+    data, receipts, outbox = configure(tmp_path, monkeypatch)
+    value = event("agent.run.completed", "d")
+    value["subject"] = {"scope": "repository", "repo": "heimgewebe/chronik", "branch": "fix/target"}
+    value["data"].update({"operation": "implement", "task_class": "coding"})
+    write_outbox(outbox, [value])
+
+    result = coding_memory.import_grabowski_outbox(outbox_root=outbox, receipt_dir=receipts)
+    history = coding_memory.query_history(repo="heimgewebe/chronik")
+
+    assert result["errors"] == []
+    assert result["events_imported"] == 1
+    assert history["events"][0]["subject"] == value["subject"]
+    assert history["events"][0]["data"]["operation"] == "implement"
+    assert history["events"][0]["data"]["task_class"] == "coding"
+
+
+def test_import_preserves_host_scope_without_fabricated_repo(tmp_path, monkeypatch):
+    data, receipts, outbox = configure(tmp_path, monkeypatch)
+    value = event("agent.run.blocked", "e")
+    value["subject"] = {"scope": "host", "host": "heim-pc"}
+    value["data"].update({"operation": "recovery", "task_class": "recovery"})
+    write_outbox(outbox, [value])
+
+    result = coding_memory.import_grabowski_outbox(outbox_root=outbox, receipt_dir=receipts)
+
+    assert result["errors"] == []
+    row = json.loads((data / "agent.ledger.jsonl").read_text().splitlines()[0])
+    assert row["payload"]["subject"] == {"scope": "host", "host": "heim-pc"}
+    assert "repo" not in row["payload"]["subject"]


### PR DESCRIPTION
## Zweck

Bureau T005 Consumer-Vertrag: Grabowski-Ereignisse können ein echtes Repository oder einen expliziten Host als Gegenstand tragen.

## Änderungen

- rückwärtskompatible `subject.scope`-Achse für `repository` und `host`
- host-scoped Events benötigen keinen erfundenen Repo-Wert
- bounded `operation` und `task_class` für neue scoped Events
- Importtests belegen unveränderte Persistenz beider Gegenstandsarten

## Prüfungen

- `pytest -q`: 282 passed
- `git diff --check`: PASS

## Grenze

Alte Events mit nur `subject.repo` bleiben gültig. Der Producer-Nachlauf liegt separat in Grabowski.