### PR TITLE
Bind operator memory to targets and ledger evidence

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -1,4 +1,4 @@
-"""Local, idempotent coding-history import and frozen query receipts."""
+"""Local, idempotent coding-history import and evidence-bound queries."""
 from __future__ import annotations
 
 import hashlib
@@ -7,6 +7,7 @@ import os
 import tempfile
 from collections import Counter
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -21,6 +22,10 @@ DOES_NOT_ESTABLISH = ["current_git_state", "current_ci_state", "current_runtime_
 GRABOWSKI_SOURCE_REPO = "heimgewebe/grabowski"
 GRABOWSKI_COMPONENT = "grabowski"
 HIGH_VALUE_KINDS = frozenset({"agent.run.started", "agent.run.completed", "agent.run.blocked"})
+OPERATIONS = frozenset({"implement", "review", "merge", "deploy", "runtime_verify", "recovery", "other"})
+TASK_CLASSES = frozenset({"coding", "review", "merge", "deploy", "runtime_verify", "recovery", "maintenance", "diagnostic", "other"})
+OUTCOMES = frozenset({"started", "completed", "blocked", "failed", "reverted", "outcome_unknown"})
+MAX_INTEGRITY_DIAGNOSTICS = 20
 
 
 def canonical_bytes(value: Any) -> bytes:
@@ -56,6 +61,7 @@ def configure_data_dir(path: Path, *, create: bool) -> Path:
     return resolved
 
 
+@lru_cache(maxsize=1)
 def _validator() -> Draft7Validator:
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     Draft7Validator.check_schema(schema)
@@ -195,42 +201,111 @@ def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str
     }
 
 
-def _records() -> list[dict[str, Any]]:
+def _record_snapshot() -> tuple[list[dict[str, Any]], dict[str, Any]]:
     rows: list[dict[str, Any]] = []
-    for _, _, line in storage.scan_domain(DOMAIN):
+    diagnostics: list[dict[str, Any]] = []
+    invalid_record_count = 0
+    total_record_count = 0
+    complete_bytes = 0
+    snapshot = hashlib.sha256()
+
+    for start_offset, next_offset, line in storage.scan_domain(DOMAIN):
+        encoded = line.encode("utf-8") + b"\n"
+        snapshot.update(encoded)
+        complete_bytes = next_offset
+        if not line.strip():
+            continue
+        total_record_count += 1
         try:
             envelope = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        payload = envelope.get("payload") if isinstance(envelope, dict) else None
-        if not isinstance(payload, dict):
-            continue
-        try:
+            if not isinstance(envelope, dict):
+                raise ValueError("envelope must be an object")
+            payload = envelope.get("payload")
+            if not isinstance(payload, dict):
+                raise ValueError("payload must be an object")
             validate_event(payload)
-        except ValueError:
+        except (json.JSONDecodeError, ValueError) as exc:
+            invalid_record_count += 1
+            if len(diagnostics) < MAX_INTEGRITY_DIAGNOSTICS:
+                diagnostics.append({"offset": start_offset, "error": str(exc)})
             continue
         rows.append({"received_at": envelope.get("received_at"), "payload": payload})
-    return rows
+
+    ledger_snapshot = {
+        "domain": DOMAIN,
+        "sha256": snapshot.hexdigest(),
+        "complete_bytes": complete_bytes,
+        "total_record_count": total_record_count,
+        "valid_record_count": len(rows),
+        "invalid_record_count": invalid_record_count,
+        "integrity_valid": invalid_record_count == 0,
+        "diagnostics": diagnostics,
+        "diagnostics_truncated": invalid_record_count > len(diagnostics),
+    }
+    return rows, ledger_snapshot
 
 
-def validate_query(*, repo: str, component: str | None = None, operation: str | None = None, outcome: str | None = None, since: str | None = None, limit: int = 20) -> datetime | None:
-    if not repo or limit < 1 or limit > 500:
-        raise ValueError("repo and limit 1..500 are required")
+def _event_operation(event: dict[str, Any]) -> str | None:
+    data = event.get("data")
+    subject = event.get("subject")
+    if isinstance(data, dict) and data.get("operation"):
+        return data["operation"]
+    if isinstance(subject, dict):
+        return subject.get("operation")
+    return None
+
+
+def _event_task_class(event: dict[str, Any]) -> str | None:
+    data = event.get("data")
+    return data.get("task_class") if isinstance(data, dict) else None
+
+
+def _target(*, repo: str | None, host: str | None) -> dict[str, str]:
+    if repo is not None:
+        return {"scope": "repository", "repo": repo}
+    assert host is not None
+    return {"scope": "host", "host": host}
+
+
+def _matches_target(subject: dict[str, Any], *, repo: str | None, host: str | None) -> bool:
+    if repo is not None:
+        return subject.get("scope") != "host" and subject.get("repo") == repo
+    return subject.get("scope") == "host" and subject.get("host") == host
+
+
+def validate_query(*, repo: str | None = None, host: str | None = None, component: str | None = None, operation: str | None = None, task_class: str | None = None, outcome: str | None = None, since: str | None = None, limit: int = 20) -> datetime | None:
+    if (repo is None) == (host is None):
+        raise ValueError("exactly one of repo or host is required")
+    if repo is not None and not repo.strip():
+        raise ValueError("repo must not be empty")
+    if host is not None and not host.strip():
+        raise ValueError("host must not be empty")
+    if limit < 1 or limit > 500:
+        raise ValueError("limit 1..500 is required")
+    if operation is not None and operation not in OPERATIONS:
+        raise ValueError(f"unsupported operation: {operation}")
+    if task_class is not None and task_class not in TASK_CLASSES:
+        raise ValueError(f"unsupported task_class: {task_class}")
+    if outcome is not None and outcome not in OUTCOMES:
+        raise ValueError(f"unsupported outcome: {outcome}")
     return _parse_timestamp(since, field="since") if since is not None else None
 
 
-def query_history(*, repo: str, component: str | None = None, operation: str | None = None, outcome: str | None = None, since: str | None = None, limit: int = 20) -> dict[str, Any]:
-    since_at = validate_query(repo=repo, component=component, operation=operation, outcome=outcome, since=since, limit=limit)
+def query_history(*, repo: str | None = None, host: str | None = None, component: str | None = None, operation: str | None = None, task_class: str | None = None, outcome: str | None = None, since: str | None = None, limit: int = 20) -> dict[str, Any]:
+    since_at = validate_query(repo=repo, host=host, component=component, operation=operation, task_class=task_class, outcome=outcome, since=since, limit=limit)
+    rows, ledger_snapshot = _record_snapshot()
     selected: list[dict[str, Any]] = []
-    for row in _records():
+    for row in rows:
         event = row["payload"]
         subject = event["subject"]
         data = event.get("data", {})
-        if subject.get("repo") != repo:
+        if not _matches_target(subject, repo=repo, host=host):
             continue
         if component and subject.get("component") != component:
             continue
-        if operation and subject.get("operation") != operation:
+        if operation and _event_operation(event) != operation:
+            continue
+        if task_class and _event_task_class(event) != task_class:
             continue
         actual_outcome = data.get("outcome") or data.get("result")
         if outcome and actual_outcome != outcome:
@@ -241,12 +316,14 @@ def query_history(*, repo: str, component: str | None = None, operation: str | N
         selected.append({**row, "event_at": event_at})
     selected.sort(key=lambda row: (row["event_at"], row["payload"]["event_id"]), reverse=True)
     selected = selected[:limit]
-    query = {"repo": repo, "component": component, "operation": operation, "outcome": outcome, "since": since, "limit": limit}
+    query = {"repo": repo, "host": host, "component": component, "operation": operation, "task_class": task_class, "outcome": outcome, "since": since, "limit": limit}
     return {
         "schema_version": "chronik-coding-history.v1",
         "query": query,
+        "target": _target(repo=repo, host=host),
         "events": [row["payload"] for row in selected],
         "event_ids": [row["payload"]["event_id"] for row in selected],
+        "ledger_snapshot": ledger_snapshot,
         "historical_only": True,
         "does_not_establish": DOES_NOT_ESTABLISH,
     }
@@ -256,8 +333,9 @@ def operator_summary(*, since: str | None = None, limit: int = 20) -> dict[str, 
     if limit < 1 or limit > 500:
         raise ValueError("limit 1..500 is required")
     since_at = _parse_timestamp(since, field="since") if since is not None else None
+    rows, ledger_snapshot = _record_snapshot()
     selected: list[tuple[datetime, dict[str, Any]]] = []
-    for row in _records():
+    for row in rows:
         event = row["payload"]
         event_at = _parse_timestamp(event["ts"], field="ts")
         if since_at is not None and event_at < since_at:
@@ -266,6 +344,22 @@ def operator_summary(*, since: str | None = None, limit: int = 20) -> dict[str, 
     selected.sort(key=lambda item: (item[0], item[1]["event_id"]), reverse=True)
     kind_counts = Counter(event["kind"] for _, event in selected)
     repo_counts = Counter(event.get("subject", {}).get("repo", "unknown") for _, event in selected)
+    host_counts = Counter(
+        event.get("subject", {}).get("host")
+        for _, event in selected
+        if event.get("subject", {}).get("scope") == "host" and event.get("subject", {}).get("host")
+    )
+    target_counts = Counter()
+    operation_counts = Counter()
+    task_class_counts = Counter()
+    for _, event in selected:
+        subject = event.get("subject", {})
+        if subject.get("scope") == "host":
+            target_counts[f"host:{subject.get('host', 'unknown')}"] += 1
+        else:
+            target_counts[f"repository:{subject.get('repo', 'unknown')}"] += 1
+        operation_counts[_event_operation(event) or "unspecified"] += 1
+        task_class_counts[_event_task_class(event) or "unspecified"] += 1
     blocker_counts = Counter(
         event.get("data", {}).get("blocker_code", "unspecified")
         for _, event in selected
@@ -273,13 +367,17 @@ def operator_summary(*, since: str | None = None, limit: int = 20) -> dict[str, 
     )
     recent = []
     for _, event in selected[:limit]:
+        subject = event.get("subject", {})
         recent.append(
             {
                 "event_id": event["event_id"],
                 "ts": event["ts"],
                 "kind": event["kind"],
                 "run_id": event.get("source", {}).get("run_id"),
-                "subject": event.get("subject", {}),
+                "target": {"scope": "host", "host": subject.get("host")} if subject.get("scope") == "host" else {"scope": "repository", "repo": subject.get("repo")},
+                "subject": subject,
+                "operation": _event_operation(event),
+                "task_class": _event_task_class(event),
                 "data": event.get("data", {}),
             }
         )
@@ -287,10 +385,16 @@ def operator_summary(*, since: str | None = None, limit: int = 20) -> dict[str, 
         "schema_version": "chronik-operator-summary.v1",
         "since": since,
         "event_count": len(selected),
+        "limit": limit,
         "counts_by_kind": dict(sorted(kind_counts.items())),
         "counts_by_subject_repo": dict(sorted(repo_counts.items())),
+        "counts_by_subject_host": dict(sorted(host_counts.items())),
+        "counts_by_target": dict(sorted(target_counts.items())),
+        "counts_by_operation": dict(sorted(operation_counts.items())),
+        "counts_by_task_class": dict(sorted(task_class_counts.items())),
         "blocked_by_code": dict(sorted(blocker_counts.items())),
         "recent": recent,
+        "ledger_snapshot": ledger_snapshot,
         "historical_only": True,
         "does_not_establish": DOES_NOT_ESTABLISH,
     }
@@ -313,17 +417,23 @@ def _atomic_write(path: Path, data: bytes) -> None:
 
 def freeze_history(output: Path, **filters: Any) -> dict[str, Any]:
     history = query_history(**filters)
+    ledger_snapshot = history["ledger_snapshot"]
+    if not ledger_snapshot["integrity_valid"]:
+        raise ValueError("cannot freeze history from a ledger with invalid records")
     body = b"".join(canonical_bytes(event) + b"\n" for event in history["events"])
     _atomic_write(output, body)
     receipt = {
         "schema_version": "chronik-history-cohort-receipt.v1",
         "domain": DOMAIN,
         "query": history["query"],
+        "target": history["target"],
         "event_ids": history["event_ids"],
         "event_count": len(history["event_ids"]),
         "cohort_path": str(output),
         "cohort_sha256": sha256_bytes(body),
         "query_sha256": sha256_bytes(canonical_bytes(history["query"])),
+        "ledger_snapshot_sha256": ledger_snapshot["sha256"],
+        "ledger_snapshot_complete_bytes": ledger_snapshot["complete_bytes"],
         "generated_at": utc_now(),
         "redaction_contract": "agent-run-event.v0 allow-list",
         "historical_only": True,

--- a/docs/chronik/direct-operator-memory-v1.md
+++ b/docs/chronik/direct-operator-memory-v1.md
@@ -8,11 +8,13 @@ Chronik übernimmt ausgewählte Grabowski-Laufereignisse direkt aus der lokalen
 Outbox. Plexer ist für diesen Pfad weder erforderlich noch autoritativ. Chronik
 bleibt ein append-only historischer Speicher und löst keine Aufgaben aus.
 
-Der Pfad beantwortet zunächst drei belastbare Fragen:
+Der Pfad beantwortet belastbar:
 
-1. Welche Agentenläufe wurden gestartet?
-2. Welche Agentenläufe wurden abgeschlossen?
-3. Welche Agentenläufe wurden blockiert und mit welchem Blocker-Code?
+1. Welche Agentenläufe wurden gestartet, abgeschlossen oder blockiert?
+2. Welches Repository oder welcher Host war das Ziel?
+3. Welche Operation und Aufgabenklasse wurde protokolliert?
+4. Welche Blocker-Codes und Ergebnisse traten auf?
+5. Auf welchem vollständigen Ledger-Snapshot beruht die Antwort?
 
 ## Datenfluss
 
@@ -33,6 +35,18 @@ Der Import akzeptiert nur Ereignisse mit:
   `agent.run.blocked`
 - gültigem `agent-run-event.v0`-Vertrag
 
+## Zielidentität
+
+Abfragen sind an genau ein Ziel gebunden:
+
+- Repository: `--repo heimgewebe/chronik`
+- Host: `--host heim-pc`
+
+Legacy-Ereignisse ohne explizites `subject.scope` bleiben als
+Repository-Ereignisse lesbar. Für die Operation gilt `data.operation` als
+kanonisches Feld; `subject.operation` bleibt nur als Rückwärtskompatibilität.
+`data.task_class` kann zusätzlich mit `--task-class` gefiltert werden.
+
 ## Sicherheits- und Wahrheitsmodell
 
 - Der Quellpfad wird nur gelesen.
@@ -44,8 +58,14 @@ Der Import akzeptiert nur Ereignisse mit:
 - Wächst eine Outbox-Datei, wird ihr neuer Hash erkannt; bereits vorhandene
   Ereignisse werden übersprungen, neue Ereignisse werden ergänzt.
 - Eine unvollständige letzte JSONL-Zeile, ungültiges JSON, Vertragsdrift oder ein
-  fremder Producer führt für die betroffene Datei zu einem Fehler ohne
+  fremder Producer führt für die betroffene Quelldatei zu einem Fehler ohne
   Importbeleg.
+- Jede Abfrage liefert `ledger_snapshot` mit SHA-256, vollständiger Bytegrenze,
+  gültigen und ungültigen Datensätzen sowie begrenzten Diagnosen.
+- Historische Abfragen bleiben bei beschädigten Datensätzen lesbar, weisen den
+  Zustand aber mit `integrity_valid = false` aus. Eine eingefrorene Kohorte wird
+  in diesem Zustand verweigert, damit kein scheinbar vollständiger Beleg aus
+  unvollständiger Evidenz entsteht.
 - Historische Abfragen beweisen keinen aktuellen Git-, CI- oder Runtime-Zustand
   und autorisieren keinen Retry.
 
@@ -59,12 +79,22 @@ python tools/coding_memory.py \
   summary --since 2026-07-14T00:00:00Z --limit 20
 ```
 
-Gefilterte Historie:
+Repository-Historie:
 
 ```bash
 python tools/coding_memory.py \
   --data-dir ~/.local/state/chronik/data \
-  query --repo heimgewebe/grabowski --outcome blocked
+  query --repo heimgewebe/chronik \
+  --operation implement --task-class coding --outcome completed
+```
+
+Host-Historie:
+
+```bash
+python tools/coding_memory.py \
+  --data-dir ~/.local/state/chronik/data \
+  query --host heim-pc \
+  --operation recovery --task-class recovery --outcome blocked
 ```
 
 Hash-gebundene Kohorte:
@@ -72,9 +102,12 @@ Hash-gebundene Kohorte:
 ```bash
 python tools/coding_memory.py \
   --data-dir ~/.local/state/chronik/data \
-  freeze --repo heimgewebe/grabowski \
-  --output /tmp/grabowski-history.jsonl
+  freeze --repo heimgewebe/chronik \
+  --output /tmp/chronik-history.jsonl
 ```
+
+Der Receipt bindet die Kohorte sowohl an die Filter als auch an den SHA-256 des
+vollständig gelesenen Ledger-Snapshots.
 
 ## User-Service
 
@@ -86,10 +119,9 @@ Der HTTP-Dienst `chronik.service` ist für diesen Pfad nicht erforderlich. Er
 soll nur aktiviert werden, wenn ein konkreter externer Konsument den HTTP-Ingest
 oder die HTTP-Abfrage benötigt.
 
-## Bekannte Grenze
+## Grenzen
 
-Bestehende Grabowski-Ereignisse tragen derzeit überwiegend
-`subject.repo = heimgewebe/grabowski`. Damit ist die Laufhistorie belastbar,
-das tatsächlich bearbeitete Zielrepository aber noch nicht immer ableitbar.
-Die Producer-Korrektur gehört in Grabowski und muss getrennt von laufenden
-Sicherheitsarbeiten umgesetzt und deployed werden.
+Chronik bleibt historische Evidenz. `summary`, `query` und `freeze` treffen
+keine Aussage darüber, ob ein Repository, Dienst, Task oder Deployment jetzt
+noch denselben Zustand besitzt. Sie ersetzen weder Bureau-Wahrheit noch frische
+Git-, CI-, Runtime- oder Recovery-Prüfungen.

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -85,3 +85,55 @@ def test_query_cli_validates_filters_without_creating_data_dir(tmp_path):
     assert result.returncode == 2
     assert "limit 1..500" in result.stderr
     assert not missing.exists()
+
+
+def test_query_prefers_canonical_data_operation_and_filters_task_class(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); value=event(); value["subject"]["operation"]="review"
+    value["data"].update({"operation":"implement","task_class":"coding"}); coding_memory.import_events([value])
+    result=coding_memory.query_history(repo="heimgewebe/example",operation="implement",task_class="coding")
+    assert result["event_ids"]==[value["event_id"]]
+    assert coding_memory.query_history(repo="heimgewebe/example",operation="review")["event_ids"]==[]
+
+
+def test_query_supports_host_target_and_summary_dimensions(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); value=event("sha256:"+"c"*64,operation="recovery",outcome="blocked")
+    value["kind"]="agent.run.blocked"; value["subject"]={"scope":"host","host":"heim-pc"}
+    value["data"].update({"result":"blocked","operation":"recovery","task_class":"recovery","blocker_code":"recovery-gate"})
+    coding_memory.import_events([value])
+    result=coding_memory.query_history(host="heim-pc",operation="recovery",task_class="recovery",outcome="blocked")
+    summary=coding_memory.operator_summary()
+    assert result["target"]=={"scope":"host","host":"heim-pc"} and result["event_ids"]==[value["event_id"]]
+    assert summary["counts_by_target"]=={"host:heim-pc":1}
+    assert summary["counts_by_operation"]=={"recovery":1} and summary["counts_by_task_class"]=={"recovery":1}
+
+
+def test_query_requires_exactly_one_target():
+    with pytest.raises(ValueError,match="exactly one"): coding_memory.validate_query()
+    with pytest.raises(ValueError,match="exactly one"): coding_memory.validate_query(repo="heimgewebe/example",host="heim-pc")
+
+
+def test_query_binds_snapshot_and_freeze_rejects_invalid_ledger(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); coding_memory.import_events([event()]); target=tmp_path/"agent.ledger.jsonl"
+    result=coding_memory.query_history(repo="heimgewebe/example")
+    assert result["ledger_snapshot"]["sha256"]==hashlib.sha256(target.read_bytes()).hexdigest()
+    assert result["ledger_snapshot"]["integrity_valid"] is True
+    with target.open("ab") as handle: handle.write(b"not-json\n")
+    degraded=coding_memory.query_history(repo="heimgewebe/example")
+    assert degraded["event_ids"]==[event()["event_id"]] and degraded["ledger_snapshot"]["invalid_record_count"]==1
+    with pytest.raises(ValueError,match="invalid records"): coding_memory.freeze_history(tmp_path/"bad.jsonl",repo="heimgewebe/example")
+
+
+def test_additive_query_contracts_keep_v1_schema_ids(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); coding_memory.import_events([event()]); output=tmp_path/"cohort.jsonl"
+    assert coding_memory.query_history(repo="heimgewebe/example")["schema_version"]=="chronik-coding-history.v1"
+    assert coding_memory.operator_summary()["schema_version"]=="chronik-operator-summary.v1"
+    assert coding_memory.freeze_history(output,repo="heimgewebe/example")["schema_version"]=="chronik-history-cohort-receipt.v1"
+
+
+def test_query_cli_supports_host_target_without_creating_data_dir(tmp_path):
+    import subprocess, sys
+    missing=tmp_path/"missing"
+    result=subprocess.run([sys.executable,str(Path(__file__).parents[1]/"tools"/"coding_memory.py"),"--data-dir",str(missing),"query","--host","heim-pc","--task-class","recovery"],text=True,capture_output=True)
+    assert result.returncode==0,result.stderr
+    assert json.loads(result.stdout)["target"]=={"scope":"host","host":"heim-pc"}
+    assert not missing.exists()

--- a/tools/coding_memory.py
+++ b/tools/coding_memory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -29,20 +30,43 @@ def load(path: Path):
 def filters(args):
     return {
         "repo": args.repo,
+        "host": args.host,
         "component": args.component,
         "operation": args.operation,
+        "task_class": args.task_class,
         "outcome": args.outcome,
         "since": args.since,
         "limit": args.limit,
     }
 
 
+def empty_snapshot():
+    return {
+        "domain": coding_memory.DOMAIN,
+        "sha256": hashlib.sha256(b"").hexdigest(),
+        "complete_bytes": 0,
+        "total_record_count": 0,
+        "valid_record_count": 0,
+        "invalid_record_count": 0,
+        "integrity_valid": True,
+        "diagnostics": [],
+        "diagnostics_truncated": False,
+    }
+
+
 def empty_query(query_filters):
+    target = (
+        {"scope": "repository", "repo": query_filters["repo"]}
+        if query_filters["repo"] is not None
+        else {"scope": "host", "host": query_filters["host"]}
+    )
     return {
         "schema_version": "chronik-coding-history.v1",
         "query": query_filters,
+        "target": target,
         "events": [],
         "event_ids": [],
+        "ledger_snapshot": empty_snapshot(),
         "historical_only": True,
         "does_not_establish": coding_memory.DOES_NOT_ESTABLISH,
     }
@@ -55,9 +79,14 @@ def empty_summary(since, limit):
         "event_count": 0,
         "counts_by_kind": {},
         "counts_by_subject_repo": {},
+        "counts_by_subject_host": {},
+        "counts_by_target": {},
+        "counts_by_operation": {},
+        "counts_by_task_class": {},
         "blocked_by_code": {},
         "recent": [],
         "limit": limit,
+        "ledger_snapshot": empty_snapshot(),
         "historical_only": True,
         "does_not_establish": coding_memory.DOES_NOT_ESTABLISH,
     }
@@ -81,10 +110,13 @@ def main(argv=None):
 
     for name in ("query", "freeze"):
         command = sub.add_parser(name)
-        command.add_argument("--repo", required=True)
+        target = command.add_mutually_exclusive_group(required=True)
+        target.add_argument("--repo")
+        target.add_argument("--host")
         command.add_argument("--component")
-        command.add_argument("--operation", choices=["implement", "review", "merge", "deploy", "runtime_verify", "recovery"])
-        command.add_argument("--outcome", choices=["completed", "blocked", "failed", "reverted", "outcome_unknown", "started"])
+        command.add_argument("--operation", choices=sorted(coding_memory.OPERATIONS))
+        command.add_argument("--task-class", choices=sorted(coding_memory.TASK_CLASSES))
+        command.add_argument("--outcome", choices=sorted(coding_memory.OUTCOMES))
         command.add_argument("--since")
         command.add_argument("--limit", type=int, default=20)
         if name == "freeze":
@@ -122,7 +154,7 @@ def main(argv=None):
                 result = coding_memory.operator_summary(since=args.since, limit=args.limit)
             else:
                 result = coding_memory.freeze_history(args.output, **query_filters)
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, coding_memory.storage.StorageError) as exc:
         print(f"chronik-coding-memory: {exc}", file=sys.stderr)
         return 2
 


### PR DESCRIPTION
## Zweck
Chronik-Abfragen werden an Repository- oder Hostziele gebunden und liefern einen Integritätsnachweis des vollständig gelesenen Ledger-Snapshots.

## Änderung
- `query`/`freeze`: genau ein Ziel per `--repo` oder `--host`
- Filter für kanonische `data.operation` und `data.task_class`
- Summary-Dimensionen für Ziel, Host, Operation und Aufgabenklasse
- SHA-256, Bytegrenze und Integritätsdiagnosen für Abfragen
- `freeze` verweigert Belege bei ungültigen Ledger-Datensätzen
- additive Erweiterung bei unveränderten v1-Schema-IDs

## Prüfung
- `./scripts/validate-local.sh`: PASS
- 288 Tests: PASS
- Rollenvertrag: PASS
- `git diff --check`: PASS

## Grenzen
Historische Evidenz beweist weiterhin keinen aktuellen Git-, CI-, Runtime- oder Recovery-Zustand.