### PR TITLE
Bind ledger snapshots to raw complete bytes

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -206,17 +206,20 @@ def _record_snapshot() -> tuple[list[dict[str, Any]], dict[str, Any]]:
     diagnostics: list[dict[str, Any]] = []
     invalid_record_count = 0
     total_record_count = 0
-    complete_bytes = 0
-    snapshot = hashlib.sha256()
+    raw_snapshot = storage.read_domain_snapshot(DOMAIN)
+    complete_bytes = len(raw_snapshot)
+    snapshot_sha256 = sha256_bytes(raw_snapshot)
+    start_offset = 0
 
-    for start_offset, next_offset, line in storage.scan_domain(DOMAIN):
-        encoded = line.encode("utf-8") + b"\n"
-        snapshot.update(encoded)
-        complete_bytes = next_offset
-        if not line.strip():
+    for raw_line in raw_snapshot.splitlines(keepends=True):
+        next_offset = start_offset + len(raw_line)
+        content = raw_line[:-1]
+        if not content.strip():
+            start_offset = next_offset
             continue
         total_record_count += 1
         try:
+            line = content.decode("utf-8")
             envelope = json.loads(line)
             if not isinstance(envelope, dict):
                 raise ValueError("envelope must be an object")
@@ -224,16 +227,22 @@ def _record_snapshot() -> tuple[list[dict[str, Any]], dict[str, Any]]:
             if not isinstance(payload, dict):
                 raise ValueError("payload must be an object")
             validate_event(payload)
-        except (json.JSONDecodeError, ValueError) as exc:
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
             invalid_record_count += 1
             if len(diagnostics) < MAX_INTEGRITY_DIAGNOSTICS:
-                diagnostics.append({"offset": start_offset, "error": str(exc)})
+                diagnostics.append({
+                    "offset": start_offset,
+                    "next_offset": next_offset,
+                    "error": str(exc),
+                })
+            start_offset = next_offset
             continue
         rows.append({"received_at": envelope.get("received_at"), "payload": payload})
+        start_offset = next_offset
 
     ledger_snapshot = {
         "domain": DOMAIN,
-        "sha256": snapshot.hexdigest(),
+        "sha256": snapshot_sha256,
         "complete_bytes": complete_bytes,
         "total_record_count": total_record_count,
         "valid_record_count": len(rows),

--- a/coding_memory.py
+++ b/coding_memory.py
@@ -211,9 +211,9 @@ def _record_snapshot() -> tuple[list[dict[str, Any]], dict[str, Any]]:
     snapshot_sha256 = sha256_bytes(raw_snapshot)
     start_offset = 0
 
-    for raw_line in raw_snapshot.splitlines(keepends=True):
-        next_offset = start_offset + len(raw_line)
-        content = raw_line[:-1]
+    complete_lines = raw_snapshot.split(b"\n")[:-1] if raw_snapshot else []
+    for content in complete_lines:
+        next_offset = start_offset + len(content) + 1
         if not content.strip():
             start_offset = next_offset
             continue

--- a/docs/chronik/direct-operator-memory-v1.md
+++ b/docs/chronik/direct-operator-memory-v1.md
@@ -60,8 +60,11 @@ kanonisches Feld; `subject.operation` bleibt nur als Rückwärtskompatibilität.
 - Eine unvollständige letzte JSONL-Zeile, ungültiges JSON, Vertragsdrift oder ein
   fremder Producer führt für die betroffene Quelldatei zu einem Fehler ohne
   Importbeleg.
-- Jede Abfrage liefert `ledger_snapshot` mit SHA-256, vollständiger Bytegrenze,
-  gültigen und ungültigen Datensätzen sowie begrenzten Diagnosen.
+- Jede Abfrage liest einen einzelnen, an der letzten vollständigen JSONL-Zeile
+  begrenzten Rohbyte-Snapshot. SHA-256, Bytegrenze, Parsing und Diagnosen werden
+  ausschließlich aus diesem unveränderlichen Snapshot abgeleitet. Ungültiges
+  UTF-8 bleibt dadurch bytegenau unterscheidbar und wird als ungültiger Datensatz
+  ausgewiesen.
 - Historische Abfragen bleiben bei beschädigten Datensätzen lesbar, weisen den
   Zustand aber mit `integrity_valid = false` aus. Eine eingefrorene Kohorte wird
   in diesem Zustand verweigert, damit kein scheinbar vollständiger Beleg aus

--- a/storage.py
+++ b/storage.py
@@ -29,6 +29,7 @@ __all__ = [
     "write_payload_unique",
     "read_tail",
     "read_last_line",
+    "read_domain_snapshot",
     "scan_domain",
     "list_domains",
     "get_lock_path",
@@ -301,6 +302,46 @@ def read_last_line(domain: str) -> str | None:
     """
     lines = read_tail(domain, 1)
     return lines[0] if lines else None
+
+
+def read_domain_snapshot(domain: str, start_offset: int = 0) -> bytes:
+    """Read one byte-exact, append-stable snapshot of complete JSONL records.
+
+    The file size is captured from the opened descriptor before reading. Bytes
+    appended afterwards are outside this snapshot. An incomplete tail is
+    excluded so parsing, offsets and hashes share one complete-record boundary.
+    """
+    if not isinstance(start_offset, int) or isinstance(start_offset, bool) or start_offset < 0:
+        raise StorageError("start_offset must be a non-negative integer")
+    try:
+        target_path = safe_target_path(domain)
+    except DomainError as exc:
+        raise StorageError("invalid target path") from exc
+
+    try:
+        with _safe_open_read(target_path) as fh:
+            observed_size = os.fstat(fh.fileno()).st_size
+            if start_offset >= observed_size:
+                return b""
+            fh.seek(start_offset)
+            remaining = observed_size - start_offset
+            chunks: list[bytes] = []
+            while remaining:
+                chunk = fh.read(min(1024 * 1024, remaining))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+    except OSError as exc:
+        if exc.errno == errno.ENOENT:
+            return b""
+        raise StorageError("read error") from exc
+
+    snapshot = b"".join(chunks)
+    if snapshot.endswith(b"\n"):
+        return snapshot
+    last_newline = snapshot.rfind(b"\n")
+    return snapshot[: last_newline + 1] if last_newline >= 0 else b""
 
 
 def scan_domain(domain: str, start_offset: int = 0) -> Iterator[Tuple[int, int, str]]:

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -190,3 +190,15 @@ def test_read_domain_snapshot_validates_offset_and_complete_boundary(tmp_path,mo
         storage.read_domain_snapshot(coding_memory.DOMAIN,-1)
     with pytest.raises(storage.StorageError,match="non-negative integer"):
         storage.read_domain_snapshot(coding_memory.DOMAIN,True)
+
+
+def test_snapshot_treats_only_lf_as_jsonl_record_boundary(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); target=tmp_path/"agent.ledger.jsonl"
+    raw=b'bad\rstill-one-record\n'
+    target.write_bytes(raw)
+    result=coding_memory.query_history(repo="heimgewebe/example")
+    snapshot=result["ledger_snapshot"]
+    assert snapshot["sha256"]==hashlib.sha256(raw).hexdigest()
+    assert snapshot["total_record_count"]==1
+    assert snapshot["invalid_record_count"]==1
+    assert snapshot["diagnostics"][0]["next_offset"]==len(raw)

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -137,3 +137,56 @@ def test_query_cli_supports_host_target_without_creating_data_dir(tmp_path):
     assert result.returncode==0,result.stderr
     assert json.loads(result.stdout)["target"]=={"scope":"host","host":"heim-pc"}
     assert not missing.exists()
+
+
+def test_snapshot_hashes_original_invalid_utf8_bytes_without_collision(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); target=tmp_path/"agent.ledger.jsonl"
+    first=b'{"payload":"\xff"}\n'; second=b'{"payload":"\xfe"}\n'
+    target.write_bytes(first)
+    first_result=coding_memory.query_history(repo="heimgewebe/example")
+    target.write_bytes(second)
+    second_result=coding_memory.query_history(repo="heimgewebe/example")
+    first_snapshot=first_result["ledger_snapshot"]; second_snapshot=second_result["ledger_snapshot"]
+    assert first_snapshot["sha256"]==hashlib.sha256(first).hexdigest()
+    assert second_snapshot["sha256"]==hashlib.sha256(second).hexdigest()
+    assert first_snapshot["sha256"]!=second_snapshot["sha256"]
+    assert first_snapshot["invalid_record_count"]==second_snapshot["invalid_record_count"]==1
+    assert first_snapshot["diagnostics"][0]["offset"]==0
+    assert first_snapshot["diagnostics"][0]["next_offset"]==len(first)
+
+
+def test_snapshot_excludes_incomplete_tail_but_includes_complete_corruption(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); coding_memory.import_events([event()]); target=tmp_path/"agent.ledger.jsonl"
+    valid=target.read_bytes(); complete_corruption=b'not-json\n'; incomplete=b'partial-tail'
+    target.write_bytes(valid+complete_corruption+incomplete)
+    result=coding_memory.query_history(repo="heimgewebe/example")
+    bounded=valid+complete_corruption; snapshot=result["ledger_snapshot"]
+    assert snapshot["sha256"]==hashlib.sha256(bounded).hexdigest()
+    assert snapshot["complete_bytes"]==len(bounded)
+    assert snapshot["total_record_count"]==2
+    assert snapshot["valid_record_count"]==1 and snapshot["invalid_record_count"]==1
+    assert result["event_ids"]==[event()["event_id"]]
+
+
+def test_query_uses_one_immutable_snapshot_even_if_file_grows_after_read(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); coding_memory.import_events([event()]); target=tmp_path/"agent.ledger.jsonl"
+    original=storage.read_domain_snapshot; observed=target.read_bytes(); calls=[]
+    def read_then_append(domain):
+        calls.append(domain); snapshot=original(domain); target.write_bytes(snapshot+b'not-json\n'); return snapshot
+    monkeypatch.setattr(storage,"read_domain_snapshot",read_then_append)
+    result=coding_memory.query_history(repo="heimgewebe/example")
+    assert calls==[coding_memory.DOMAIN]
+    assert result["ledger_snapshot"]["sha256"]==hashlib.sha256(observed).hexdigest()
+    assert result["ledger_snapshot"]["integrity_valid"] is True
+    assert target.read_bytes()==observed+b'not-json\n'
+
+
+def test_read_domain_snapshot_validates_offset_and_complete_boundary(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); target=tmp_path/"agent.ledger.jsonl"
+    target.write_bytes(b'one\ntwo\npartial')
+    assert storage.read_domain_snapshot(coding_memory.DOMAIN)==b'one\ntwo\n'
+    assert storage.read_domain_snapshot(coding_memory.DOMAIN,4)==b'two\n'
+    with pytest.raises(storage.StorageError,match="non-negative integer"):
+        storage.read_domain_snapshot(coding_memory.DOMAIN,-1)
+    with pytest.raises(storage.StorageError,match="non-negative integer"):
+        storage.read_domain_snapshot(coding_memory.DOMAIN,True)


### PR DESCRIPTION
## Zweck
Schließt Bureau-Task `CCM-V1-T006`: Chronik bindet Ledger-Abfragen auch bei ungültigem UTF-8 an die tatsächlich gelesenen Rohbytes.

## Änderung
- neuer append-stabiler Rohbyte-Snapshot bis zur letzten vollständigen JSONL-Zeile
- Hash, Bytegrenze, Parsing und Diagnosen aus genau einem Snapshot
- ungültiges UTF-8 wird strikt erkannt statt über Ersatzzeichen neu kodiert
- ausschließlich LF (`0x0A`) beendet einen JSONL-Datensatz
- Diagnose enthält Start- und Endoffset des beschädigten Datensatzes
- v1-Ausgabeformate und fail-closed `freeze` bleiben unverändert

## Regressionen
- verschiedene ungültige Bytefolgen erzeugen verschiedene Hashes
- vollständige Korruption bleibt im Snapshot, unvollständiger Tail bleibt draußen
- Dateiwachstum nach dem Read verändert den Beleg nicht
- nacktes CR erzeugt keine falsche Datensatzgrenze
- Offsetvalidierung und vollständige Grenze geprüft

## Prüfung
- `./scripts/validate-local.sh`: PASS
- 293 Tests: PASS
- Rollenvertrag: PASS
- HTTP-Smoke: PASS
- `git diff --check`: PASS