### PR TITLE
Scale direct outbox import with one ledger scan

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -77,12 +77,23 @@ def validate_event(event: dict[str, Any]) -> None:
     _parse_timestamp(event["ts"], field="ts")
 
 
+def _envelope_lines(events: Iterable[dict[str, Any]]) -> list[str]:
+    return [
+        json.dumps(
+            build_envelope(DOMAIN, event),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        for event in events
+    ]
+
+
 def import_events(events: Iterable[dict[str, Any]]) -> dict[str, Any]:
     values = [dict(event) for event in events]
     for event in values:
         validate_event(event)
-    lines = [json.dumps(build_envelope(DOMAIN, event), sort_keys=True, separators=(",", ":"), ensure_ascii=False) for event in values]
-    written, skipped = storage.write_payload_unique(DOMAIN, lines)
+    written, skipped = storage.write_payload_unique(DOMAIN, _envelope_lines(values))
     receipt = {
         "schema_version": "chronik-import-receipt.v1",
         "domain": DOMAIN,
@@ -145,47 +156,155 @@ def _validate_grabowski_source(event: dict[str, Any]) -> None:
         raise ValueError(f"unsupported operator-memory kind: {event.get('kind')}")
 
 
-def import_grabowski_outbox_file(source: Path, *, receipt_dir: Path) -> dict[str, Any]:
+def _prepare_grabowski_outbox_source(source: Path, *, receipt_dir: Path) -> dict[str, Any]:
     raw, events = _read_jsonl_snapshot(source)
-    source_sha256 = sha256_bytes(raw)
-    receipt_path = _receipt_path(source, receipt_dir)
-    previous = _load_receipt(receipt_path)
-    source_unchanged = previous is not None and previous.get("source_sha256") == source_sha256
     if not events:
         raise ValueError(f"outbox contains no events: {source}")
     for event in events:
         _validate_grabowski_source(event)
-    imported = import_events(events)
+    source_sha256 = sha256_bytes(raw)
+    receipt_path = _receipt_path(source, receipt_dir)
+    previous = _load_receipt(receipt_path)
+    return {
+        "source": source,
+        "raw": raw,
+        "events": events,
+        "source_sha256": source_sha256,
+        "receipt_path": receipt_path,
+        "source_unchanged": previous is not None and previous.get("source_sha256") == source_sha256,
+    }
+
+
+def _write_grabowski_outbox_receipt(
+    prepared: dict[str, Any],
+    *,
+    written: int,
+    skipped: int,
+    target_scans: int,
+    target_records_scanned: int,
+) -> dict[str, Any]:
+    source = prepared["source"]
+    raw = prepared["raw"]
+    events = prepared["events"]
+    receipt_path = prepared["receipt_path"]
     receipt = {
         "schema_version": "chronik-grabowski-outbox-import.v1",
         "domain": DOMAIN,
         "source_path": str(source.resolve()),
-        "source_sha256": source_sha256,
+        "source_sha256": prepared["source_sha256"],
         "source_bytes": len(raw),
         "selection_contract": sorted(HIGH_VALUE_KINDS),
         "event_ids": sorted(event["event_id"] for event in events),
-        "requested": imported["requested"],
-        "imported": imported["imported"],
-        "skipped_existing": imported["skipped_existing"],
+        "requested": len(events),
+        "imported": written,
+        "skipped_existing": skipped,
+        "batch_target_scans": target_scans,
+        "batch_target_records_scanned": target_records_scanned,
         "recorded_at": utc_now(),
         "historical_only": True,
         "does_not_establish": DOES_NOT_ESTABLISH,
     }
     receipt["receipt_sha256"] = sha256_bytes(canonical_bytes(receipt))
-    _atomic_write(receipt_path, json.dumps(receipt, indent=2, sort_keys=True).encode("utf-8") + b"\n")
-    return {**receipt, "unchanged": source_unchanged, "receipt_path": str(receipt_path)}
+    _atomic_write(
+        receipt_path,
+        json.dumps(receipt, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+    )
+    return {
+        **receipt,
+        "unchanged": prepared["source_unchanged"],
+        "receipt_path": str(receipt_path),
+    }
+
+
+def _import_prepared_grabowski_sources(
+    prepared_sources: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, object], list[tuple[str, Exception]]]:
+    grouped = storage.write_payload_unique_groups(
+        DOMAIN,
+        [
+            (str(index), _envelope_lines(prepared["events"]))
+            for index, prepared in enumerate(prepared_sources)
+        ],
+    )
+    raw_group_results = grouped.get("groups")
+    if not isinstance(raw_group_results, list):
+        raise storage.StorageError("grouped write omitted per-source results")
+    group_results = {
+        str(item.get("group_id")): item
+        for item in raw_group_results
+        if isinstance(item, dict)
+    }
+    target_scans = int(grouped.get("target_scans", 0))
+    target_records_scanned = int(grouped.get("target_records_scanned", 0))
+    results: list[dict[str, Any]] = []
+    receipt_errors: list[tuple[str, Exception]] = []
+    for index, prepared in enumerate(prepared_sources):
+        stats = group_results.get(str(index))
+        if stats is None:
+            raise storage.StorageError(f"grouped write omitted source group {index}")
+        written = int(stats.get("written", 0))
+        skipped = int(stats.get("skipped", 0))
+        try:
+            result = _write_grabowski_outbox_receipt(
+                prepared,
+                written=written,
+                skipped=skipped,
+                target_scans=target_scans,
+                target_records_scanned=target_records_scanned,
+            )
+        except (OSError, ValueError, storage.StorageError) as exc:
+            result = {
+                "source_path": str(prepared["source"].resolve()),
+                "imported": written,
+                "skipped_existing": skipped,
+                "unchanged": prepared["source_unchanged"],
+            }
+            receipt_errors.append((str(prepared["source"]), exc))
+        results.append(result)
+    return results, grouped, receipt_errors
+
+
+def import_grabowski_outbox_file(source: Path, *, receipt_dir: Path) -> dict[str, Any]:
+    prepared = _prepare_grabowski_outbox_source(source, receipt_dir=receipt_dir)
+    results, _, receipt_errors = _import_prepared_grabowski_sources([prepared])
+    if receipt_errors:
+        raise receipt_errors[0][1]
+    return results[0]
 
 
 def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str, Any]:
     source_dir = outbox_root.expanduser() / "grabowski" / "chronik-outbox"
     sources = sorted(source_dir.glob("*.jsonl")) if source_dir.is_dir() else []
+    prepared_sources: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
     errors: list[dict[str, str]] = []
+    target_scans: int | None = 0
+    target_records_scanned: int | None = 0
     for source in sources:
         try:
-            results.append(import_grabowski_outbox_file(source, receipt_dir=receipt_dir))
+            prepared_sources.append(
+                _prepare_grabowski_outbox_source(source, receipt_dir=receipt_dir)
+            )
         except (OSError, ValueError, storage.StorageError) as exc:
             errors.append({"source_path": str(source), "error": str(exc)})
+    if prepared_sources:
+        try:
+            results, grouped, receipt_errors = _import_prepared_grabowski_sources(
+                prepared_sources
+            )
+            target_scans = int(grouped.get("target_scans", 0))
+            target_records_scanned = int(grouped.get("target_records_scanned", 0))
+            errors.extend(
+                {
+                    "source_path": source_path,
+                    "error": f"receipt write failed after ledger update: {exc}",
+                }
+                for source_path, exc in receipt_errors
+            )
+        except (OSError, ValueError, storage.StorageError) as exc:
+            target_scans = None
+            target_records_scanned = None
+            errors.append({"source_path": "<batch>", "error": str(exc)})
     return {
         "schema_version": "chronik-grabowski-outbox-batch.v1",
         "source_dir": str(source_dir),
@@ -195,6 +314,8 @@ def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str
         "files_unchanged": sum(1 for result in results if result.get("unchanged") is True),
         "events_imported": sum(int(result.get("imported", 0)) for result in results),
         "events_skipped_existing": sum(int(result.get("skipped_existing", 0)) for result in results),
+        "target_scans": target_scans,
+        "target_records_scanned": target_records_scanned,
         "errors": errors,
         "historical_only": True,
         "does_not_establish": DOES_NOT_ESTABLISH,

--- a/docs/chronik/direct-operator-memory-v1.md
+++ b/docs/chronik/direct-operator-memory-v1.md
@@ -112,11 +112,52 @@ python tools/coding_memory.py \
 Der Receipt bindet die Kohorte sowohl an die Filter als auch an den SHA-256 des
 vollständig gelesenen Ledger-Snapshots.
 
+## Skalierungsvertrag
+
+Der Import liest und validiert weiterhin jede vollständige Quelldatei. Alle
+gültigen Ereignisse werden danach in **einer** gruppierten Storage-Operation
+abgeglichen. Unter einem einzigen Lock wird der Ziel-Ledger höchstens einmal
+vollständig gescannt. Pro Quelldatei bleiben getrennte, an Pfad, SHA-256 und
+Größe gebundene Receipts erhalten.
+
+Vor der Optimierung wurden folgende Grenzen festgelegt:
+
+- höchstens ein Ziel-Ledger-Scan pro Batch;
+- repräsentativer Tier: 200 Quelldateien, 500 bestehende Ereignisse, höchstens
+  5 Sekunden;
+- projizierter Tier: 1000 Quelldateien, 5000 bestehende Ereignisse, höchstens
+  30 Sekunden;
+- absolute Timergrenze: höchstens 60 Sekunden, also mindestens Faktor 2
+  Reserve zum Zwei-Minuten-Intervall.
+
+Reproduzierbarer Benchmark:
+
+```bash
+python tools/benchmark_outbox_import.py \
+  --output /tmp/chronik-outbox-benchmark.json
+```
+
+Der Bericht enthält Maschinenkontext, Laufzeit und Peak-Speicher für Erst- und
+Wiederholungsimport, Ziel-Ledger-Scans, gescannte Zieldatensätze sowie
+geschriebene und übersprungene Ereignisse. Ein Importbeleg bleibt dabei reine
+Evidenz: Auch der Wiederholungsimport gleicht jedes Ereignis gegen den
+tatsächlichen Ledger ab und vertraut niemals nur dem Receipt.
+
+Ein Receipt wird erst nach dem erfolgreichen Ledger-Abgleich geschrieben. Falls
+dieser Evidenzschritt scheitert, bleiben die bereits bestätigten Ledger-Zahlen
+in der Batch-Ausgabe erhalten und die betroffene Quelle wird zusätzlich als
+Fehler gemeldet. Der nächste Lauf gleicht erneut gegen den realen Ledger ab und
+kann das Receipt wiederherstellen. `target_scans = 0` bedeutet, dass keine
+gültige Quelle einen Ledger-Abgleich erforderte; `null` bedeutet, dass für einen
+vorbereiteten Batch keine verlässliche Scan-Telemetrie vorliegt.
+
 ## User-Service
 
 Die Unit `chronik-outbox-import.service` ist ein gehärteter One-shot-Importer.
-Der Timer startet sie alle zwei Minuten. Die Unit darf die Grabowski-Outbox nur
-lesen und ausschließlich unter `~/.local/state/chronik` schreiben.
+Der Timer startet sie alle zwei Minuten. Dieselbe One-shot-Unit wird von systemd
+nicht parallel ein zweites Mal gestartet; ein noch aktiver Lauf verhindert damit
+überlappende Importer. Die Unit darf die Grabowski-Outbox nur lesen und
+ausschließlich unter `~/.local/state/chronik` schreiben.
 
 Der HTTP-Dienst `chronik.service` ist für diesen Pfad nicht erforderlich. Er
 soll nur aktiviert werden, wenn ein konkreter externer Konsument den HTTP-Ingest

--- a/storage.py
+++ b/storage.py
@@ -8,7 +8,6 @@ import json
 import logging
 import os
 import re
-from collections import deque
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Final, Iterable, Iterator, Tuple
@@ -27,6 +26,7 @@ __all__ = [
     "safe_target_path",
     "write_payload",
     "write_payload_unique",
+    "write_payload_unique_groups",
     "read_tail",
     "read_last_line",
     "read_domain_snapshot",
@@ -541,68 +541,137 @@ def write_payload(domain: str, lines: Iterable[str]) -> None:
             raise
 
 
-def write_payload_unique(domain: str, lines: Iterable[str], *, identity_key: str = "event_id") -> tuple[int, int]:
-    """Append JSON lines once per payload identity under the domain lock.
+def _parse_unique_payload(line: str, identity_key: str) -> tuple[str | None, bytes]:
+    value = json.loads(line)
+    payload = value.get("payload", value) if isinstance(value, dict) else None
+    identity = payload.get(identity_key) if isinstance(payload, dict) else None
+    canonical_payload = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return identity if isinstance(identity, str) else None, canonical_payload
 
-    Returns ``(written, skipped)``. Existing malformed lines are preserved but do
-    not participate in identity matching. The lock covers both scan and append.
-    """
-    candidates = list(lines)
-    if not candidates:
-        return 0, 0
+
+def write_payload_unique_groups(
+    domain: str,
+    groups: Iterable[tuple[str, Iterable[str]]],
+    *,
+    identity_key: str = "event_id",
+) -> dict[str, object]:
+    """Append grouped JSON lines with one target-ledger scan under one lock."""
+    materialized = []
+    seen_group_ids = set()
+    for group_id, lines in groups:
+        if not isinstance(group_id, str) or not group_id:
+            raise StorageError("group_id must be a non-empty string")
+        if group_id in seen_group_ids:
+            raise StorageError(f"duplicate group_id: {group_id}")
+        seen_group_ids.add(group_id)
+        materialized.append((group_id, list(lines)))
+    parsed_groups = []
+    candidate_payloads = {}
+    candidate_count = 0
+    for group_id, lines in materialized:
+        parsed = []
+        for line in lines:
+            try:
+                identity, canonical_payload = _parse_unique_payload(line, identity_key)
+            except (TypeError, ValueError) as exc:
+                raise StorageError("invalid JSON line") from exc
+            if not identity:
+                raise StorageError(f"missing {identity_key}")
+            previous = candidate_payloads.get(identity)
+            if previous is not None and previous != canonical_payload:
+                raise StorageError(f"conflicting {identity_key}: {identity}")
+            candidate_payloads.setdefault(identity, canonical_payload)
+            parsed.append((identity, line, canonical_payload))
+            candidate_count += 1
+        parsed_groups.append((group_id, parsed))
+    if candidate_count == 0:
+        return {
+            "written": 0,
+            "skipped": 0,
+            "target_scans": 0,
+            "target_records_scanned": 0,
+            "groups": [
+                {"group_id": gid, "requested": len(lines), "written": 0, "skipped": 0}
+                for gid, lines in materialized
+            ],
+        }
     try:
         target_path = safe_target_path(domain)
     except DomainError as exc:
         raise StorageError("invalid target path") from exc
-
-    parsed: list[tuple[str, str, bytes]] = []
-    candidate_payloads: dict[str, bytes] = {}
-    for line in candidates:
-        try:
-            value = json.loads(line)
-            payload = value.get("payload", value) if isinstance(value, dict) else None
-            identity = payload.get(identity_key) if isinstance(payload, dict) else None
-            canonical_payload = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode("utf-8")
-        except (TypeError, ValueError) as exc:
-            raise StorageError("invalid JSON line") from exc
-        if not isinstance(identity, str) or not identity:
-            raise StorageError(f"missing {identity_key}")
-        previous = candidate_payloads.get(identity)
-        if previous is not None and previous != canonical_payload:
-            raise StorageError(f"conflicting {identity_key}: {identity}")
-        candidate_payloads.setdefault(identity, canonical_payload)
-        parsed.append((identity, line, canonical_payload))
-
     with _locked_open(target_path, "a+") as fh:
         fh.seek(0)
-        existing: dict[str, bytes] = {}
+        existing = {}
+        target_records_scanned = 0
         for raw in fh:
+            target_records_scanned += 1
             try:
-                value = json.loads(raw)
-                payload = value.get("payload", value) if isinstance(value, dict) else None
-                identity = payload.get(identity_key) if isinstance(payload, dict) else None
-                canonical_payload = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode("utf-8")
+                identity, canonical_payload = _parse_unique_payload(raw, identity_key)
             except (TypeError, ValueError):
                 continue
-            if isinstance(identity, str):
+            if identity:
                 previous = existing.get(identity)
                 if previous is not None and previous != canonical_payload:
                     raise StorageError(f"conflicting {identity_key}: {identity}")
                 existing.setdefault(identity, canonical_payload)
-        for identity, _, canonical_payload in parsed:
-            previous = existing.get(identity)
-            if previous is not None and previous != canonical_payload:
-                raise StorageError(f"conflicting {identity_key}: {identity}")
-        written = 0
-        skipped = 0
-        for identity, line, canonical_payload in parsed:
-            if identity in existing:
-                skipped += 1
-                continue
-            fh.write(line)
-            fh.write("\n")
-            existing[identity] = canonical_payload
-            written += 1
+        for _, parsed in parsed_groups:
+            for identity, _, canonical_payload in parsed:
+                previous = existing.get(identity)
+                if previous is not None and previous != canonical_payload:
+                    raise StorageError(f"conflicting {identity_key}: {identity}")
+        total_written = 0
+        total_skipped = 0
+        group_results = []
+        for group_id, parsed in parsed_groups:
+            group_written = 0
+            group_skipped = 0
+            for identity, line, canonical_payload in parsed:
+                if identity in existing:
+                    group_skipped += 1
+                    total_skipped += 1
+                    continue
+                fh.write(line)
+                fh.write("\n")
+                existing[identity] = canonical_payload
+                group_written += 1
+                total_written += 1
+            group_results.append(
+                {
+                    "group_id": group_id,
+                    "requested": len(parsed),
+                    "written": group_written,
+                    "skipped": group_skipped,
+                }
+            )
         fh.flush()
         os.fsync(fh.fileno())
-    return written, skipped
+    return {
+        "written": total_written,
+        "skipped": total_skipped,
+        "target_scans": 1,
+        "target_records_scanned": target_records_scanned,
+        "groups": group_results,
+    }
+
+
+def write_payload_unique(
+    domain: str, lines: Iterable[str], *, identity_key: str = "event_id"
+) -> tuple[int, int]:
+    """Append JSON lines once per payload identity under the domain lock."""
+    result = write_payload_unique_groups(
+        domain, [("single", lines)], identity_key=identity_key
+    )
+    groups = result["groups"]
+    if (
+        not isinstance(groups, list)
+        or len(groups) != 1
+        or not isinstance(groups[0], dict)
+    ):
+        raise StorageError("invalid grouped write result")
+    return int(groups[0]["written"]), int(groups[0]["skipped"])

--- a/tests/test_benchmark_outbox_import.py
+++ b/tests/test_benchmark_outbox_import.py
@@ -1,0 +1,36 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_benchmark_reports_single_scan_first_and_repeat(tmp_path):
+    root = Path(__file__).parents[1]
+    output = tmp_path / "benchmark.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(root / "tools" / "benchmark_outbox_import.py"),
+            "--name",
+            "test",
+            "--source-files",
+            "3",
+            "--preexisting-events",
+            "4",
+            "--max-seconds",
+            "5",
+            "--output",
+            str(output),
+        ],
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr
+    report = json.loads(output.read_text())
+    tier = report["tiers"][0]
+    assert report["passed"] is True
+    assert tier["first"]["target_scans"] == 1
+    assert tier["repeat"]["target_scans"] == 1
+    assert tier["first"]["events_imported"] == 6
+    assert tier["repeat"]["events_skipped_existing"] == 6
+    assert tier["passed"] is True

--- a/tests/test_grabowski_outbox_import.py
+++ b/tests/test_grabowski_outbox_import.py
@@ -81,10 +81,55 @@ def test_receipt_never_replaces_target_store_verification(tmp_path, monkeypatch)
 
     assert recovered["files_unchanged"] == 1
     assert recovered["events_imported"] == 2
-    assert len((data / "agent.ledger.jsonl").read_text(encoding="utf-8").splitlines()) == 2
+    assert (
+        len((data / "agent.ledger.jsonl").read_text(encoding="utf-8").splitlines()) == 2
+    )
 
 
-def test_appended_source_updates_receipt_and_imports_only_new_event(tmp_path, monkeypatch):
+def test_missing_receipt_is_rebuilt_after_store_verification(tmp_path, monkeypatch):
+    data, receipts, outbox = configure(tmp_path, monkeypatch)
+    write_outbox(outbox, [event("agent.run.completed", "a")])
+    coding_memory.import_grabowski_outbox(outbox_root=outbox, receipt_dir=receipts)
+    receipt_path = next(receipts.glob("*.receipt.json"))
+    receipt_path.unlink()
+
+    recovered = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+
+    assert recovered["events_imported"] == 0
+    assert recovered["events_skipped_existing"] == 1
+    assert recovered["files_unchanged"] == 0
+    assert recovered["target_scans"] == 1
+    assert receipt_path.exists()
+    assert len((data / "agent.ledger.jsonl").read_text().splitlines()) == 1
+
+
+def test_stale_receipt_cannot_override_store_verification(tmp_path, monkeypatch):
+    data, receipts, outbox = configure(tmp_path, monkeypatch)
+    write_outbox(outbox, [event("agent.run.completed", "a")])
+    coding_memory.import_grabowski_outbox(outbox_root=outbox, receipt_dir=receipts)
+    receipt_path = next(receipts.glob("*.receipt.json"))
+    stale = json.loads(receipt_path.read_text())
+    stale["source_sha256"] = "0" * 64
+    receipt_path.write_text(json.dumps(stale), encoding="utf-8")
+
+    recovered = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+
+    assert recovered["events_imported"] == 0
+    assert recovered["events_skipped_existing"] == 1
+    assert recovered["files_unchanged"] == 0
+    assert recovered["target_records_scanned"] == 1
+    refreshed = json.loads(receipt_path.read_text())
+    assert refreshed["source_sha256"] != "0" * 64
+    assert len((data / "agent.ledger.jsonl").read_text().splitlines()) == 1
+
+
+def test_appended_source_updates_receipt_and_imports_only_new_event(
+    tmp_path, monkeypatch
+):
     data, receipts, outbox = configure(tmp_path, monkeypatch)
     source = write_outbox(outbox, [event("agent.run.started", "a")])
     coding_memory.import_grabowski_outbox(outbox_root=outbox, receipt_dir=receipts)
@@ -194,9 +239,162 @@ def test_import_preserves_host_scope_without_fabricated_repo(tmp_path, monkeypat
     value["data"].update({"operation": "recovery", "task_class": "recovery"})
     write_outbox(outbox, [value])
 
-    result = coding_memory.import_grabowski_outbox(outbox_root=outbox, receipt_dir=receipts)
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
 
     assert result["errors"] == []
     row = json.loads((data / "agent.ledger.jsonl").read_text().splitlines()[0])
     assert row["payload"]["subject"] == {"scope": "host", "host": "heim-pc"}
     assert "repo" not in row["payload"]["subject"]
+
+
+def write_named_outbox(root: Path, name: str, values: list[dict]) -> Path:
+    path = root / "grabowski" / "chronik-outbox" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(value, sort_keys=True) + "\n" for value in values),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_multi_file_batch_scans_target_once_and_repeat_verifies_store(
+    tmp_path, monkeypatch
+):
+    data, receipts, outbox = configure(tmp_path, monkeypatch)
+    for index, suffix in enumerate(("a", "b", "c")):
+        write_named_outbox(
+            outbox,
+            f"grabowski_task-{index}-a1.jsonl",
+            [event("agent.run.completed", suffix)],
+        )
+    first = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+    second = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+    assert first["target_scans"] == 1
+    assert first["target_records_scanned"] == 0
+    assert first["events_imported"] == 3
+    assert second["target_scans"] == 1
+    assert second["target_records_scanned"] == 3
+    assert second["events_imported"] == 0
+    assert second["events_skipped_existing"] == 3
+    assert second["files_unchanged"] == 3
+    assert len((data / "agent.ledger.jsonl").read_text().splitlines()) == 3
+
+
+def test_batch_imports_valid_sources_while_reporting_invalid_source(
+    tmp_path, monkeypatch
+):
+    data, receipts, outbox = configure(tmp_path, monkeypatch)
+    write_named_outbox(
+        outbox, "grabowski_task-valid-a1.jsonl", [event("agent.run.completed", "a")]
+    )
+    write_named_outbox(
+        outbox,
+        "grabowski_task-invalid-a1.jsonl",
+        [event("agent.run.completed", "b", source_repo="heimgewebe/other")],
+    )
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+    assert result["target_scans"] == 1
+    assert result["events_imported"] == 1
+    assert len(result["errors"]) == 1
+    assert len(list(receipts.glob("*.receipt.json"))) == 1
+    assert len((data / "agent.ledger.jsonl").read_text().splitlines()) == 1
+
+
+def test_cross_file_divergent_event_id_fails_before_batch_append(tmp_path, monkeypatch):
+    data, receipts, outbox = configure(tmp_path, monkeypatch)
+    first = event("agent.run.completed", "a")
+    second = event("agent.run.completed", "a")
+    second["subject"] = {"scope": "repository", "repo": "heimgewebe/other"}
+    second["data"].update({"operation": "implement", "task_class": "coding"})
+    write_named_outbox(outbox, "grabowski_task-first-a1.jsonl", [first])
+    write_named_outbox(outbox, "grabowski_task-second-a1.jsonl", [second])
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+    assert result["files_imported_or_confirmed"] == 0
+    assert result["events_imported"] == 0
+    assert result["target_scans"] is None
+    assert result["errors"][0]["source_path"] == "<batch>"
+    assert "conflicting event_id" in result["errors"][0]["error"]
+    target = data / "agent.ledger.jsonl"
+    assert not target.exists() or target.read_text() == ""
+    assert not receipts.exists()
+
+
+
+def test_single_file_receipt_failure_preserves_original_exception(
+    tmp_path, monkeypatch
+):
+    data, receipts, outbox = configure(tmp_path, monkeypatch)
+    source = write_outbox(outbox, [event("agent.run.completed", "a")])
+
+    def fail_receipt_write(path: Path, payload: bytes) -> None:
+        raise OSError("simulated direct receipt ENOSPC")
+
+    monkeypatch.setattr(coding_memory, "_atomic_write", fail_receipt_write)
+    with pytest.raises(OSError, match="simulated direct receipt ENOSPC"):
+        coding_memory.import_grabowski_outbox_file(source, receipt_dir=receipts)
+
+    assert len((data / "agent.ledger.jsonl").read_text().splitlines()) == 1
+
+
+def test_empty_batch_reports_zero_target_scans(tmp_path, monkeypatch):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+
+    assert result["files_seen"] == 0
+    assert result["target_scans"] == 0
+    assert result["target_records_scanned"] == 0
+    assert result["errors"] == []
+
+
+def test_receipt_failure_preserves_ledger_stats_and_is_recoverable(
+    tmp_path, monkeypatch
+):
+    data, receipts, outbox = configure(tmp_path, monkeypatch)
+    source = write_outbox(outbox, [event("agent.run.completed", "a")])
+    atomic_write = coding_memory._atomic_write
+
+    def fail_receipt_write(path: Path, payload: bytes) -> None:
+        raise OSError("simulated receipt ENOSPC")
+
+    monkeypatch.setattr(coding_memory, "_atomic_write", fail_receipt_write)
+    failed = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+
+    assert failed["files_imported_or_confirmed"] == 1
+    assert failed["events_imported"] == 1
+    assert failed["events_skipped_existing"] == 0
+    assert failed["target_scans"] == 1
+    assert failed["target_records_scanned"] == 0
+    assert failed["errors"] == [
+        {
+            "source_path": str(source),
+            "error": "receipt write failed after ledger update: simulated receipt ENOSPC",
+        }
+    ]
+    assert len((data / "agent.ledger.jsonl").read_text().splitlines()) == 1
+    assert not receipts.exists()
+
+    monkeypatch.setattr(coding_memory, "_atomic_write", atomic_write)
+    recovered = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+
+    assert recovered["events_imported"] == 0
+    assert recovered["events_skipped_existing"] == 1
+    assert recovered["target_scans"] == 1
+    assert recovered["errors"] == []
+    assert len(list(receipts.glob("*.receipt.json"))) == 1

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 import storage
 
@@ -86,3 +88,50 @@ def test_read_last_line_invalid_domain(mock_data_dir):
     """Verify it raises StorageError for an invalid domain name."""
     with pytest.raises(storage.StorageError, match="invalid target"):
         storage.read_last_line("domain with spaces")
+
+
+def _unique_line(event_id: str, value: str) -> str:
+    return json.dumps(
+        {"payload": {"event_id": event_id, "value": value}}, sort_keys=True
+    )
+
+
+def test_write_payload_unique_groups_scans_once_and_allocates_counts(mock_data_dir):
+    storage.write_payload("agent.ledger", [_unique_line("existing", "same")])
+    result = storage.write_payload_unique_groups(
+        "agent.ledger",
+        [
+            ("first", [_unique_line("existing", "same"), _unique_line("new-a", "a")]),
+            ("second", [_unique_line("new-a", "a"), _unique_line("new-b", "b")]),
+        ],
+    )
+    assert result["target_scans"] == 1
+    assert result["target_records_scanned"] == 1
+    assert result["written"] == 2
+    assert result["skipped"] == 2
+    assert result["groups"] == [
+        {"group_id": "first", "requested": 2, "written": 1, "skipped": 1},
+        {"group_id": "second", "requested": 2, "written": 1, "skipped": 1},
+    ]
+    assert len((mock_data_dir / "agent.ledger.jsonl").read_text().splitlines()) == 3
+
+
+def test_write_payload_unique_groups_rejects_cross_group_conflict_before_write(
+    mock_data_dir,
+):
+    with pytest.raises(storage.StorageError, match="conflicting event_id"):
+        storage.write_payload_unique_groups(
+            "agent.ledger",
+            [
+                ("first", [_unique_line("same", "a")]),
+                ("second", [_unique_line("same", "b")]),
+            ],
+        )
+    target = mock_data_dir / "agent.ledger.jsonl"
+    assert not target.exists() or target.read_text() == ""
+
+
+def test_write_payload_unique_wrapper_retains_tuple_contract(mock_data_dir):
+    assert storage.write_payload_unique(
+        "agent.ledger", [_unique_line("one", "a"), _unique_line("one", "a")]
+    ) == (1, 1)

--- a/tools/benchmark_outbox_import.py
+++ b/tools/benchmark_outbox_import.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Deterministic scaling benchmark for the direct Grabowski outbox importer."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import coding_memory  # noqa: E402
+import storage  # noqa: E402
+
+DEFAULT_TIERS = (
+    {
+        "name": "representative",
+        "source_files": 200,
+        "preexisting_events": 500,
+        "max_seconds": 5.0,
+    },
+    {
+        "name": "projected",
+        "source_files": 1000,
+        "preexisting_events": 5000,
+        "max_seconds": 30.0,
+    },
+)
+TIMER_BUDGET_SECONDS = 60.0
+MAX_TARGET_SCANS = 1
+
+
+def synthetic_event(label: str, kind: str = "agent.run.completed") -> dict:
+    event_id = "sha256:" + hashlib.sha256(label.encode("utf-8")).hexdigest()
+    result = {
+        "agent.run.started": "started",
+        "agent.run.completed": "completed",
+        "agent.run.blocked": "blocked",
+    }[kind]
+    data = {"result": result, "operation": "implement", "task_class": "coding"}
+    if kind == "agent.run.blocked":
+        data["blocker_code"] = "benchmark"
+    return {
+        "schema_version": "agent-run-event.v0",
+        "event_id": event_id,
+        "kind": kind,
+        "ts": "2026-07-15T00:00:00Z",
+        "source": {
+            "repo": "heimgewebe/grabowski",
+            "component": "grabowski",
+            "run_id": label,
+        },
+        "subject": {"scope": "repository", "repo": "heimgewebe/chronik"},
+        "trust_tier": "declared" if kind == "agent.run.started" else "observed",
+        "status": "active",
+        "caused_by": [],
+        "evidence_refs": ["benchmark:" + label],
+        "data": data,
+    }
+
+
+def _measure(outbox_root: Path, receipt_dir: Path) -> dict:
+    tracemalloc.start()
+    started = time.perf_counter()
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox_root,
+        receipt_dir=receipt_dir,
+    )
+    elapsed = time.perf_counter() - started
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return {
+        "elapsed_seconds": round(elapsed, 6),
+        "peak_memory_bytes": peak,
+        "target_scans": result["target_scans"],
+        "target_records_scanned": result["target_records_scanned"],
+        "events_imported": result["events_imported"],
+        "events_skipped_existing": result["events_skipped_existing"],
+        "errors": result["errors"],
+    }
+
+
+def benchmark_tier(
+    *,
+    name: str,
+    source_files: int,
+    preexisting_events: int,
+    max_seconds: float,
+) -> dict:
+    with tempfile.TemporaryDirectory(prefix="chronik-outbox-benchmark-") as temp:
+        temp_root = Path(temp)
+        data_dir = temp_root / "data"
+        data_dir.mkdir()
+        storage.DATA_DIR = data_dir
+        if preexisting_events:
+            coding_memory.import_events(
+                synthetic_event(f"existing-{index}")
+                for index in range(preexisting_events)
+            )
+        outbox_root = temp_root / "state"
+        source_dir = outbox_root / "grabowski" / "chronik-outbox"
+        source_dir.mkdir(parents=True)
+        for index in range(source_files):
+            values = (
+                synthetic_event(f"{name}-{index}-started", "agent.run.started"),
+                synthetic_event(f"{name}-{index}-completed"),
+            )
+            (source_dir / f"grabowski_task-{index:06d}-a1.jsonl").write_text(
+                "".join(json.dumps(value, sort_keys=True) + "\n" for value in values),
+                encoding="utf-8",
+            )
+        receipt_dir = temp_root / "receipts"
+        first = _measure(outbox_root, receipt_dir)
+        repeat = _measure(outbox_root, receipt_dir)
+        worst_seconds = max(first["elapsed_seconds"], repeat["elapsed_seconds"])
+        passed = (
+            not first["errors"]
+            and not repeat["errors"]
+            and first["target_scans"] <= MAX_TARGET_SCANS
+            and repeat["target_scans"] <= MAX_TARGET_SCANS
+            and worst_seconds <= max_seconds
+            and worst_seconds <= TIMER_BUDGET_SECONDS
+        )
+        return {
+            "name": name,
+            "source_files": source_files,
+            "source_events": source_files * 2,
+            "preexisting_events": preexisting_events,
+            "max_seconds": max_seconds,
+            "timer_budget_seconds": TIMER_BUDGET_SECONDS,
+            "max_target_scans": MAX_TARGET_SCANS,
+            "first": first,
+            "repeat": repeat,
+            "worst_seconds": worst_seconds,
+            "passed": passed,
+        }
+
+
+def run_benchmark(tiers: tuple[dict, ...] = DEFAULT_TIERS) -> dict:
+    results = [benchmark_tier(**tier) for tier in tiers]
+    return {
+        "schema_version": "chronik-outbox-import-benchmark.v1",
+        "machine": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "cpu_count": os.cpu_count(),
+        },
+        "thresholds": {
+            "max_target_scans": MAX_TARGET_SCANS,
+            "timer_budget_seconds": TIMER_BUDGET_SECONDS,
+        },
+        "tiers": results,
+        "passed": all(result["passed"] for result in results),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--name")
+    parser.add_argument("--source-files", type=int)
+    parser.add_argument("--preexisting-events", type=int)
+    parser.add_argument("--max-seconds", type=float)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    values = (args.name, args.source_files, args.preexisting_events, args.max_seconds)
+    if any(value is not None for value in values):
+        if any(value is None for value in values):
+            parser.error(
+                "custom tier requires --name, --source-files, "
+                "--preexisting-events and --max-seconds"
+            )
+        if (
+            args.source_files < 1
+            or args.preexisting_events < 0
+            or args.max_seconds <= 0
+        ):
+            parser.error(
+                "tier sizes and threshold must be positive, "
+                "except preexisting events may be zero"
+            )
+        tiers = (
+            {
+                "name": args.name,
+                "source_files": args.source_files,
+                "preexisting_events": args.preexisting_events,
+                "max_seconds": args.max_seconds,
+            },
+        )
+    else:
+        tiers = DEFAULT_TIERS
+    report = run_benchmark(tiers)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Zweck

Skaliert den direkten Grabowski-Outbox-Import, ohne einen persistenten Index oder eine zweite Autoritätsquelle einzuführen.

## Belegter Ausgangsfehler

Die bisherige Batchlogik rief `write_payload_unique` pro Quelldatei auf und scannte deshalb den vollständigen Ziel-Ledger für jede Datei erneut.

Baseline vor der Änderung:

- repräsentativ: 200 Quelldateien, 400 Quellereignisse, 500 bestehende Ledger-Ereignisse, 5,346139 s, 200 Ziel-Ledger-Scans;
- projiziert: 1000 Quelldateien, 2000 Quellereignisse, 5000 bestehende Ledger-Ereignisse, 187,856265 s, 1000 Ziel-Ledger-Scans.

Vorab festgelegter Messvertrag:

- höchstens ein vollständiger Ziel-Ledger-Scan pro Batch;
- repräsentativer Tier höchstens 5 s;
- projizierter Tier höchstens 30 s;
- jeder Lauf höchstens 60 s als Faktor-2-Reserve zum Zwei-Minuten-Timer.

## Änderung

- neue gruppierte Storage-Primitive `write_payload_unique_groups`;
- vollständige Kandidatenvalidierung vor dem ersten Append;
- gruppenübergreifende Konflikterkennung für divergente identische `event_id`;
- genau ein Ziel-Ledger-Scan unter einem prozessübergreifenden Lock;
- gruppenweise Zählung von geschriebenen und vorhandenen Ereignissen;
- kompatibler `write_payload_unique`-Wrapper mit unverändertem `(written, skipped)`-Vertrag;
- Outbox-Verarbeitung in Vorbereitung, gemeinsamen Ledger-Abgleich und getrennte Receipt-Publikation aufgeteilt;
- `target_scans` und `target_records_scanned` in der Batch-Telemetrie;
- Receipt-I/O-Fehler nach erfolgreichem Ledger-Append bewahren wahrheitsgemäß die Ledger-Zahlen, werden quellspezifisch gemeldet und sind beim nächsten Lauf aus Ledger und Outbox reparierbar;
- deterministisches Benchmark-Werkzeug und dokumentierter Skalierungsvertrag.

## Integritäts- und Recovery-Vertrag

- Der Ledger bleibt alleinige Autorität; Receipts sind ableitbare Evidenz.
- Ein vorhandenes Receipt ersetzt nie den realen Ledger-Abgleich.
- Ledger-Verlust, Receipt-Verlust, stale Receipts und gewachsene Quelldateien werden durch erneuten realen Abgleich behandelt.
- Ein divergenter gültiger `event_id`-Konflikt stoppt den vorbereiteten Batch vor Append und Receipt.
- Ungültige Einzelquellen werden separat gemeldet; andere gültige Quellen dürfen importiert werden.
- Der Einzeldatei-Importer behält bei Receipt-I/O-Fehlern den ursprünglichen Fehlertyp bei.

## Finaler Benchmark

Job: `grabowski-job-619e77ffa9cd`

Repräsentativ:

- Erstimport: 0,416491 s, 1 Scan, 500 gescannte Zieldatensätze, 400 importiert, Peak 3.120.115 Bytes;
- Wiederholung: 0,439070 s, 1 Scan, 900 gescannte Zieldatensätze, 400 bestätigt, Peak 3.341.137 Bytes.

Projiziert:

- Erstimport: 2,181003 s, 1 Scan, 5000 gescannte Zieldatensätze, 2000 importiert, Peak 17.035.286 Bytes;
- Wiederholung: 2,289956 s, 1 Scan, 7000 gescannte Zieldatensätze, 2000 bestätigt, Peak 19.822.059 Bytes.

Der Messvertrag ist vollständig bestanden. Gegenüber der Baseline sinkt der projizierte Lauf von rund 187,86 s auf höchstens 2,29 s und von 1000 auf einen Ziel-Ledger-Scan.

## Entscheidung gegen persistenten Index

Ein zusätzlicher persistenter Index wird bewusst nicht eingeführt. Die gruppierte lineare Prüfung unterschreitet alle festgelegten Schwellen deutlich, bleibt vollständig aus Ledger und Outbox rekonstruierbar und vermeidet eine weitere Konsistenz- und Recovery-Domäne. Ein Index ist erst neu zu bewerten, wenn spätere reale Benchmarks die dokumentierten Grenzen verletzen.

## Prüfung

- Ruff auf allen betroffenen Python-Dateien: bestanden;
- `git diff --check`: bestanden;
- fokussiert: 51 Tests bestanden;
- vollständige Validierung: 305 Tests bestanden;
- Rollenvertrag: bestanden;
- Local-Smoke: bestanden;
- finaler Benchmark: bestanden;
- bekannte bestehende Warnung: Starlette `TestClient`/`httpx`-Deprecation.

Vollvalidierungs- und Benchmark-Job: `grabowski-job-619e77ffa9cd`, argv SHA-256 `a2c6dddb8329e94cf2e8084c320903e4d6cfec7f62c958a3a6d3d421cb1b200b`, gültiger erfolgreicher Finalisierungsbeleg.
