### PR TITLE
Read canonical producer component in history queries

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -390,6 +390,12 @@ def _event_task_class(event: dict[str, Any]) -> str | None:
     return data.get("task_class") if isinstance(data, dict) else None
 
 
+def _event_source_component(event: dict[str, Any]) -> str | None:
+    """Return the canonical producer component without a subject fallback."""
+    source = event.get("source")
+    return source.get("component") if isinstance(source, dict) else None
+
+
 def _target(*, repo: str | None, host: str | None) -> dict[str, str]:
     if repo is not None:
         return {"scope": "repository", "repo": repo}
@@ -431,7 +437,7 @@ def query_history(*, repo: str | None = None, host: str | None = None, component
         data = event.get("data", {})
         if not _matches_target(subject, repo=repo, host=host):
             continue
-        if component and subject.get("component") != component:
+        if component and _event_source_component(event) != component:
             continue
         if operation and _event_operation(event) != operation:
             continue

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -3,8 +3,8 @@ from pathlib import Path
 import pytest
 import coding_memory, storage
 
-def event(event_id="sha256:"+"a"*64, repo="heimgewebe/example", component="api", operation="implement", outcome="completed", ts="2026-07-13T10:00:00Z"):
-    return {"schema_version":"agent-run-event.v0","event_id":event_id,"kind":"agent.run.completed","ts":ts,"source":{"repo":"heimgewebe/grabowski","component":"grabowski","run_id":"task-test-a1"},"subject":{"repo":repo,"component":component,"operation":operation,"bureau_task_id":"CCM-V1-T001","pr_number":1},"trust_tier":"observed","status":"active","caused_by":[],"evidence_refs":["grabowski-task:test"],"data":{"result":"completed","outcome":outcome}}
+def event(event_id="sha256:"+"a"*64, repo="heimgewebe/example", component="api", operation="implement", outcome="completed", ts="2026-07-13T10:00:00Z", source_component="grabowski"):
+    return {"schema_version":"agent-run-event.v0","event_id":event_id,"kind":"agent.run.completed","ts":ts,"source":{"repo":"heimgewebe/grabowski","component":source_component,"run_id":"task-test-a1"},"subject":{"repo":repo,"component":component,"operation":operation,"bureau_task_id":"CCM-V1-T001","pr_number":1},"trust_tier":"observed","status":"active","caused_by":[],"evidence_refs":["grabowski-task:test"],"data":{"result":"completed","outcome":outcome}}
 
 def setup(tmp_path,monkeypatch):
     monkeypatch.setattr(storage,"DATA_DIR",tmp_path); return tmp_path
@@ -40,7 +40,7 @@ def test_query_compares_since_offset_in_utc(tmp_path,monkeypatch):
 
 def test_query_filters_and_marks_history_only(tmp_path,monkeypatch):
     setup(tmp_path,monkeypatch); coding_memory.import_events([event(),event("sha256:"+"b"*64,repo="heimgewebe/other")])
-    result=coding_memory.query_history(repo="heimgewebe/example",component="api",operation="implement",outcome="completed")
+    result=coding_memory.query_history(repo="heimgewebe/example",component="grabowski",operation="implement",outcome="completed")
     assert result["event_ids"]==["sha256:"+"a"*64]
     assert result["historical_only"] is True and "current_ci_state" in result["does_not_establish"]
 
@@ -105,6 +105,39 @@ def test_query_supports_host_target_and_summary_dimensions(tmp_path,monkeypatch)
     assert result["target"]=={"scope":"host","host":"heim-pc"} and result["event_ids"]==[value["event_id"]]
     assert summary["counts_by_target"]=={"host:heim-pc":1}
     assert summary["counts_by_operation"]=={"recovery":1} and summary["counts_by_task_class"]=={"recovery":1}
+
+
+def test_query_component_uses_canonical_source_for_repository_target_and_combined_filters(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); value=event(component="target-api")
+    value["data"]["task_class"]="coding"; coding_memory.import_events([value])
+    result=coding_memory.query_history(repo="heimgewebe/example",component="grabowski",operation="implement",task_class="coding",outcome="completed")
+    assert result["event_ids"]==[value["event_id"]]
+    assert coding_memory.query_history(repo="heimgewebe/example",component="target-api")["event_ids"]==[]
+
+
+def test_query_component_uses_canonical_source_for_host_target(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); value=event("sha256:"+"d"*64,component="target-runtime",operation="recovery",outcome="blocked")
+    value["kind"]="agent.run.blocked"; value["subject"]={"scope":"host","host":"heim-pc","component":"target-runtime"}
+    value["data"].update({"result":"blocked","operation":"recovery","task_class":"recovery"}); coding_memory.import_events([value])
+    result=coding_memory.query_history(host="heim-pc",component="grabowski",operation="recovery",task_class="recovery",outcome="blocked")
+    assert result["event_ids"]==[value["event_id"]]
+    assert coding_memory.query_history(host="heim-pc",component="target-runtime")["event_ids"]==[]
+
+
+def test_query_component_never_allows_subject_to_override_present_source(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); value=event(component="grabowski",source_component="other-producer")
+    coding_memory.import_events([value])
+    assert coding_memory.query_history(repo="heimgewebe/example",component="grabowski")["event_ids"]==[]
+    assert coding_memory.query_history(repo="heimgewebe/example",component="other-producer")["event_ids"]==[value["event_id"]]
+
+
+def test_query_component_has_no_legacy_subject_fallback(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); legacy=event(component="grabowski"); del legacy["source"]["component"]
+    target=tmp_path/"agent.ledger.jsonl"; target.write_text(json.dumps({"payload":legacy})+"\n")
+    result=coding_memory.query_history(repo="heimgewebe/example",component="grabowski")
+    assert result["event_ids"]==[]
+    assert result["ledger_snapshot"]["invalid_record_count"]==1
+    assert result["ledger_snapshot"]["integrity_valid"] is False
 
 
 def test_query_requires_exactly_one_target():


### PR DESCRIPTION
## Root Cause

`query_history` compared the producer filter against `subject.component`. That field describes the work target, while the canonical producer identity is `event.source.component`.

## Change

- Read producer identity exclusively from `event.source.component`.
- Keep `subject` semantics limited to repository/host targets.
- Deliberately provide no fallback to `subject.component`; a missing canonical source component remains an integrity boundary.

## Verification

- Added regression coverage for repository and host targets.
- Added combined filtering with operation, task class, and outcome.
- Added boundary tests proving `subject.component` cannot override or replace `source.component`.
- Focused tests: 23 passed.
- Full suite: 309 passed.
- Role contract, local smoke, Ruff checks, and `git diff --check` passed.
- Existing compact-test Ruff baseline exclusions remain E401, E501, E701, and E702.

## Live A/B Evidence

On the identical ledger snapshot (`sha256:95ace6b9b89af7b65f2e89d26eff83dbc56fa68c8a6a6e612c76e660c6499da0`, 973 valid, 0 invalid), the deployed old release returned 0 matches while this branch returned exactly one known event (`sha256:48e2f68452689dd078397d420a9bcf55310cdda9bffbfdfafbba95c9f0342b42`) for repository `heimgewebe/hausKI`, producer `grabowski`, operation `implement`, task class `coding`, and outcome `completed`.

The ledger was not mutated. HTTP Chronik and Plexer are outside this change.