### PR TITLE
Harden partial JSONL append rollback

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+import stat
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Final, Iterable, Iterator, Tuple
@@ -20,6 +21,7 @@ __all__ = [
     "StorageError",
     "StorageFullError",
     "StorageBusyError",
+    "StorageRecoveryError",
     "sanitize_domain",
     "secure_filename",
     "target_filename",
@@ -53,6 +55,10 @@ class StorageFullError(StorageError):
 
 class StorageBusyError(StorageError):
     """Raised when the target file is locked/busy."""
+
+
+class StorageRecoveryError(StorageError):
+    """Raised when append rollback or durability cannot be established."""
 
 
 DATA_DIR: Final[Path] = Path(
@@ -228,12 +234,12 @@ def _locked_open(target_path: Path, mode: str) -> Iterator:
         encoding = None
     elif mode == "a":
         flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
-        py_mode = "a"
-        encoding = "utf-8"
+        py_mode = "ab"
+        encoding = None
     elif mode == "a+":
         flags = os.O_RDWR | os.O_CREAT | os.O_APPEND
-        py_mode = "a+"
-        encoding = "utf-8"
+        py_mode = "a+b"
+        encoding = None
     else:
         raise ValueError(f"unsupported mode: {mode}")
 
@@ -276,6 +282,114 @@ def _locked_open(target_path: Path, mode: str) -> Iterator:
     except Timeout as exc:
         logger.warning("busy (lock timeout)", extra={"file": str(target_path)})
         raise StorageBusyError("busy, try again") from exc
+
+
+def _target_stat_for_fd(target_path: Path, fd: int) -> os.stat_result:
+    """Return the opened-file stat only while the path still names that file."""
+    try:
+        opened = os.fstat(fd)
+        current = os.stat(target_path, follow_symlinks=False)
+    except OSError as exc:
+        raise StorageRecoveryError("target identity unavailable") from exc
+    if (
+        not stat.S_ISREG(opened.st_mode)
+        or not stat.S_ISREG(current.st_mode)
+        or (opened.st_dev, opened.st_ino) != (current.st_dev, current.st_ino)
+    ):
+        raise StorageRecoveryError("target identity changed")
+    return opened
+
+
+def _fsync_file(fd: int) -> None:
+    """Sync file contents or expose a distinct durability failure."""
+    try:
+        os.fsync(fd)
+    except OSError as exc:
+        raise StorageRecoveryError("file durability sync failed") from exc
+
+
+def _fsync_parent_directory(target_path: Path) -> None:
+    """Durably bind file creation and metadata changes to the trusted directory."""
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_DIRECTORY", 0)
+    try:
+        dirfd = os.open(str(target_path.parent), flags)
+        try:
+            os.fsync(dirfd)
+        finally:
+            os.close(dirfd)
+    except OSError as exc:
+        raise StorageRecoveryError("directory durability sync failed") from exc
+
+
+def _rollback_append(fd: int, target_path: Path, pre_append_size: int) -> None:
+    """Restore and durably verify the exact byte size captured under the lock."""
+    os.ftruncate(fd, pre_append_size)
+    _fsync_file(fd)
+    _fsync_parent_directory(target_path)
+    restored = _target_stat_for_fd(target_path, fd)
+    if restored.st_size != pre_append_size:
+        raise OSError(
+            errno.EIO,
+            f"rollback size mismatch: expected {pre_append_size}, got {restored.st_size}",
+        )
+
+
+def _raise_append_error(exc: BaseException, target_path: Path) -> None:
+    if isinstance(exc, StorageRecoveryError):
+        raise exc
+    if isinstance(exc, OSError):
+        if exc.errno == errno.ENOSPC:
+            logger.error("disk full", extra={"file": str(target_path)})
+            raise StorageFullError("insufficient storage") from exc
+        raise StorageError("append failed") from exc
+    raise exc
+
+
+def _append_jsonl_transaction(fh, target_path: Path, lines: Iterable[str]) -> None:
+    """Append complete UTF-8 JSONL records or restore the exact previous bytes."""
+    fh.flush()
+    fd = fh.fileno()
+    pre_append = _target_stat_for_fd(target_path, fd)
+    pre_append_size = pre_append.st_size
+    appended_bytes = 0
+    try:
+        for line in lines:
+            payload = (line + "\n").encode("utf-8")
+            written = os.write(fd, payload)
+            if written != len(payload):
+                raise OSError(
+                    errno.EIO,
+                    f"short append write: expected {len(payload)}, wrote {written}",
+                )
+            appended_bytes += written
+        if appended_bytes == 0:
+            return
+        _fsync_file(fd)
+        _fsync_parent_directory(target_path)
+        committed = _target_stat_for_fd(target_path, fd)
+        expected_size = pre_append_size + appended_bytes
+        if committed.st_size != expected_size:
+            raise StorageRecoveryError(
+                f"append size mismatch: expected {expected_size}, got {committed.st_size}"
+            )
+    except BaseException as exc:
+        try:
+            _rollback_append(fd, target_path, pre_append_size)
+        except BaseException as rollback_exc:
+            logger.critical(
+                "append rollback failed",
+                extra={
+                    "file": str(target_path),
+                    "pre_append_size": pre_append_size,
+                    "append_error": repr(exc),
+                    "rollback_error": repr(rollback_exc),
+                },
+            )
+            raise StorageRecoveryError(
+                "append rollback failed; ledger integrity is uncertain"
+            ) from rollback_exc
+        _raise_append_error(exc, target_path)
 
 
 def read_tail(domain: str, limit: int) -> list[str]:
@@ -530,18 +644,12 @@ def write_payload(domain: str, lines: Iterable[str]) -> None:
         raise StorageError("invalid target path") from exc
 
     with _locked_open(target_path, "a") as fh:
-        try:
-            for line in lines:
-                fh.write(line)
-                fh.write("\n")
-        except OSError as exc:
-            if exc.errno == errno.ENOSPC:
-                logger.error("disk full", extra={"file": str(target_path)})
-                raise StorageFullError("insufficient storage") from exc
-            raise
+        _append_jsonl_transaction(fh, target_path, lines)
 
 
-def _parse_unique_payload(line: str, identity_key: str) -> tuple[str | None, bytes]:
+def _parse_unique_payload(
+    line: str | bytes, identity_key: str
+) -> tuple[str | None, bytes]:
     value = json.loads(line)
     payload = value.get("payload", value) if isinstance(value, dict) else None
     identity = payload.get(identity_key) if isinstance(payload, dict) else None
@@ -628,6 +736,7 @@ def write_payload_unique_groups(
         total_written = 0
         total_skipped = 0
         group_results = []
+        append_lines = []
         for group_id, parsed in parsed_groups:
             group_written = 0
             group_skipped = 0
@@ -636,8 +745,7 @@ def write_payload_unique_groups(
                     group_skipped += 1
                     total_skipped += 1
                     continue
-                fh.write(line)
-                fh.write("\n")
+                append_lines.append(line)
                 existing[identity] = canonical_payload
                 group_written += 1
                 total_written += 1
@@ -649,8 +757,7 @@ def write_payload_unique_groups(
                     "skipped": group_skipped,
                 }
             )
-        fh.flush()
-        os.fsync(fh.fileno())
+        _append_jsonl_transaction(fh, target_path, append_lines)
     return {
         "written": total_written,
         "skipped": total_skipped,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -763,22 +763,15 @@ def test_disk_full_returns_507(monkeypatch, tmp_path, client):
 
 
 def test_disk_full_during_write_returns_507(monkeypatch, tmp_path, client):
-    """Test ENOSPC during the write call itself (not just open)."""
-    from contextlib import contextmanager
-
+    """Test ENOSPC during the low-level transactional append."""
     secret = _test_secret()
     monkeypatch.setenv("CHRONIK_TOKEN", secret)
     monkeypatch.setattr("storage.DATA_DIR", tmp_path)
 
-    # Mock _locked_open to return a file-like object that fails on write
-    @contextmanager
-    def _mock_locked_open(*args, **kwargs):
-        class MockFile:
-            def write(self, data):
-                raise OSError(errno.ENOSPC, "No space left on device")
-        yield MockFile()
+    def _raise_enospc(fd, data):
+        raise OSError(errno.ENOSPC, "No space left on device")
 
-    monkeypatch.setattr("storage._locked_open", _mock_locked_open)
+    monkeypatch.setattr("storage.os.write", _raise_enospc)
 
     response = client.post(
         "/ingest/example.com",
@@ -788,6 +781,38 @@ def test_disk_full_during_write_returns_507(monkeypatch, tmp_path, client):
 
     assert response.status_code == 507
     assert "insufficient" in response.text.lower()
+
+
+def test_recovery_error_returns_500_and_preserves_original_bytes(
+    monkeypatch, tmp_path, client
+):
+    secret = _test_secret()
+    monkeypatch.setenv("CHRONIK_TOKEN", secret)
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+    target = tmp_path / "example.com.jsonl"
+    original = b'{"existing":true}\n'
+    target.write_bytes(original)
+    real_fsync = storage.os.fsync
+    calls = 0
+
+    def fail_first_fsync(fd):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError(errno.EIO, "simulated durability failure")
+        return real_fsync(fd)
+
+    monkeypatch.setattr("storage.os.fsync", fail_first_fsync)
+
+    response = client.post(
+        "/ingest/example.com",
+        headers={"X-Auth": secret, "Content-Type": "application/json"},
+        json={"data": "foo"},
+    )
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "storage error"}
+    assert target.read_bytes() == original
 
 
 def test_fd_leak_prevented_on_oserror(monkeypatch, tmp_path, client):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -135,3 +135,202 @@ def test_write_payload_unique_wrapper_retains_tuple_contract(mock_data_dir):
     assert storage.write_payload_unique(
         "agent.ledger", [_unique_line("one", "a"), _unique_line("one", "a")]
     ) == (1, 1)
+
+
+def test_write_payload_rolls_back_short_write(mock_data_dir, monkeypatch):
+    original = b'{"existing":1}\n'
+    target = mock_data_dir / "agent.ledger.jsonl"
+    target.write_bytes(original)
+    real_write = storage.os.write
+
+    def short_write(fd, payload):
+        prefix = max(1, len(payload) // 2)
+        return real_write(fd, payload[:prefix])
+
+    monkeypatch.setattr(storage.os, "write", short_write)
+
+    with pytest.raises(storage.StorageError, match="append failed"):
+        storage.write_payload("agent.ledger", ['{"new":2}'])
+
+    assert target.read_bytes() == original
+    assert storage.read_domain_snapshot("agent.ledger") == original
+
+
+def test_write_payload_rolls_back_enospc_after_prior_record(mock_data_dir, monkeypatch):
+    original = b'{"existing":1}\n'
+    target = mock_data_dir / "agent.ledger.jsonl"
+    target.write_bytes(original)
+    real_write = storage.os.write
+    calls = 0
+
+    def fail_second_write(fd, payload):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError(28, "No space left on device")
+        return real_write(fd, payload)
+
+    monkeypatch.setattr(storage.os, "write", fail_second_write)
+
+    with pytest.raises(storage.StorageFullError, match="insufficient storage"):
+        storage.write_payload("agent.ledger", ['{"new":2}', '{"new":3}'])
+
+    assert target.read_bytes() == original
+
+
+def test_unique_group_append_rolls_back_without_weakening_conflicts(
+    mock_data_dir, monkeypatch
+):
+    first = _unique_line("existing", "same")
+    storage.write_payload("agent.ledger", [first])
+    target = mock_data_dir / "agent.ledger.jsonl"
+    original = target.read_bytes()
+    real_write = storage.os.write
+
+    def short_write(fd, payload):
+        real_write(fd, payload[:4])
+        return 4
+
+    monkeypatch.setattr(storage.os, "write", short_write)
+    with pytest.raises(storage.StorageError, match="append failed"):
+        storage.write_payload_unique_groups(
+            "agent.ledger", [("new", [_unique_line("new", "value")])]
+        )
+    assert target.read_bytes() == original
+
+    monkeypatch.setattr(storage.os, "write", real_write)
+    with pytest.raises(storage.StorageError, match="conflicting event_id"):
+        storage.write_payload_unique_groups(
+            "agent.ledger", [("conflict", [_unique_line("existing", "different")])]
+        )
+    assert target.read_bytes() == original
+
+
+def test_append_rollback_failure_is_distinct(mock_data_dir, monkeypatch):
+    target = mock_data_dir / "agent.ledger.jsonl"
+    target.write_bytes(b'{"existing":1}\n')
+
+    def fail_write(fd, payload):
+        raise OSError(28, "No space left on device")
+
+    def fail_rollback(fd, size):
+        raise OSError(5, "rollback failed")
+
+    monkeypatch.setattr(storage.os, "write", fail_write)
+    monkeypatch.setattr(storage.os, "ftruncate", fail_rollback)
+
+    with pytest.raises(
+        storage.StorageRecoveryError, match="ledger integrity is uncertain"
+    ):
+        storage.write_payload("agent.ledger", ['{"new":2}'])
+
+
+def test_append_detects_target_replacement_and_fails_closed(
+    mock_data_dir, monkeypatch
+):
+    target = mock_data_dir / "agent.ledger.jsonl"
+    original = b'{"existing":1}\n'
+    target.write_bytes(original)
+    displaced = mock_data_dir / "displaced.jsonl"
+    real_write = storage.os.write
+    replaced = False
+
+    def replace_after_write(fd, payload):
+        nonlocal replaced
+        written = real_write(fd, payload)
+        if not replaced:
+            target.rename(displaced)
+            target.write_bytes(b'{"replacement":true}\n')
+            replaced = True
+        return written
+
+    monkeypatch.setattr(storage.os, "write", replace_after_write)
+
+    with pytest.raises(storage.StorageRecoveryError):
+        storage.write_payload("agent.ledger", ['{"new":2}'])
+
+    assert target.read_bytes() == b'{"replacement":true}\n'
+    assert displaced.read_bytes() == original
+
+
+def test_append_rollback_happens_before_domain_lock_release(
+    mock_data_dir, monkeypatch
+):
+    from filelock import FileLock, Timeout
+
+    target = mock_data_dir / "agent.ledger.jsonl"
+    target.write_bytes(b'{"existing":1}\n')
+    lock_path = storage.get_lock_path(target)
+    real_truncate = storage.os.ftruncate
+    lock_was_held = False
+
+    def checked_truncate(fd, size):
+        nonlocal lock_was_held
+        contender = FileLock(str(lock_path), timeout=0)
+        try:
+            contender.acquire()
+        except Timeout:
+            lock_was_held = True
+        else:
+            contender.release()
+        real_truncate(fd, size)
+
+    def fail_write(fd, payload):
+        raise OSError(5, "simulated append failure")
+
+    monkeypatch.setattr(storage.os, "write", fail_write)
+    monkeypatch.setattr(storage.os, "ftruncate", checked_truncate)
+
+    with pytest.raises(storage.StorageError, match="append failed"):
+        storage.write_payload("agent.ledger", ['{"new":2}'])
+
+    assert lock_was_held
+
+
+def test_write_payload_serializes_across_processes(mock_data_dir):
+    import os
+    import subprocess
+    import sys
+
+    code = (
+        "import storage; "
+        "storage.write_payload('agent.ledger', "
+        "['{\\\"process\\\":' + __import__('sys').argv[1] + '}'])"
+    )
+    env = os.environ.copy()
+    env["CHRONIK_DATA_DIR"] = str(mock_data_dir)
+    processes = [
+        subprocess.Popen([sys.executable, "-c", code, str(index)], env=env)
+        for index in range(8)
+    ]
+    assert [process.wait(timeout=20) for process in processes] == [0] * 8
+
+    target = mock_data_dir / "agent.ledger.jsonl"
+    lines = target.read_bytes().splitlines(keepends=True)
+    assert len(lines) == 8
+    assert all(line.endswith(b"\n") for line in lines)
+    assert {json.loads(line)["process"] for line in lines} == set(range(8))
+
+
+def test_commit_fsync_failure_rolls_back_and_is_recovery_error(
+    mock_data_dir, monkeypatch
+):
+    original = b'{"existing":1}\n'
+    target = mock_data_dir / "agent.ledger.jsonl"
+    target.write_bytes(original)
+    real_fsync = storage.os.fsync
+    calls = 0
+
+    def fail_first_fsync(fd):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError(5, "simulated durability failure")
+        return real_fsync(fd)
+
+    monkeypatch.setattr(storage.os, "fsync", fail_first_fsync)
+
+    with pytest.raises(storage.StorageRecoveryError, match="durability sync failed"):
+        storage.write_payload("agent.ledger", ['{"new":2}'])
+
+    assert target.read_bytes() == original


### PR DESCRIPTION
## Ziel

Schließt Bureau `CHRONIK-ECOSYSTEM-CLOSEOUT-V1-T008`: partielle JSONL-Appends dürfen bei Short Write, `ENOSPC`, Durability- oder Identitätsfehlern keine halben Datensätze im Ledger hinterlassen.

## Änderung

- erfasst Dateigröße und Inode-Identität unter dem bestehenden prozessübergreifenden Domain-Lock;
- schreibt vollständige UTF-8-JSONL-Datensätze mit Low-Level-Append;
- behandelt Short Writes konservativ als Fehler und rollt vor Lockfreigabe auf die exakte Ausgangsgröße zurück;
- synchronisiert Datei und Elternverzeichnis;
- meldet Durability-, Zielersetzungs- und Rollbackfehler als eigenen fail-closed `StorageRecoveryError`;
- verwendet denselben Transaktionspfad für normale und deduplizierende Gruppen-Appends;
- bewahrt bestehende `event_id`-Konfliktsemantik.

## Gebundene Evidence

- Base: `4d7e328980baeb53bdfb02657e80ffe2a044c67e`
- Head: `f47bfa8fc04d400563407d31e68f2345d316b84d`
- Tree: `4e4d747916ed79853846e517b2f1f7b84f03ee82`
- Diff-Artefakt: `/home/alex/iCloud/Drive/halde/chronik-t008-partial-append-rollback-f47bfa8.diff`
- Diff-SHA-256: `f78fff4d9cf28392f33f3237520d5c3d9243a73711ca5bda52990da952b742ea`
- Stable Patch-ID: `80a10e02319ee45594e9762c8ed9d82d9b867548`
- Exakte-Head-Validierung: `grabowski-job-6e81d1a31a4d`
- Finalization Receipt: `dfb44156f60fa3109831f2b138ca6e08e0e62978451a31111a72b0d02b5267d3`
- Rollenvertrag: bestanden
- Tests: 318 bestanden
- `validate-local.sh`: bestanden, Smoke-Test bestanden
- Vorwärts- und Reverse-Apply des Artefakts: bestanden

## Grenzen

- keine Änderung am Live-Ledger;
- keine Aktivierung von HTTP- oder Plexer-Diensten;
- kein Deployment in diesem PR-Schritt;
- bestehende Starlette/httpx-Abkündigungswarnung bleibt außerhalb dieses Integritätsfixes.
