### PR TITLE
docs: source system context from Systemkatalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,13 +267,14 @@ print(ingest_event(
 ))
 ```
 
-## Organismus-Kontext
+## Systemkontext
 
-Dieses Repository ist Teil des **Heimgewebe-Organismus**.
+Der aktuelle Zweck, Lifecycle-Status und die Beziehungen dieses Repositories zu anderen
+Heimgewebe-Systemen werden im [Systemkatalog](https://github.com/heimgewebe/systemkatalog) geführt. Die
+[gerenderte Systemübersicht](https://github.com/heimgewebe/systemkatalog/blob/main/rendered/system-catalog.md)
+ist die lesbare Gesamtsicht; die
+[maschinenlesbare Inventur](https://github.com/heimgewebe/systemkatalog/blob/main/registry/ecosystem/nodes.json)
+ist die Quelle für Automatisierung.
 
-Die übergeordnete Architektur, Achsen, Rollen und Contracts sind zentral beschrieben im  
-👉 [`metarepo/docs/system/heimgewebe-organismus.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/system/heimgewebe-organismus.md)  
-👉 [`metarepo/docs/heimgewebe-zielbild.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-zielbild.md).
-
-Alle Rollen-Definitionen, Datenflüsse und Contract-Zuordnungen dieses Repos
-sind dort verankert.
+Repositoryeigene Betriebs-, Daten- und Implementierungswahrheit bleibt in diesem Repository.
+Gemeinsame Contracts bleiben bei ihrer jeweiligen Primärquelle.


### PR DESCRIPTION
## Zweck

Aktive Verweise auf die historisierte Metarepo-Organismusarchitektur werden durch den Systemkatalog als Primärquelle für Zweck, Lifecycle-Status und Beziehungen ersetzt.

## Änderung

- README-Systemkontext auf Systemkatalog umgestellt
- repositoryeigene Betriebs-, Daten- und Implementierungswahrheit klar lokal belassen
- gemeinsame Contracts bei ihren jeweiligen Primärquellen belassen

## Prüfung

- lokaler Validator grün
- 318 Tests und Smoke bestanden
- T006-Drift-, Ziel- und Whitespace-Gate bestanden

Bureau: `METAREPO-LEGACY-RECONCILIATION-V1-T006`