### PR TITLE
perf: bound coding-memory query selection

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import heapq
 import json
 import os
 import tempfile
@@ -9,7 +10,7 @@ from collections import Counter
 from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 from jsonschema import Draft7Validator
 
@@ -322,19 +323,25 @@ def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str
     }
 
 
-def _record_snapshot() -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    rows: list[dict[str, Any]] = []
+def _scan_record_snapshot(
+    visit: Callable[[dict[str, Any], int], None],
+) -> dict[str, Any]:
+    """Validate one byte-bound snapshot while releasing each decoded row promptly."""
     diagnostics: list[dict[str, Any]] = []
     invalid_record_count = 0
     total_record_count = 0
+    valid_record_count = 0
     raw_snapshot = storage.read_domain_snapshot(DOMAIN)
     complete_bytes = len(raw_snapshot)
     snapshot_sha256 = sha256_bytes(raw_snapshot)
     start_offset = 0
 
-    complete_lines = raw_snapshot.split(b"\n")[:-1] if raw_snapshot else []
-    for content in complete_lines:
-        next_offset = start_offset + len(content) + 1
+    while start_offset < complete_bytes:
+        newline_at = raw_snapshot.find(b"\n", start_offset)
+        if newline_at < 0:
+            break
+        content = raw_snapshot[start_offset:newline_at]
+        next_offset = newline_at + 1
         if not content.strip():
             start_offset = next_offset
             continue
@@ -351,28 +358,56 @@ def _record_snapshot() -> tuple[list[dict[str, Any]], dict[str, Any]]:
         except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
             invalid_record_count += 1
             if len(diagnostics) < MAX_INTEGRITY_DIAGNOSTICS:
-                diagnostics.append({
-                    "offset": start_offset,
-                    "next_offset": next_offset,
-                    "error": str(exc),
-                })
+                diagnostics.append(
+                    {
+                        "offset": start_offset,
+                        "next_offset": next_offset,
+                        "error": str(exc),
+                    }
+                )
             start_offset = next_offset
             continue
-        rows.append({"received_at": envelope.get("received_at"), "payload": payload})
+        row = {"received_at": envelope.get("received_at"), "payload": payload}
+        visit(row, valid_record_count)
+        valid_record_count += 1
         start_offset = next_offset
 
-    ledger_snapshot = {
+    return {
         "domain": DOMAIN,
         "sha256": snapshot_sha256,
         "complete_bytes": complete_bytes,
         "total_record_count": total_record_count,
-        "valid_record_count": len(rows),
+        "valid_record_count": valid_record_count,
         "invalid_record_count": invalid_record_count,
         "integrity_valid": invalid_record_count == 0,
         "diagnostics": diagnostics,
         "diagnostics_truncated": invalid_record_count > len(diagnostics),
     }
+
+
+def _record_snapshot() -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Materialize a snapshot for compatibility with existing internal callers."""
+    rows: list[dict[str, Any]] = []
+    ledger_snapshot = _scan_record_snapshot(lambda row, _sequence: rows.append(row))
     return rows, ledger_snapshot
+
+
+def _retain_latest(
+    heap: list[tuple[datetime, str, int, dict[str, Any]]],
+    *,
+    event_at: datetime,
+    event_id: str,
+    sequence: int,
+    value: dict[str, Any],
+    limit: int,
+) -> None:
+    """Keep only the newest bounded candidates using the public ordering contract."""
+    candidate_key = (event_at, event_id, -sequence)
+    candidate = (*candidate_key, value)
+    if len(heap) < limit:
+        heapq.heappush(heap, candidate)
+    elif candidate_key > heap[0][:3]:
+        heapq.heapreplace(heap, candidate)
 
 
 def _event_operation(event: dict[str, Any]) -> str | None:
@@ -427,38 +462,75 @@ def validate_query(*, repo: str | None = None, host: str | None = None, componen
     return _parse_timestamp(since, field="since") if since is not None else None
 
 
-def query_history(*, repo: str | None = None, host: str | None = None, component: str | None = None, operation: str | None = None, task_class: str | None = None, outcome: str | None = None, since: str | None = None, limit: int = 20) -> dict[str, Any]:
-    since_at = validate_query(repo=repo, host=host, component=component, operation=operation, task_class=task_class, outcome=outcome, since=since, limit=limit)
-    rows, ledger_snapshot = _record_snapshot()
-    selected: list[dict[str, Any]] = []
-    for row in rows:
+def query_history(
+    *,
+    repo: str | None = None,
+    host: str | None = None,
+    component: str | None = None,
+    operation: str | None = None,
+    task_class: str | None = None,
+    outcome: str | None = None,
+    since: str | None = None,
+    limit: int = 20,
+) -> dict[str, Any]:
+    since_at = validate_query(
+        repo=repo,
+        host=host,
+        component=component,
+        operation=operation,
+        task_class=task_class,
+        outcome=outcome,
+        since=since,
+        limit=limit,
+    )
+    selected: list[tuple[datetime, str, int, dict[str, Any]]] = []
+
+    def consider(row: dict[str, Any], sequence: int) -> None:
         event = row["payload"]
         subject = event["subject"]
         data = event.get("data", {})
         if not _matches_target(subject, repo=repo, host=host):
-            continue
+            return
         if component and _event_source_component(event) != component:
-            continue
+            return
         if operation and _event_operation(event) != operation:
-            continue
+            return
         if task_class and _event_task_class(event) != task_class:
-            continue
+            return
         actual_outcome = data.get("outcome") or data.get("result")
         if outcome and actual_outcome != outcome:
-            continue
+            return
         event_at = _parse_timestamp(event["ts"], field="ts")
         if since_at is not None and event_at < since_at:
-            continue
-        selected.append({**row, "event_at": event_at})
-    selected.sort(key=lambda row: (row["event_at"], row["payload"]["event_id"]), reverse=True)
-    selected = selected[:limit]
-    query = {"repo": repo, "host": host, "component": component, "operation": operation, "task_class": task_class, "outcome": outcome, "since": since, "limit": limit}
+            return
+        _retain_latest(
+            selected,
+            event_at=event_at,
+            event_id=event["event_id"],
+            sequence=sequence,
+            value=row,
+            limit=limit,
+        )
+
+    ledger_snapshot = _scan_record_snapshot(consider)
+    selected.sort(key=lambda item: item[:3], reverse=True)
+    selected_rows = [item[3] for item in selected]
+    query = {
+        "repo": repo,
+        "host": host,
+        "component": component,
+        "operation": operation,
+        "task_class": task_class,
+        "outcome": outcome,
+        "since": since,
+        "limit": limit,
+    }
     return {
         "schema_version": "chronik-coding-history.v1",
         "query": query,
         "target": _target(repo=repo, host=host),
-        "events": [row["payload"] for row in selected],
-        "event_ids": [row["payload"]["event_id"] for row in selected],
+        "events": [row["payload"] for row in selected_rows],
+        "event_ids": [row["payload"]["event_id"] for row in selected_rows],
         "ledger_snapshot": ledger_snapshot,
         "historical_only": True,
         "does_not_establish": DOES_NOT_ESTABLISH,
@@ -469,40 +541,49 @@ def operator_summary(*, since: str | None = None, limit: int = 20) -> dict[str, 
     if limit < 1 or limit > 500:
         raise ValueError("limit 1..500 is required")
     since_at = _parse_timestamp(since, field="since") if since is not None else None
-    rows, ledger_snapshot = _record_snapshot()
-    selected: list[tuple[datetime, dict[str, Any]]] = []
-    for row in rows:
+    event_count = 0
+    kind_counts: Counter[str] = Counter()
+    repo_counts: Counter[str] = Counter()
+    host_counts: Counter[str] = Counter()
+    target_counts: Counter[str] = Counter()
+    operation_counts: Counter[str] = Counter()
+    task_class_counts: Counter[str] = Counter()
+    blocker_counts: Counter[str] = Counter()
+    recent_heap: list[tuple[datetime, str, int, dict[str, Any]]] = []
+
+    def summarize(row: dict[str, Any], sequence: int) -> None:
+        nonlocal event_count
         event = row["payload"]
         event_at = _parse_timestamp(event["ts"], field="ts")
         if since_at is not None and event_at < since_at:
-            continue
-        selected.append((event_at, event))
-    selected.sort(key=lambda item: (item[0], item[1]["event_id"]), reverse=True)
-    kind_counts = Counter(event["kind"] for _, event in selected)
-    repo_counts = Counter(event.get("subject", {}).get("repo", "unknown") for _, event in selected)
-    host_counts = Counter(
-        event.get("subject", {}).get("host")
-        for _, event in selected
-        if event.get("subject", {}).get("scope") == "host" and event.get("subject", {}).get("host")
-    )
-    target_counts = Counter()
-    operation_counts = Counter()
-    task_class_counts = Counter()
-    for _, event in selected:
+            return
+        event_count += 1
         subject = event.get("subject", {})
-        if subject.get("scope") == "host":
-            target_counts[f"host:{subject.get('host', 'unknown')}"] += 1
+        data = event.get("data", {})
+        kind_counts[event["kind"]] += 1
+        repo_counts[subject.get("repo", "unknown")] += 1
+        if subject.get("scope") == "host" and subject.get("host"):
+            host_counts[subject["host"]] += 1
+            target_counts[f"host:{subject['host']}"] += 1
         else:
             target_counts[f"repository:{subject.get('repo', 'unknown')}"] += 1
         operation_counts[_event_operation(event) or "unspecified"] += 1
         task_class_counts[_event_task_class(event) or "unspecified"] += 1
-    blocker_counts = Counter(
-        event.get("data", {}).get("blocker_code", "unspecified")
-        for _, event in selected
-        if event.get("kind") == "agent.run.blocked"
-    )
+        if event.get("kind") == "agent.run.blocked":
+            blocker_counts[data.get("blocker_code", "unspecified")] += 1
+        _retain_latest(
+            recent_heap,
+            event_at=event_at,
+            event_id=event["event_id"],
+            sequence=sequence,
+            value=event,
+            limit=limit,
+        )
+
+    ledger_snapshot = _scan_record_snapshot(summarize)
+    recent_heap.sort(key=lambda item: item[:3], reverse=True)
     recent = []
-    for _, event in selected[:limit]:
+    for _, _, _, event in recent_heap:
         subject = event.get("subject", {})
         recent.append(
             {
@@ -510,7 +591,11 @@ def operator_summary(*, since: str | None = None, limit: int = 20) -> dict[str, 
                 "ts": event["ts"],
                 "kind": event["kind"],
                 "run_id": event.get("source", {}).get("run_id"),
-                "target": {"scope": "host", "host": subject.get("host")} if subject.get("scope") == "host" else {"scope": "repository", "repo": subject.get("repo")},
+                "target": (
+                    {"scope": "host", "host": subject.get("host")}
+                    if subject.get("scope") == "host"
+                    else {"scope": "repository", "repo": subject.get("repo")}
+                ),
                 "subject": subject,
                 "operation": _event_operation(event),
                 "task_class": _event_task_class(event),
@@ -520,7 +605,7 @@ def operator_summary(*, since: str | None = None, limit: int = 20) -> dict[str, 
     return {
         "schema_version": "chronik-operator-summary.v1",
         "since": since,
-        "event_count": len(selected),
+        "event_count": event_count,
         "limit": limit,
         "counts_by_kind": dict(sorted(kind_counts.items())),
         "counts_by_subject_repo": dict(sorted(repo_counts.items())),

--- a/coding_memory.py
+++ b/coding_memory.py
@@ -69,13 +69,13 @@ def _validator() -> Draft7Validator:
     return Draft7Validator(schema)
 
 
-def validate_event(event: dict[str, Any]) -> None:
+def validate_event(event: dict[str, Any]) -> datetime:
     errors = sorted(_validator().iter_errors(event), key=lambda error: list(error.absolute_path))
     if errors:
         error = errors[0]
         path = "/".join(str(part) for part in error.absolute_path) or "<root>"
         raise ValueError(f"invalid coding event at {path}: {error.message}")
-    _parse_timestamp(event["ts"], field="ts")
+    return _parse_timestamp(event["ts"], field="ts")
 
 
 def _envelope_lines(events: Iterable[dict[str, Any]]) -> list[str]:
@@ -324,9 +324,9 @@ def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str
 
 
 def _scan_record_snapshot(
-    visit: Callable[[dict[str, Any], int], None],
+    visit: Callable[[dict[str, Any], datetime, int], None],
 ) -> dict[str, Any]:
-    """Validate one byte-bound snapshot while releasing each decoded row promptly."""
+    """Validate complete records from one byte-bound snapshot and visit each once."""
     diagnostics: list[dict[str, Any]] = []
     invalid_record_count = 0
     total_record_count = 0
@@ -354,7 +354,7 @@ def _scan_record_snapshot(
             payload = envelope.get("payload")
             if not isinstance(payload, dict):
                 raise ValueError("payload must be an object")
-            validate_event(payload)
+            event_at = validate_event(payload)
         except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
             invalid_record_count += 1
             if len(diagnostics) < MAX_INTEGRITY_DIAGNOSTICS:
@@ -368,7 +368,7 @@ def _scan_record_snapshot(
             start_offset = next_offset
             continue
         row = {"received_at": envelope.get("received_at"), "payload": payload}
-        visit(row, valid_record_count)
+        visit(row, event_at, valid_record_count)
         valid_record_count += 1
         start_offset = next_offset
 
@@ -385,13 +385,6 @@ def _scan_record_snapshot(
     }
 
 
-def _record_snapshot() -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    """Materialize a snapshot for compatibility with existing internal callers."""
-    rows: list[dict[str, Any]] = []
-    ledger_snapshot = _scan_record_snapshot(lambda row, _sequence: rows.append(row))
-    return rows, ledger_snapshot
-
-
 def _retain_latest(
     heap: list[tuple[datetime, str, int, dict[str, Any]]],
     *,
@@ -402,6 +395,8 @@ def _retain_latest(
     limit: int,
 ) -> None:
     """Keep only the newest bounded candidates using the public ordering contract."""
+    # The former stable reverse sort kept the earlier row first when public
+    # keys were equal. Negating the scan sequence preserves that exact contract.
     candidate_key = (event_at, event_id, -sequence)
     candidate = (*candidate_key, value)
     if len(heap) < limit:
@@ -485,10 +480,9 @@ def query_history(
     )
     selected: list[tuple[datetime, str, int, dict[str, Any]]] = []
 
-    def consider(row: dict[str, Any], sequence: int) -> None:
+    def consider(row: dict[str, Any], event_at: datetime, sequence: int) -> None:
         event = row["payload"]
         subject = event["subject"]
-        data = event.get("data", {})
         if not _matches_target(subject, repo=repo, host=host):
             return
         if component and _event_source_component(event) != component:
@@ -497,10 +491,15 @@ def query_history(
             return
         if task_class and _event_task_class(event) != task_class:
             return
-        actual_outcome = data.get("outcome") or data.get("result")
-        if outcome and actual_outcome != outcome:
-            return
-        event_at = _parse_timestamp(event["ts"], field="ts")
+        if outcome:
+            data = event.get("data")
+            actual_outcome = (
+                data.get("outcome") or data.get("result")
+                if isinstance(data, dict)
+                else None
+            )
+            if actual_outcome != outcome:
+                return
         if since_at is not None and event_at < since_at:
             return
         _retain_latest(
@@ -551,10 +550,9 @@ def operator_summary(*, since: str | None = None, limit: int = 20) -> dict[str, 
     blocker_counts: Counter[str] = Counter()
     recent_heap: list[tuple[datetime, str, int, dict[str, Any]]] = []
 
-    def summarize(row: dict[str, Any], sequence: int) -> None:
+    def summarize(row: dict[str, Any], event_at: datetime, sequence: int) -> None:
         nonlocal event_count
         event = row["payload"]
-        event_at = _parse_timestamp(event["ts"], field="ts")
         if since_at is not None and event_at < since_at:
             return
         event_count += 1

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -237,9 +237,7 @@ def test_snapshot_treats_only_lf_as_jsonl_record_boundary(tmp_path,monkeypatch):
     assert snapshot["diagnostics"][0]["next_offset"]==len(raw)
 
 
-def test_queries_keep_bounded_latest_candidates_without_materializing_all_rows(
-    tmp_path, monkeypatch
-):
+def test_queries_keep_bounded_latest_candidates(tmp_path, monkeypatch):
     setup(tmp_path, monkeypatch)
     values = [
         event(
@@ -250,10 +248,6 @@ def test_queries_keep_bounded_latest_candidates_without_materializing_all_rows(
     ]
     coding_memory.import_events(values)
 
-    def forbidden_materialization():
-        raise AssertionError("queries must not materialize the full record snapshot")
-
-    monkeypatch.setattr(coding_memory, "_record_snapshot", forbidden_materialization)
     observed_heap_sizes = []
     retain_latest = coding_memory._retain_latest
 
@@ -274,3 +268,70 @@ def test_queries_keep_bounded_latest_candidates_without_materializing_all_rows(
     assert summary["event_count"] == 40
     assert observed_heap_sizes
     assert all(size <= limit for limit, size in observed_heap_sizes)
+
+
+def test_operator_summary_count_remains_since_filtered_while_snapshot_count_is_total(
+    tmp_path, monkeypatch
+):
+    setup(tmp_path, monkeypatch)
+    coding_memory.import_events(
+        [
+            event(ts="2026-07-13T09:00:00Z"),
+            event("sha256:" + "b" * 64, ts="2026-07-13T11:00:00Z"),
+        ]
+    )
+
+    summary = coding_memory.operator_summary(since="2026-07-13T10:00:00Z")
+
+    assert summary["event_count"] == 1
+    assert summary["ledger_snapshot"]["total_record_count"] == 2
+    assert [row["event_id"] for row in summary["recent"]] == [
+        "sha256:" + "b" * 64
+    ]
+
+
+def test_equal_public_sort_keys_preserve_earlier_snapshot_order_at_limit(
+    tmp_path, monkeypatch
+):
+    setup(tmp_path, monkeypatch)
+    first = event()
+    first["source"]["run_id"] = "first"
+    second = event()
+    second["source"]["run_id"] = "second"
+    target = tmp_path / "agent.ledger.jsonl"
+    target.write_text(
+        json.dumps({"payload": first}) + "\n" + json.dumps({"payload": second}) + "\n",
+        encoding="utf-8",
+    )
+
+    history = coding_memory.query_history(repo="heimgewebe/example", limit=1)
+    summary = coding_memory.operator_summary(limit=1)
+
+    assert history["events"][0]["source"]["run_id"] == "first"
+    assert summary["recent"][0]["run_id"] == "first"
+
+
+def test_queries_reuse_timestamp_parsed_during_validation(tmp_path, monkeypatch):
+    setup(tmp_path, monkeypatch)
+    coding_memory.import_events(
+        [
+            event(),
+            event("sha256:" + "b" * 64),
+            event("sha256:" + "c" * 64),
+        ]
+    )
+    parse_timestamp = coding_memory._parse_timestamp
+    calls = []
+
+    def counted_parse(value, *, field):
+        calls.append((value, field))
+        return parse_timestamp(value, field=field)
+
+    monkeypatch.setattr(coding_memory, "_parse_timestamp", counted_parse)
+
+    coding_memory.query_history(repo="heimgewebe/example")
+    assert len(calls) == 3
+
+    calls.clear()
+    coding_memory.operator_summary()
+    assert len(calls) == 3

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -235,3 +235,42 @@ def test_snapshot_treats_only_lf_as_jsonl_record_boundary(tmp_path,monkeypatch):
     assert snapshot["total_record_count"]==1
     assert snapshot["invalid_record_count"]==1
     assert snapshot["diagnostics"][0]["next_offset"]==len(raw)
+
+
+def test_queries_keep_bounded_latest_candidates_without_materializing_all_rows(
+    tmp_path, monkeypatch
+):
+    setup(tmp_path, monkeypatch)
+    values = [
+        event(
+            "sha256:" + format(index, "064x"),
+            ts="2026-07-13T10:00:00Z",
+        )
+        for index in range(40)
+    ]
+    coding_memory.import_events(values)
+
+    def forbidden_materialization():
+        raise AssertionError("queries must not materialize the full record snapshot")
+
+    monkeypatch.setattr(coding_memory, "_record_snapshot", forbidden_materialization)
+    observed_heap_sizes = []
+    retain_latest = coding_memory._retain_latest
+
+    def track_heap(heap, **kwargs):
+        retain_latest(heap, **kwargs)
+        observed_heap_sizes.append((kwargs["limit"], len(heap)))
+
+    monkeypatch.setattr(coding_memory, "_retain_latest", track_heap)
+    history = coding_memory.query_history(repo="heimgewebe/example", limit=3)
+    summary = coding_memory.operator_summary(limit=4)
+
+    assert history["event_ids"] == [
+        "sha256:" + format(index, "064x") for index in (39, 38, 37)
+    ]
+    assert [row["event_id"] for row in summary["recent"]] == [
+        "sha256:" + format(index, "064x") for index in (39, 38, 37, 36)
+    ]
+    assert summary["event_count"] == 40
+    assert observed_heap_sizes
+    assert all(size <= limit for limit, size in observed_heap_sizes)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -213,11 +213,11 @@ def test_append_rollback_failure_is_distinct(mock_data_dir, monkeypatch):
     def fail_write(fd, payload):
         raise OSError(28, "No space left on device")
 
-    def fail_rollback(fd, size):
+    def fail_rollback(fd, target_path, pre_append_size):
         raise OSError(5, "rollback failed")
 
     monkeypatch.setattr(storage.os, "write", fail_write)
-    monkeypatch.setattr(storage.os, "ftruncate", fail_rollback)
+    monkeypatch.setattr(storage, "_rollback_append", fail_rollback)
 
     with pytest.raises(
         storage.StorageRecoveryError, match="ledger integrity is uncertain"


### PR DESCRIPTION
## Ziel

History- und Operator-Summary-Abfragen sollen den bytegenauen Ledger-Snapshot weiter vollständig validieren, aber nicht zusätzlich sämtliche dekodierten Zeilen und Treffer materialisieren.

## Änderungen

- vollständige JSONL-Sätze werden innerhalb eines unveränderten, bytegebundenen Rohsnapshots einmal validiert und besucht
- Filter und Zähler werden während desselben Scans berechnet
- nur die neuesten `limit` Kandidaten bleiben in einem begrenzten Top-K-Heap
- die stabile Vorher-Reihenfolge bei gleichen Zeitstempeln und Event-IDs bleibt erhalten
- der bei der Validierung normalisierte UTC-Zeitstempel wird für Filterung und Heap wiederverwendet
- ein unbenutzter materialisierender Kompatibilitäts-Wrapper wurde entfernt
- der Rollback-Test mockt Chroniks eigene Rollback-Grenze statt global `os.ftruncate`, kompatibel mit `filelock 3.30.2`

## Messung

Synthetischer, schema-valider Ledger: 10.000 Events / 6.593.890 Byte, `limit=20`, `tracemalloc`.

| Abfrage | vorher Peak | nachher Peak |
| --- | ---: | ---: |
| `query_history` | 54,50 MB | 13,19 MB |
| `operator_summary` | 54,41 MB | 13,19 MB |

Ergebnis: rund 75,8 % weniger Spitzenverbrauch. Die CPU-Komplexität bleibt wegen der vollständigen Integritätsvalidierung linear. Laufzeitänderungen liegen im einstelligen Prozentbereich und werden wegen Messrauschen nicht als belastbarer Hauptgewinn beansprucht.

Finaler Median aus drei Läufen nach Review-Härtung:

- `query_history`: 4,386 s, 13.189.150 Byte Peak
- `operator_summary`: 4,360 s, 13.189.766 Byte Peak

## Prüfung

- `scripts/validate-local.sh`
- 322 Tests bestanden
- Rollenvertrag bestanden
- HTTP-Smoke-Test bestanden
- `git diff --check` und Python-Kompilierung bestanden
- Differentialtest gegen den vorherigen PR-Head: vollständige JSON-Ausgaben identisch, SHA-256 `ce69207818b060a62a915a46b5bbb1bffc4bdd592d1399788ce57585aebe5606`
- GitHub-CI und CodeQL vollständig grün

## Risiken und Grenzen

- Der rohe Snapshot bleibt vollständig im Speicher, damit Hash, vollständige Satzgrenze und Diagnosewerte an dieselben Bytes gebunden bleiben.
- Ein echter descriptor-gebundener Streaming-Scanner ist ein gesonderter Architekturpfad und bereits als Nachlauf registriert.
- Kein zusätzlicher Index und kein zweiter Wahrheitszustand werden eingeführt.
