### PR TITLE
perf: reuse unchanged Grabowski import receipts

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -172,8 +172,58 @@ def _prepare_grabowski_outbox_source(source: Path, *, receipt_dir: Path) -> dict
         "events": events,
         "source_sha256": source_sha256,
         "receipt_path": receipt_path,
+        "previous_receipt": previous,
         "source_unchanged": previous is not None and previous.get("source_sha256") == source_sha256,
     }
+
+
+def _receipt_matches_prepared_source(
+    prepared: dict[str, Any], receipt: dict[str, Any] | None
+) -> bool:
+    """Return whether an existing receipt is intact and bound to these source bytes."""
+    if not isinstance(receipt, dict):
+        return False
+    source = prepared["source"]
+    raw = prepared["raw"]
+    events = prepared["events"]
+    expected = {
+        "schema_version": "chronik-grabowski-outbox-import.v1",
+        "domain": DOMAIN,
+        "source_path": str(source.resolve()),
+        "source_sha256": prepared["source_sha256"],
+        "source_bytes": len(raw),
+        "selection_contract": sorted(HIGH_VALUE_KINDS),
+        "event_ids": sorted(event["event_id"] for event in events),
+        "requested": len(events),
+        "historical_only": True,
+        "does_not_establish": DOES_NOT_ESTABLISH,
+    }
+    if any(receipt.get(key) != value for key, value in expected.items()):
+        return False
+    for key in (
+        "imported",
+        "skipped_existing",
+        "batch_target_scans",
+        "batch_target_records_scanned",
+    ):
+        value = receipt.get(key)
+        if type(value) is not int or value < 0:
+            return False
+    if receipt["imported"] + receipt["skipped_existing"] != len(events):
+        return False
+    recorded_at = receipt.get("recorded_at")
+    if not isinstance(recorded_at, str):
+        return False
+    try:
+        _parse_timestamp(recorded_at, field="recorded_at")
+    except ValueError:
+        return False
+    claimed_digest = receipt.get("receipt_sha256")
+    if not isinstance(claimed_digest, str):
+        return False
+    unsigned = dict(receipt)
+    unsigned.pop("receipt_sha256", None)
+    return claimed_digest == sha256_bytes(canonical_bytes(unsigned))
 
 
 def _write_grabowski_outbox_receipt(
@@ -188,6 +238,38 @@ def _write_grabowski_outbox_receipt(
     raw = prepared["raw"]
     events = prepared["events"]
     receipt_path = prepared["receipt_path"]
+    previous_receipt = prepared.get("previous_receipt")
+    if (
+        prepared["source_unchanged"]
+        and written == 0
+        and skipped == len(events)
+        and _receipt_matches_prepared_source(prepared, previous_receipt)
+    ):
+        # The authoritative ledger was still scanned above. Reusing this intact
+        # source-bound receipt only suppresses an identical filesystem rewrite.
+        return {
+            "schema_version": previous_receipt["schema_version"],
+            "domain": previous_receipt["domain"],
+            "source_path": previous_receipt["source_path"],
+            "source_sha256": previous_receipt["source_sha256"],
+            "source_bytes": previous_receipt["source_bytes"],
+            "selection_contract": previous_receipt["selection_contract"],
+            "event_ids": previous_receipt["event_ids"],
+            "requested": previous_receipt["requested"],
+            "imported": written,
+            "skipped_existing": skipped,
+            "batch_target_scans": target_scans,
+            "batch_target_records_scanned": target_records_scanned,
+            "recorded_at": previous_receipt["recorded_at"],
+            "historical_only": previous_receipt["historical_only"],
+            "does_not_establish": previous_receipt["does_not_establish"],
+            "receipt_sha256": previous_receipt["receipt_sha256"],
+            "receipt_digest_scope": "persisted_receipt",
+            "unchanged": True,
+            "receipt_path": str(receipt_path),
+            "receipt_reused": True,
+            "receipt_written": False,
+        }
     receipt = {
         "schema_version": "chronik-grabowski-outbox-import.v1",
         "domain": DOMAIN,
@@ -214,6 +296,9 @@ def _write_grabowski_outbox_receipt(
         **receipt,
         "unchanged": prepared["source_unchanged"],
         "receipt_path": str(receipt_path),
+        "receipt_digest_scope": "persisted_receipt",
+        "receipt_reused": False,
+        "receipt_written": True,
     }
 
 
@@ -259,6 +344,8 @@ def _import_prepared_grabowski_sources(
                 "imported": written,
                 "skipped_existing": skipped,
                 "unchanged": prepared["source_unchanged"],
+                "receipt_reused": False,
+                "receipt_written": False,
             }
             receipt_errors.append((str(prepared["source"]), exc))
         results.append(result)
@@ -313,6 +400,8 @@ def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str
         "files_seen": len(sources),
         "files_imported_or_confirmed": len(results),
         "files_unchanged": sum(1 for result in results if result.get("unchanged") is True),
+        "receipts_written": sum(1 for result in results if result.get("receipt_written") is True),
+        "receipts_reused": sum(1 for result in results if result.get("receipt_reused") is True),
         "events_imported": sum(int(result.get("imported", 0)) for result in results),
         "events_skipped_existing": sum(int(result.get("skipped_existing", 0)) for result in results),
         "target_scans": target_scans,

--- a/docs/chronik/direct-operator-memory-v1.md
+++ b/docs/chronik/direct-operator-memory-v1.md
@@ -169,3 +169,11 @@ Chronik bleibt historische Evidenz. `summary`, `query` und `freeze` treffen
 keine Aussage darüber, ob ein Repository, Dienst, Task oder Deployment jetzt
 noch denselben Zustand besitzt. Sie ersetzen weder Bureau-Wahrheit noch frische
 Git-, CI-, Runtime- oder Recovery-Prüfungen.
+
+## Receipt-Wiederverwendung und Replay-Autorität
+
+Jeder Outbox-Import gleicht die Event-IDs weiterhin mit dem maßgeblichen Chronik-Ledger ab. Sind die Quellbytes unverändert, alle angeforderten Events im Ledger vorhanden und der vorhandene quellgebundene Receipt durch seinen SHA-256-Digest intakt, wird die Receipt-Datei nicht ersetzt. Die Batch-Telemetrie trennt `receipts_written` und `receipts_reused`.
+
+`receipt_sha256` im Laufergebnis bindet ausdrücklich die unveränderte Receipt-Datei (`receipt_digest_scope=persisted_receipt`), nicht die aktuellen Laufzähler. `imported`, `skipped_existing` und die Scan-Zähler beschreiben den aktuellen Lauf.
+
+Receipts bleiben nicht maßgeblich. Fehlen Ledger-Daten, werden sie trotz intaktem Receipt aus der Grabowski-Outbox rekonstruiert. Die Quelldateien bleiben deshalb Replay-Evidenz; Löschen oder Kompaktieren benötigt einen eigenen Verlustwiederherstellungsvertrag und folgt nicht aus der Receipt-Wiederverwendung.

--- a/tests/test_grabowski_outbox_import.py
+++ b/tests/test_grabowski_outbox_import.py
@@ -56,12 +56,22 @@ def test_batch_import_is_idempotent_and_receipt_bound(tmp_path, monkeypatch):
     source = write_outbox(outbox, [event("agent.run.started", "a"), event("agent.run.completed", "b")])
 
     first = coding_memory.import_grabowski_outbox(outbox_root=outbox, receipt_dir=receipts)
+    receipt_path = next(receipts.glob("*.receipt.json"))
+    first_receipt = receipt_path.read_bytes()
+    first_stat = receipt_path.stat()
     second = coding_memory.import_grabowski_outbox(outbox_root=outbox, receipt_dir=receipts)
 
     assert first["events_imported"] == 2
     assert first["errors"] == []
+    assert first["receipts_written"] == 1
+    assert first["receipts_reused"] == 0
     assert second["events_imported"] == 0
     assert second["files_unchanged"] == 1
+    assert second["receipts_written"] == 0
+    assert second["receipts_reused"] == 1
+    assert receipt_path.read_bytes() == first_receipt
+    assert receipt_path.stat().st_ino == first_stat.st_ino
+    assert receipt_path.stat().st_mtime_ns == first_stat.st_mtime_ns
     assert len(list(receipts.glob("*.receipt.json"))) == 1
     rows = (data / "agent.ledger.jsonl").read_text(encoding="utf-8").splitlines()
     assert len(rows) == 2
@@ -69,6 +79,39 @@ def test_batch_import_is_idempotent_and_receipt_bound(tmp_path, monkeypatch):
     assert receipt["source_path"] == str(source.resolve())
     assert receipt["source_sha256"]
     assert receipt["receipt_sha256"]
+
+
+def test_reused_single_file_result_keeps_persisted_digest_separate_from_run_stats(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    source = write_outbox(
+        outbox,
+        [event("agent.run.started", "a"), event("agent.run.completed", "b")],
+    )
+    first = coding_memory.import_grabowski_outbox_file(
+        source, receipt_dir=receipts
+    )
+    second = coding_memory.import_grabowski_outbox_file(
+        source, receipt_dir=receipts
+    )
+    persisted = json.loads(Path(second["receipt_path"]).read_text(encoding="utf-8"))
+    unsigned = dict(persisted)
+    claimed = unsigned.pop("receipt_sha256")
+
+    assert first["receipt_written"] is True
+    assert first["receipt_reused"] is False
+    assert second["imported"] == 0
+    assert second["skipped_existing"] == 2
+    assert second["receipt_written"] is False
+    assert second["receipt_reused"] is True
+    assert second["receipt_digest_scope"] == "persisted_receipt"
+    assert second["receipt_sha256"] == claimed
+    assert claimed == coding_memory.sha256_bytes(
+        coding_memory.canonical_bytes(unsigned)
+    )
+    assert persisted["imported"] == 2
+    assert persisted["skipped_existing"] == 0
 
 
 def test_receipt_never_replaces_target_store_verification(tmp_path, monkeypatch):
@@ -81,6 +124,8 @@ def test_receipt_never_replaces_target_store_verification(tmp_path, monkeypatch)
 
     assert recovered["files_unchanged"] == 1
     assert recovered["events_imported"] == 2
+    assert recovered["receipts_written"] == 1
+    assert recovered["receipts_reused"] == 0
     assert (
         len((data / "agent.ledger.jsonl").read_text(encoding="utf-8").splitlines()) == 2
     )
@@ -101,6 +146,8 @@ def test_missing_receipt_is_rebuilt_after_store_verification(tmp_path, monkeypat
     assert recovered["events_skipped_existing"] == 1
     assert recovered["files_unchanged"] == 0
     assert recovered["target_scans"] == 1
+    assert recovered["receipts_written"] == 1
+    assert recovered["receipts_reused"] == 0
     assert receipt_path.exists()
     assert len((data / "agent.ledger.jsonl").read_text().splitlines()) == 1
 
@@ -122,8 +169,69 @@ def test_stale_receipt_cannot_override_store_verification(tmp_path, monkeypatch)
     assert recovered["events_skipped_existing"] == 1
     assert recovered["files_unchanged"] == 0
     assert recovered["target_records_scanned"] == 1
+    assert recovered["receipts_written"] == 1
+    assert recovered["receipts_reused"] == 0
     refreshed = json.loads(receipt_path.read_text())
     assert refreshed["source_sha256"] != "0" * 64
+    assert len((data / "agent.ledger.jsonl").read_text().splitlines()) == 1
+
+
+def test_matching_receipt_with_invalid_timestamp_is_repaired(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    write_outbox(outbox, [event("agent.run.completed", "a")])
+    coding_memory.import_grabowski_outbox(outbox_root=outbox, receipt_dir=receipts)
+    receipt_path = next(receipts.glob("*.receipt.json"))
+    corrupt = json.loads(receipt_path.read_text())
+    corrupt["recorded_at"] = "not-a-timestamp"
+    unsigned = dict(corrupt)
+    unsigned.pop("receipt_sha256")
+    corrupt["receipt_sha256"] = coding_memory.sha256_bytes(
+        coding_memory.canonical_bytes(unsigned)
+    )
+    receipt_path.write_text(json.dumps(corrupt), encoding="utf-8")
+
+    recovered = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+
+    assert recovered["events_imported"] == 0
+    assert recovered["events_skipped_existing"] == 1
+    assert recovered["receipts_written"] == 1
+    assert recovered["receipts_reused"] == 0
+    repaired = json.loads(receipt_path.read_text())
+    assert repaired["recorded_at"] != "not-a-timestamp"
+
+
+def test_matching_but_corrupt_receipt_is_repaired_after_store_verification(
+    tmp_path, monkeypatch
+):
+    data, receipts, outbox = configure(tmp_path, monkeypatch)
+    source = write_outbox(outbox, [event("agent.run.completed", "a")])
+    coding_memory.import_grabowski_outbox(outbox_root=outbox, receipt_dir=receipts)
+    receipt_path = next(receipts.glob("*.receipt.json"))
+    corrupt = json.loads(receipt_path.read_text())
+    corrupt["event_ids"] = ["sha256:" + "f" * 64]
+    unsigned = dict(corrupt)
+    unsigned.pop("receipt_sha256")
+    corrupt["receipt_sha256"] = coding_memory.sha256_bytes(
+        coding_memory.canonical_bytes(unsigned)
+    )
+    receipt_path.write_text(json.dumps(corrupt), encoding="utf-8")
+
+    recovered = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+
+    assert recovered["events_imported"] == 0
+    assert recovered["events_skipped_existing"] == 1
+    assert recovered["files_unchanged"] == 1
+    assert recovered["receipts_written"] == 1
+    assert recovered["receipts_reused"] == 0
+    repaired = json.loads(receipt_path.read_text())
+    assert repaired["source_path"] == str(source.resolve())
+    assert repaired["event_ids"] == [event("agent.run.completed", "a")["event_id"]]
     assert len((data / "agent.ledger.jsonl").read_text().splitlines()) == 1
 
 
@@ -140,6 +248,8 @@ def test_appended_source_updates_receipt_and_imports_only_new_event(
 
     assert result["events_imported"] == 1
     assert result["events_skipped_existing"] == 1
+    assert result["receipts_written"] == 1
+    assert result["receipts_reused"] == 0
     assert len((data / "agent.ledger.jsonl").read_text(encoding="utf-8").splitlines()) == 2
 
 
@@ -278,11 +388,15 @@ def test_multi_file_batch_scans_target_once_and_repeat_verifies_store(
     assert first["target_scans"] == 1
     assert first["target_records_scanned"] == 0
     assert first["events_imported"] == 3
+    assert first["receipts_written"] == 3
+    assert first["receipts_reused"] == 0
     assert second["target_scans"] == 1
     assert second["target_records_scanned"] == 3
     assert second["events_imported"] == 0
     assert second["events_skipped_existing"] == 3
     assert second["files_unchanged"] == 3
+    assert second["receipts_written"] == 0
+    assert second["receipts_reused"] == 3
     assert len((data / "agent.ledger.jsonl").read_text().splitlines()) == 3
 
 


### PR DESCRIPTION
## Zweck

Unterdrückt identische Receipt-Dateiersetzungen im zweiminütigen Grabowski-Outbox-Import, ohne Receipts zur Store-Autorität zu machen.

## Verhalten

- Der vollständige Chronik-Ledger wird weiterhin genau einmal pro Batch gegen alle Event-IDs geprüft.
- Ein vorhandener Receipt wird nur wiederverwendet, wenn Quellpfad, Quellbytes, Event-IDs, Auswahlvertrag und eigener SHA-256-Digest exakt stimmen und alle Events im Ledger vorhanden sind.
- Fehlende, veraltete oder inhaltlich inkonsistente Receipts werden nach der Ledger-Prüfung neu geschrieben.
- Lauftelemetrie trennt `receipts_written` und `receipts_reused`.
- `receipt_sha256` bindet ausdrücklich die persistierte Receipt-Datei; aktuelle Import- und Scan-Zähler bleiben Lauftelemetrie.
- Outbox-Quelldateien bleiben Replay-Evidenz und werden in diesem PR nicht gelöscht oder archiviert.

## Prüfung am exakten Head

- Rollenvertrag: PASS
- Vollsuite: 324 Tests bestanden
- lokaler Health/Version/Ingest/Events-Smoke: PASS
- A/B mit 2.300 echten, kopierten Outbox-Dateien und 4.589 Events:
  - alter Wiederholungslauf: 2,999 s / 3,020 s; alle 2.300 Receipts ersetzt
  - neuer Wiederholungslauf: 1,679 s / 1,661 s; 2.300 Receipts wiederverwendet, 0 ersetzt
  - beide Varianten: ein vollständiger Ziel-Ledger-Scan, 0 Fehler

## Grenzen

Nur historische Evidenz: kein aktueller Git-, CI-, Runtime- oder Retry-Beleg; kein HTTP-Service-Start; keine Quellkompaktierung; keine Änderung an Bureau- oder Orchestrierungswahrheit.