### PR TITLE
feat: compact terminal Grabowski outbox sources

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -5,6 +5,7 @@ import hashlib
 import heapq
 import json
 import os
+import stat
 import tempfile
 from collections import Counter
 from datetime import datetime, timezone
@@ -27,6 +28,10 @@ OPERATIONS = frozenset({"implement", "review", "merge", "deploy", "runtime_verif
 TASK_CLASSES = frozenset({"coding", "review", "merge", "deploy", "runtime_verify", "recovery", "maintenance", "diagnostic", "other"})
 OUTCOMES = frozenset({"started", "completed", "blocked", "failed", "reverted", "outcome_unknown"})
 MAX_INTEGRITY_DIAGNOSTICS = 20
+GRABOWSKI_TERMINAL_KINDS = frozenset({"agent.run.completed", "agent.run.blocked"})
+GRABOWSKI_BUNDLE_DIRNAME = "bundles"
+GRABOWSKI_BUNDLE_ENTRY_SCHEMA = "chronik-grabowski-outbox-bundle-source.v1"
+GRABOWSKI_BUNDLE_MANIFEST_SCHEMA = "chronik-grabowski-outbox-bundle-manifest.v1"
 
 
 def canonical_bytes(value: Any) -> bytes:
@@ -111,8 +116,7 @@ def import_events(events: Iterable[dict[str, Any]]) -> dict[str, Any]:
     return receipt
 
 
-def _read_jsonl_snapshot(path: Path) -> tuple[bytes, list[dict[str, Any]]]:
-    raw = path.read_bytes()
+def _parse_jsonl_snapshot(path: Path, raw: bytes) -> list[dict[str, Any]]:
     if raw and not raw.endswith(b"\n"):
         raise ValueError(f"incomplete JSONL tail: {path}")
     events: list[dict[str, Any]] = []
@@ -126,7 +130,16 @@ def _read_jsonl_snapshot(path: Path) -> tuple[bytes, list[dict[str, Any]]]:
         if not isinstance(value, dict):
             raise ValueError(f"event must be an object at {path}:{line_number}")
         events.append(value)
-    return raw, events
+    return events
+
+
+def _read_jsonl_snapshot(path: Path) -> tuple[bytes, list[dict[str, Any]]]:
+    raw = path.read_bytes()
+    return raw, _parse_jsonl_snapshot(path, raw)
+
+
+def _file_identity(value: os.stat_result) -> tuple[int, int, int, int]:
+    return (value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns)
 
 
 def _receipt_path(source: Path, receipt_dir: Path) -> Path:
@@ -157,15 +170,27 @@ def _validate_grabowski_source(event: dict[str, Any]) -> None:
         raise ValueError(f"unsupported operator-memory kind: {event.get('kind')}")
 
 
-def _prepare_grabowski_outbox_source(source: Path, *, receipt_dir: Path) -> dict[str, Any]:
-    raw, events = _read_jsonl_snapshot(source)
+def _prepare_grabowski_source_bytes(
+    source: Path,
+    raw: bytes,
+    *,
+    receipt_dir: Path,
+    source_origin: str,
+    source_identity: tuple[int, int, int, int] | None = None,
+    source_mtime_ns: int | None = None,
+    bundle_manifest_path: Path | None = None,
+) -> dict[str, Any]:
+    events = _parse_jsonl_snapshot(source, raw)
     if not events:
         raise ValueError(f"outbox contains no events: {source}")
     for event in events:
         _validate_grabowski_source(event)
     source_sha256 = sha256_bytes(raw)
     receipt_path = _receipt_path(source, receipt_dir)
-    previous = _load_receipt(receipt_path)
+    try:
+        previous = _load_receipt(receipt_path)
+    except ValueError:
+        previous = None
     return {
         "source": source,
         "raw": raw,
@@ -174,7 +199,27 @@ def _prepare_grabowski_outbox_source(source: Path, *, receipt_dir: Path) -> dict
         "receipt_path": receipt_path,
         "previous_receipt": previous,
         "source_unchanged": previous is not None and previous.get("source_sha256") == source_sha256,
+        "source_origin": source_origin,
+        "source_identity": source_identity,
+        "source_mtime_ns": source_mtime_ns,
+        "bundle_manifest_path": bundle_manifest_path,
     }
+
+
+def _prepare_grabowski_outbox_source(source: Path, *, receipt_dir: Path) -> dict[str, Any]:
+    before = source.stat()
+    raw = source.read_bytes()
+    after = source.stat()
+    if _file_identity(before) != _file_identity(after):
+        raise ValueError(f"outbox source changed while reading: {source}")
+    return _prepare_grabowski_source_bytes(
+        source,
+        raw,
+        receipt_dir=receipt_dir,
+        source_origin="loose",
+        source_identity=_file_identity(after),
+        source_mtime_ns=after.st_mtime_ns,
+    )
 
 
 def _receipt_matches_prepared_source(
@@ -226,6 +271,381 @@ def _receipt_matches_prepared_source(
     return claimed_digest == sha256_bytes(canonical_bytes(unsigned))
 
 
+
+def _ledger_payloads_by_event_id() -> tuple[dict[str, bytes], int]:
+    """Read one complete ledger snapshot and bind every event id to its payload."""
+    snapshot = storage.read_domain_snapshot(DOMAIN)
+    payloads: dict[str, bytes] = {}
+    records_scanned = 0
+    for line_number, raw_line in enumerate(snapshot.splitlines(), start=1):
+        if not raw_line.strip():
+            continue
+        records_scanned += 1
+        try:
+            value = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            raise storage.StorageError(
+                f"invalid ledger JSON at record {line_number}"
+            ) from exc
+        payload = value.get("payload", value) if isinstance(value, dict) else None
+        if not isinstance(payload, dict):
+            raise storage.StorageError(
+                f"invalid ledger payload at record {line_number}"
+            )
+        event_id = payload.get("event_id")
+        if not isinstance(event_id, str) or not event_id:
+            raise storage.StorageError(
+                f"ledger record {line_number} has no event_id"
+            )
+        canonical = canonical_bytes(payload)
+        previous = payloads.get(event_id)
+        if previous is not None and previous != canonical:
+            raise storage.StorageError(f"conflicting event_id in ledger: {event_id}")
+        payloads.setdefault(event_id, canonical)
+    return payloads, records_scanned
+
+
+def _bundle_source_record(
+    prepared: dict[str, Any], *, offset: int
+) -> dict[str, Any]:
+    events = prepared["events"]
+    record = {
+        "schema_version": GRABOWSKI_BUNDLE_ENTRY_SCHEMA,
+        "source_path": str(prepared["source"].resolve()),
+        "source_name": prepared["source"].name,
+        "offset": offset,
+        "source_sha256": prepared["source_sha256"],
+        "source_bytes": len(prepared["raw"]),
+        "event_ids": [event["event_id"] for event in events],
+        "terminal_kind": events[-1]["kind"],
+    }
+    record["record_sha256"] = sha256_bytes(canonical_bytes(record))
+    return record
+
+
+def _decode_bundle_source(
+    record: dict[str, Any],
+    bundle_raw: bytes,
+    *,
+    expected_offset: int,
+    source_dir: Path,
+    receipt_dir: Path,
+    manifest_path: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    expected_keys = {
+        "schema_version",
+        "source_path",
+        "source_name",
+        "offset",
+        "source_sha256",
+        "source_bytes",
+        "event_ids",
+        "terminal_kind",
+        "record_sha256",
+    }
+    if set(record) != expected_keys:
+        raise ValueError(f"invalid bundle source fields: {manifest_path}")
+    if record["schema_version"] != GRABOWSKI_BUNDLE_ENTRY_SCHEMA:
+        raise ValueError(f"unsupported bundle source schema: {manifest_path}")
+    claimed_record_sha256 = record.get("record_sha256")
+    if not isinstance(claimed_record_sha256, str):
+        raise ValueError(f"invalid bundle source digest: {manifest_path}")
+    unsigned = dict(record)
+    unsigned.pop("record_sha256")
+    if claimed_record_sha256 != sha256_bytes(canonical_bytes(unsigned)):
+        raise ValueError(f"bundle source digest mismatch: {manifest_path}")
+    source_path = record.get("source_path")
+    source_name = record.get("source_name")
+    if not isinstance(source_path, str) or not isinstance(source_name, str):
+        raise ValueError(f"invalid bundled source identity: {manifest_path}")
+    original_source = Path(source_path)
+    if (
+        not original_source.is_absolute()
+        or original_source.name != source_name
+        or Path(source_name).name != source_name
+        or source_name in {"", ".", ".."}
+        or not source_name.endswith(".jsonl")
+    ):
+        raise ValueError(f"invalid bundled source identity: {manifest_path}")
+    offset = record.get("offset")
+    source_bytes = record.get("source_bytes")
+    if (
+        type(offset) is not int
+        or offset != expected_offset
+        or type(source_bytes) is not int
+        or source_bytes < 1
+        or offset + source_bytes > len(bundle_raw)
+    ):
+        raise ValueError(f"invalid bundle source byte range: {manifest_path}")
+    raw = bundle_raw[offset : offset + source_bytes]
+    source_sha256 = record.get("source_sha256")
+    if not isinstance(source_sha256, str) or source_sha256 != sha256_bytes(raw):
+        raise ValueError(f"bundled source digest mismatch: {manifest_path}")
+    source = source_dir.resolve() / source_name
+    prepared = _prepare_grabowski_source_bytes(
+        source,
+        raw,
+        receipt_dir=receipt_dir,
+        source_origin="bundle",
+        bundle_manifest_path=manifest_path,
+    )
+    expected_event_ids = [event["event_id"] for event in prepared["events"]]
+    if record.get("event_ids") != expected_event_ids:
+        raise ValueError(f"bundled event id list mismatch: {manifest_path}")
+    terminal_kind = record.get("terminal_kind")
+    if (
+        terminal_kind not in GRABOWSKI_TERMINAL_KINDS
+        or prepared["events"][-1]["kind"] != terminal_kind
+    ):
+        raise ValueError(f"bundled source is not terminal: {manifest_path}")
+    return prepared, dict(record)
+
+
+def _load_grabowski_bundle(
+    manifest_path: Path,
+    *,
+    source_dir: Path,
+    receipt_dir: Path,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    manifest_raw = _read_immutable_artifact(
+        manifest_path, label="bundle manifest"
+    )
+    if not manifest_raw.endswith(b"\n"):
+        raise ValueError(f"incomplete bundle manifest: {manifest_path}")
+    try:
+        manifest = json.loads(manifest_raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid bundle manifest JSON: {manifest_path}") from exc
+    expected_manifest_keys = {
+        "schema_version",
+        "domain",
+        "bundle_file",
+        "bundle_sha256",
+        "bundle_bytes",
+        "source_count",
+        "event_count",
+        "sources",
+        "created_at",
+        "historical_only",
+        "does_not_establish",
+        "manifest_sha256",
+    }
+    if not isinstance(manifest, dict) or set(manifest) != expected_manifest_keys:
+        raise ValueError(f"invalid bundle manifest fields: {manifest_path}")
+    if (
+        manifest["schema_version"] != GRABOWSKI_BUNDLE_MANIFEST_SCHEMA
+        or manifest["domain"] != DOMAIN
+        or manifest["historical_only"] is not True
+        or manifest["does_not_establish"] != DOES_NOT_ESTABLISH
+    ):
+        raise ValueError(f"invalid bundle manifest contract: {manifest_path}")
+    claimed_manifest_sha256 = manifest.get("manifest_sha256")
+    if not isinstance(claimed_manifest_sha256, str):
+        raise ValueError(f"invalid manifest digest: {manifest_path}")
+    unsigned_manifest = dict(manifest)
+    unsigned_manifest.pop("manifest_sha256")
+    if claimed_manifest_sha256 != sha256_bytes(canonical_bytes(unsigned_manifest)):
+        raise ValueError(f"bundle manifest digest mismatch: {manifest_path}")
+    created_at = manifest.get("created_at")
+    if not isinstance(created_at, str):
+        raise ValueError(f"invalid bundle creation timestamp: {manifest_path}")
+    _parse_timestamp(created_at, field="created_at")
+    bundle_file = manifest.get("bundle_file")
+    bundle_sha256 = manifest.get("bundle_sha256")
+    if not isinstance(bundle_file, str) or Path(bundle_file).name != bundle_file:
+        raise ValueError(f"invalid bundle filename: {manifest_path}")
+    if not isinstance(bundle_sha256, str) or len(bundle_sha256) != 64:
+        raise ValueError(f"invalid bundle digest: {manifest_path}")
+    expected_prefix = f"grabowski-{bundle_sha256}"
+    if (
+        bundle_file != f"{expected_prefix}.bundle.jsonl"
+        or manifest_path.name != f"{expected_prefix}.manifest.json"
+    ):
+        raise ValueError(f"bundle filename is not digest-bound: {manifest_path}")
+    bundle_path = manifest_path.parent / bundle_file
+    if bundle_path.parent.resolve() != manifest_path.parent.resolve():
+        raise ValueError(f"bundle path escapes bundle directory: {manifest_path}")
+    bundle_raw = _read_immutable_artifact(bundle_path, label="bundle file")
+    bundle_bytes = manifest.get("bundle_bytes")
+    if type(bundle_bytes) is not int or bundle_bytes < 1 or bundle_bytes != len(bundle_raw):
+        raise ValueError(f"bundle byte count mismatch: {bundle_path}")
+    if sha256_bytes(bundle_raw) != bundle_sha256:
+        raise ValueError(f"bundle digest mismatch: {bundle_path}")
+    if not bundle_raw.endswith(b"\n"):
+        raise ValueError(f"incomplete bundle JSONL: {bundle_path}")
+    source_records = manifest.get("sources")
+    if not isinstance(source_records, list) or not source_records:
+        raise ValueError(f"empty bundle is forbidden: {manifest_path}")
+    prepared_sources: list[dict[str, Any]] = []
+    validated_records: list[dict[str, Any]] = []
+    names: set[str] = set()
+    original_paths: set[str] = set()
+    expected_offset = 0
+    for record in source_records:
+        if not isinstance(record, dict):
+            raise ValueError(f"bundle source must be an object: {manifest_path}")
+        prepared, validated = _decode_bundle_source(
+            record,
+            bundle_raw,
+            expected_offset=expected_offset,
+            source_dir=source_dir,
+            receipt_dir=receipt_dir,
+            manifest_path=manifest_path,
+        )
+        source_name = validated["source_name"]
+        source_path = validated["source_path"]
+        if source_name in names or source_path in original_paths:
+            raise ValueError(f"duplicate source in bundle: {manifest_path}")
+        names.add(source_name)
+        original_paths.add(source_path)
+        prepared_sources.append(prepared)
+        validated_records.append(validated)
+        expected_offset += validated["source_bytes"]
+    if expected_offset != len(bundle_raw):
+        raise ValueError(f"bundle has unassigned trailing bytes: {bundle_path}")
+    source_count = manifest.get("source_count")
+    event_count = manifest.get("event_count")
+    if (
+        type(source_count) is not int
+        or source_count != len(prepared_sources)
+        or type(event_count) is not int
+        or event_count != sum(len(item["events"]) for item in prepared_sources)
+    ):
+        raise ValueError(f"bundle manifest inventory mismatch: {manifest_path}")
+    return prepared_sources, {
+        "manifest_path": str(manifest_path),
+        "manifest_sha256": claimed_manifest_sha256,
+        "bundle_path": str(bundle_path),
+        "bundle_sha256": bundle_sha256,
+        "bundle_bytes": bundle_bytes,
+        "source_count": source_count,
+        "event_count": event_count,
+        "sources": validated_records,
+    }
+
+
+def _merge_prepared_grabowski_sources(
+    prepared_sources: Iterable[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {}
+    for prepared in prepared_sources:
+        key = str(prepared["source"].resolve())
+        previous = merged.get(key)
+        if previous is None:
+            merged[key] = prepared
+            continue
+        if previous["raw"] != prepared["raw"]:
+            raise ValueError(f"conflicting loose and bundled source bytes: {key}")
+        if previous.get("source_origin") == "bundle" and prepared.get("source_origin") == "loose":
+            merged[key] = prepared
+    return [merged[key] for key in sorted(merged)]
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _ensure_bundle_directory(source_dir: Path, bundle_dir: Path) -> None:
+    try:
+        bundle_dir.mkdir(mode=0o700)
+    except FileExistsError:
+        pass
+    try:
+        bundle_state = bundle_dir.lstat()
+    except OSError as exc:
+        raise ValueError(f"cannot inspect bundle directory: {bundle_dir}") from exc
+    if not stat.S_ISDIR(bundle_state.st_mode):
+        raise ValueError(f"bundle directory must be a real directory: {bundle_dir}")
+    if bundle_dir.resolve().parent != source_dir.resolve():
+        raise ValueError(f"bundle directory escapes source directory: {bundle_dir}")
+    _fsync_directory(source_dir)
+
+
+def _read_immutable_artifact(path: Path, *, label: str) -> bytes:
+    try:
+        before = path.lstat()
+    except OSError as exc:
+        raise ValueError(f"cannot inspect {label}: {path}") from exc
+    if not stat.S_ISREG(before.st_mode):
+        raise ValueError(f"{label} must be a regular file: {path}")
+    try:
+        raw = path.read_bytes()
+        after = path.lstat()
+    except OSError as exc:
+        raise ValueError(f"cannot read {label}: {path}") from exc
+    if _file_identity(before) != _file_identity(after):
+        raise ValueError(f"{label} changed while reading: {path}")
+    return raw
+
+
+def _publish_immutable(path: Path, data: bytes) -> bool:
+    """Publish bytes without replacing an existing immutable artifact."""
+    try:
+        parent_state = path.parent.lstat()
+    except OSError as exc:
+        raise ValueError(f"cannot inspect artifact directory: {path.parent}") from exc
+    if not stat.S_ISDIR(parent_state.st_mode):
+        raise ValueError(f"artifact directory must be a real directory: {path.parent}")
+    try:
+        existing_state = path.lstat()
+    except FileNotFoundError:
+        existing = None
+    else:
+        if not stat.S_ISREG(existing_state.st_mode):
+            raise ValueError(f"immutable artifact must be a regular file: {path}")
+        existing = path.read_bytes()
+    if existing is not None:
+        if existing != data:
+            raise ValueError(f"immutable artifact conflict: {path}")
+        return False
+    fd, name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o600)
+        try:
+            os.link(temporary, path)
+        except FileExistsError:
+            if path.read_bytes() != data:
+                raise ValueError(f"immutable artifact conflict: {path}")
+            return False
+        _fsync_directory(path.parent)
+        if path.read_bytes() != data:
+            raise OSError(f"immutable artifact readback failed: {path}")
+        return True
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _source_still_matches(prepared: dict[str, Any]) -> bool:
+    source = prepared["source"]
+    expected_identity = prepared.get("source_identity")
+    if expected_identity is None:
+        return False
+    try:
+        before = source.stat()
+        raw = source.read_bytes()
+        after = source.stat()
+    except OSError:
+        return False
+    return (
+        _file_identity(before) == expected_identity
+        and _file_identity(after) == expected_identity
+        and sha256_bytes(raw) == prepared["source_sha256"]
+    )
+
+
+def _unlink_loose_source(path: Path) -> None:
+    path.unlink()
+
+
 def _write_grabowski_outbox_receipt(
     prepared: dict[str, Any],
     *,
@@ -269,6 +689,12 @@ def _write_grabowski_outbox_receipt(
             "receipt_path": str(receipt_path),
             "receipt_reused": True,
             "receipt_written": False,
+            "source_origin": prepared.get("source_origin", "loose"),
+            "bundle_manifest_path": (
+                str(prepared["bundle_manifest_path"])
+                if prepared.get("bundle_manifest_path") is not None
+                else None
+            ),
         }
     receipt = {
         "schema_version": "chronik-grabowski-outbox-import.v1",
@@ -299,6 +725,12 @@ def _write_grabowski_outbox_receipt(
         "receipt_digest_scope": "persisted_receipt",
         "receipt_reused": False,
         "receipt_written": True,
+        "source_origin": prepared.get("source_origin", "loose"),
+        "bundle_manifest_path": (
+            str(prepared["bundle_manifest_path"])
+            if prepared.get("bundle_manifest_path") is not None
+            else None
+        ),
     }
 
 
@@ -346,6 +778,12 @@ def _import_prepared_grabowski_sources(
                 "unchanged": prepared["source_unchanged"],
                 "receipt_reused": False,
                 "receipt_written": False,
+                "source_origin": prepared.get("source_origin", "loose"),
+                "bundle_manifest_path": (
+                    str(prepared["bundle_manifest_path"])
+                    if prepared.get("bundle_manifest_path") is not None
+                    else None
+                ),
             }
             receipt_errors.append((str(prepared["source"]), exc))
         results.append(result)
@@ -362,20 +800,56 @@ def import_grabowski_outbox_file(source: Path, *, receipt_dir: Path) -> dict[str
 
 def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str, Any]:
     source_dir = outbox_root.expanduser() / "grabowski" / "chronik-outbox"
+    bundle_dir = source_dir / GRABOWSKI_BUNDLE_DIRNAME
     sources = sorted(source_dir.glob("*.jsonl")) if source_dir.is_dir() else []
-    prepared_sources: list[dict[str, Any]] = []
+    manifests = sorted(bundle_dir.glob("*.manifest.json")) if bundle_dir.is_dir() else []
+    bundle_files = sorted(bundle_dir.glob("*.bundle.jsonl")) if bundle_dir.is_dir() else []
+    all_prepared: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
     errors: list[dict[str, str]] = []
-    target_scans: int | None = 0
-    target_records_scanned: int | None = 0
+    bundle_metadata: list[dict[str, Any]] = []
+    referenced_bundle_paths: set[str] = set()
     for source in sources:
         try:
-            prepared_sources.append(
+            all_prepared.append(
                 _prepare_grabowski_outbox_source(source, receipt_dir=receipt_dir)
             )
         except (OSError, ValueError, storage.StorageError) as exc:
             errors.append({"source_path": str(source), "error": str(exc)})
-    if prepared_sources:
+    for manifest_path in manifests:
+        try:
+            bundled, metadata = _load_grabowski_bundle(
+                manifest_path,
+                source_dir=source_dir,
+                receipt_dir=receipt_dir,
+            )
+            all_prepared.extend(bundled)
+            bundle_metadata.append(metadata)
+            referenced_bundle_paths.add(str(Path(metadata["bundle_path"]).resolve()))
+        except (OSError, ValueError, storage.StorageError) as exc:
+            errors.append({"source_path": str(manifest_path), "error": str(exc)})
+    orphan_bundles = [
+        path
+        for path in bundle_files
+        if str(path.resolve()) not in referenced_bundle_paths
+    ]
+    errors.extend(
+        {
+            "source_path": str(path),
+            "error": "orphan bundle has no valid manifest and was ignored",
+        }
+        for path in orphan_bundles
+    )
+    target_scans: int | None = 0
+    target_records_scanned: int | None = 0
+    prepared_sources: list[dict[str, Any]] = []
+    try:
+        prepared_sources = _merge_prepared_grabowski_sources(all_prepared)
+    except ValueError as exc:
+        target_scans = None
+        target_records_scanned = None
+        errors.append({"source_path": "<batch>", "error": str(exc)})
+    if prepared_sources and target_scans is not None:
         try:
             results, grouped, receipt_errors = _import_prepared_grabowski_sources(
                 prepared_sources
@@ -393,23 +867,250 @@ def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str
             target_scans = None
             target_records_scanned = None
             errors.append({"source_path": "<batch>", "error": str(exc)})
+    bundled_sources_seen = sum(int(item["source_count"]) for item in bundle_metadata)
     return {
-        "schema_version": "chronik-grabowski-outbox-batch.v1",
+        "schema_version": "chronik-grabowski-outbox-batch.v2",
         "source_dir": str(source_dir),
         "receipt_dir": str(receipt_dir),
         "files_seen": len(sources),
+        "loose_files_seen": len(sources),
+        "bundle_manifests_seen": len(manifests),
+        "bundles_valid": len(bundle_metadata),
+        "bundled_sources_seen": bundled_sources_seen,
+        "sources_seen_total": len(sources) + bundled_sources_seen,
+        "sources_after_deduplication": len(prepared_sources),
+        "orphan_bundles": len(orphan_bundles),
         "files_imported_or_confirmed": len(results),
         "files_unchanged": sum(1 for result in results if result.get("unchanged") is True),
         "receipts_written": sum(1 for result in results if result.get("receipt_written") is True),
         "receipts_reused": sum(1 for result in results if result.get("receipt_reused") is True),
+        "loose_sources_imported_or_confirmed": sum(
+            1 for result in results if result.get("source_origin") == "loose"
+        ),
+        "bundled_sources_imported_or_confirmed": sum(
+            1 for result in results if result.get("source_origin") == "bundle"
+        ),
         "events_imported": sum(int(result.get("imported", 0)) for result in results),
         "events_skipped_existing": sum(int(result.get("skipped_existing", 0)) for result in results),
         "target_scans": target_scans,
         "target_records_scanned": target_records_scanned,
+        "bundle_inventory": bundle_metadata,
         "errors": errors,
         "historical_only": True,
         "does_not_establish": DOES_NOT_ESTABLISH,
     }
+
+
+def compact_grabowski_outbox(
+    *,
+    outbox_root: Path,
+    receipt_dir: Path,
+    grace_seconds: int = 86400,
+    apply: bool = False,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    if type(grace_seconds) is not int or grace_seconds < 0:
+        raise ValueError("grace_seconds must be a non-negative integer")
+    if not isinstance(apply, bool):
+        raise ValueError("apply must be a boolean")
+    observed_at = now or datetime.now(timezone.utc)
+    if observed_at.tzinfo is None:
+        raise ValueError("now must include a timezone")
+    observed_at = observed_at.astimezone(timezone.utc)
+    source_dir = outbox_root.expanduser() / "grabowski" / "chronik-outbox"
+    bundle_dir = source_dir / GRABOWSKI_BUNDLE_DIRNAME
+    sources = sorted(source_dir.glob("*.jsonl")) if source_dir.is_dir() else []
+    skipped: Counter[str] = Counter()
+    errors: list[dict[str, str]] = []
+    eligible: list[dict[str, Any]] = []
+    ledger_payloads, ledger_records_scanned = _ledger_payloads_by_event_id()
+    observed_ns = int(observed_at.timestamp() * 1_000_000_000)
+    grace_ns = grace_seconds * 1_000_000_000
+    for source in sources:
+        try:
+            prepared = _prepare_grabowski_outbox_source(
+                source, receipt_dir=receipt_dir
+            )
+        except (OSError, ValueError, storage.StorageError) as exc:
+            skipped["invalid_source"] += 1
+            errors.append({"source_path": str(source), "error": str(exc)})
+            continue
+        if prepared["events"][-1]["kind"] not in GRABOWSKI_TERMINAL_KINDS:
+            skipped["nonterminal"] += 1
+            continue
+        source_mtime_ns = prepared.get("source_mtime_ns")
+        if (
+            type(source_mtime_ns) is not int
+            or observed_ns - source_mtime_ns < grace_ns
+        ):
+            skipped["grace_pending"] += 1
+            continue
+        if not _receipt_matches_prepared_source(
+            prepared, prepared.get("previous_receipt")
+        ):
+            skipped["receipt_invalid_or_missing"] += 1
+            continue
+        if any(
+            ledger_payloads.get(event["event_id"]) != canonical_bytes(event)
+            for event in prepared["events"]
+        ):
+            skipped["ledger_unconfirmed"] += 1
+            continue
+        eligible.append(prepared)
+    result: dict[str, Any] = {
+        "schema_version": "chronik-grabowski-outbox-compaction.v1",
+        "mode": "apply" if apply else "dry-run",
+        "source_dir": str(source_dir),
+        "receipt_dir": str(receipt_dir),
+        "bundle_dir": str(bundle_dir),
+        "grace_seconds": grace_seconds,
+        "observed_at": observed_at.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "loose_sources_seen": len(sources),
+        "eligible_sources": len(eligible),
+        "eligible_events": sum(len(item["events"]) for item in eligible),
+        "eligible_source_bytes": sum(len(item["raw"]) for item in eligible),
+        "skipped_by_reason": dict(sorted(skipped.items())),
+        "ledger_records_scanned": ledger_records_scanned,
+        "bundle_path": None,
+        "bundle_sha256": None,
+        "bundle_bytes": 0,
+        "manifest_path": None,
+        "manifest_sha256": None,
+        "bundle_published": False,
+        "manifest_published": False,
+        "bundle_reused": False,
+        "sources_removed": 0,
+        "loose_sources_remaining": len(sources),
+        "errors": errors,
+        "historical_only": True,
+        "does_not_establish": DOES_NOT_ESTABLISH,
+    }
+    if not apply or not eligible:
+        return result
+    stable: list[dict[str, Any]] = []
+    for prepared in eligible:
+        if _source_still_matches(prepared):
+            stable.append(prepared)
+        else:
+            skipped["source_changed_before_publish"] += 1
+            errors.append(
+                {
+                    "source_path": str(prepared["source"]),
+                    "error": "source changed before bundle publication",
+                }
+            )
+    result["skipped_by_reason"] = dict(sorted(skipped.items()))
+    result["eligible_sources"] = len(stable)
+    result["eligible_events"] = sum(len(item["events"]) for item in stable)
+    result["eligible_source_bytes"] = sum(len(item["raw"]) for item in stable)
+    if not stable:
+        return result
+    entries: list[dict[str, Any]] = []
+    bundle_parts: list[bytes] = []
+    bundle_offset = 0
+    for item in stable:
+        entries.append(_bundle_source_record(item, offset=bundle_offset))
+        bundle_parts.append(item["raw"])
+        bundle_offset += len(item["raw"])
+    bundle_raw = b"".join(bundle_parts)
+    bundle_sha256 = sha256_bytes(bundle_raw)
+    prefix = f"grabowski-{bundle_sha256}"
+    bundle_path = bundle_dir / f"{prefix}.bundle.jsonl"
+    manifest_path = bundle_dir / f"{prefix}.manifest.json"
+    result.update(
+        {
+            "bundle_path": str(bundle_path),
+            "bundle_sha256": bundle_sha256,
+            "bundle_bytes": len(bundle_raw),
+            "manifest_path": str(manifest_path),
+        }
+    )
+    try:
+        _ensure_bundle_directory(source_dir, bundle_dir)
+        result["bundle_published"] = _publish_immutable(bundle_path, bundle_raw)
+        if manifest_path.exists():
+            loaded, metadata = _load_grabowski_bundle(
+                manifest_path,
+                source_dir=source_dir,
+                receipt_dir=receipt_dir,
+            )
+            result["bundle_reused"] = True
+        else:
+            manifest = {
+                "schema_version": GRABOWSKI_BUNDLE_MANIFEST_SCHEMA,
+                "domain": DOMAIN,
+                "bundle_file": bundle_path.name,
+                "bundle_sha256": bundle_sha256,
+                "bundle_bytes": len(bundle_raw),
+                "source_count": len(entries),
+                "event_count": sum(len(item["events"]) for item in stable),
+                "sources": entries,
+                "created_at": utc_now(),
+                "historical_only": True,
+                "does_not_establish": DOES_NOT_ESTABLISH,
+            }
+            manifest["manifest_sha256"] = sha256_bytes(canonical_bytes(manifest))
+            manifest_raw = (
+                json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8")
+                + b"\n"
+            )
+            result["manifest_published"] = _publish_immutable(
+                manifest_path, manifest_raw
+            )
+            loaded, metadata = _load_grabowski_bundle(
+                manifest_path,
+                source_dir=source_dir,
+                receipt_dir=receipt_dir,
+            )
+        expected_sources = entries
+        if metadata["sources"] != expected_sources:
+            raise ValueError("published bundle inventory does not match selection")
+        loaded_by_path = {
+            str(item["source"].resolve()): item["raw"] for item in loaded
+        }
+        if loaded_by_path != {
+            str(item["source"].resolve()): item["raw"] for item in stable
+        }:
+            raise ValueError("published bundle readback does not match source bytes")
+        result["manifest_sha256"] = metadata["manifest_sha256"]
+    except (OSError, ValueError, storage.StorageError) as exc:
+        errors.append({"source_path": str(manifest_path), "error": str(exc)})
+        return result
+    removed = 0
+    for prepared in stable:
+        source = prepared["source"]
+        if not _source_still_matches(prepared):
+            skipped["source_changed_before_remove"] += 1
+            errors.append(
+                {
+                    "source_path": str(source),
+                    "error": "source changed after bundle publication and was retained",
+                }
+            )
+            continue
+        try:
+            _unlink_loose_source(source)
+        except OSError as exc:
+            skipped["unlink_failed"] += 1
+            errors.append({"source_path": str(source), "error": f"unlink failed: {exc}"})
+        else:
+            removed += 1
+    if removed:
+        try:
+            _fsync_directory(source_dir)
+        except OSError as exc:
+            errors.append(
+                {
+                    "source_path": str(source_dir),
+                    "error": f"source directory fsync failed after removal: {exc}",
+                }
+            )
+    result["sources_removed"] = removed
+    result["loose_sources_remaining"] = (
+        len(list(source_dir.glob("*.jsonl"))) if source_dir.is_dir() else 0
+    )
+    result["skipped_by_reason"] = dict(sorted(skipped.items()))
+    return result
 
 
 def _scan_record_snapshot(

--- a/docs/chronik/direct-operator-memory-v1.md
+++ b/docs/chronik/direct-operator-memory-v1.md
@@ -147,7 +147,9 @@ Ein Receipt wird erst nach dem erfolgreichen Ledger-Abgleich geschrieben. Falls
 dieser Evidenzschritt scheitert, bleiben die bereits bestätigten Ledger-Zahlen
 in der Batch-Ausgabe erhalten und die betroffene Quelle wird zusätzlich als
 Fehler gemeldet. Der nächste Lauf gleicht erneut gegen den realen Ledger ab und
-kann das Receipt wiederherstellen. `target_scans = 0` bedeutet, dass keine
+kann das Receipt wiederherstellen. Auch ein syntaktisch beschädigtes Receipt
+wird dabei wie fehlende Evidenz behandelt und nach dem Ledger-Abgleich ersetzt.
+`target_scans = 0` bedeutet, dass keine
 gültige Quelle einen Ledger-Abgleich erforderte; `null` bedeutet, dass für einen
 vorbereiteten Batch keine verlässliche Scan-Telemetrie vorliegt.
 
@@ -177,3 +179,116 @@ Jeder Outbox-Import gleicht die Event-IDs weiterhin mit dem maßgeblichen Chroni
 `receipt_sha256` im Laufergebnis bindet ausdrücklich die unveränderte Receipt-Datei (`receipt_digest_scope=persisted_receipt`), nicht die aktuellen Laufzähler. `imported`, `skipped_existing` und die Scan-Zähler beschreiben den aktuellen Lauf.
 
 Receipts bleiben nicht maßgeblich. Fehlen Ledger-Daten, werden sie trotz intaktem Receipt aus der Grabowski-Outbox rekonstruiert. Die Quelldateien bleiben deshalb Replay-Evidenz; Löschen oder Kompaktieren benötigt einen eigenen Verlustwiederherstellungsvertrag und folgt nicht aus der Receipt-Wiederverwendung.
+
+## Terminalitätsgebundene Outbox-Kompaktierung
+
+`compact-outbox` begrenzt die Zahl loser Grabowski-Quelldateien, ohne Receipts
+oder einen zusätzlichen Index zur Wahrheit zu erheben. Der Befehl läuft
+standardmäßig nur als Dry-run:
+
+```bash
+python tools/coding_memory.py \
+  --data-dir ~/.local/state/chronik \
+  compact-outbox \
+  --outbox-root ~/.local/state \
+  --receipt-dir ~/.local/state/chronik/import-receipts \
+  --grace-seconds 86400
+```
+
+Erst `--apply` erlaubt die Veröffentlichung eines Bundles und das anschließende
+Entfernen geeigneter loser Quellen. Der Import-Timer führt diese Kompaktierung
+nicht implizit aus.
+
+### Autoritätsgrenzen
+
+- Der Chronik-Ledger bleibt die operative Import- und Abfrageautorität.
+- Eine lose Grabowski-JSONL-Datei oder ein vollständig validiertes Bundle enthält
+  die Replay-Evidenz, aus der ein verlorener Ledger wiederhergestellt werden
+  kann.
+- Ein Import-Receipt belegt nur einen früheren Abgleich. Es darf weder einen
+  fehlenden Ledger ersetzen noch allein eine Quelle löschbar machen.
+- Bundle und Manifest begründen keine aktuelle Task-, Git-, Dienst- oder
+  Deployment-Wahrheit.
+
+Ein Bundle besteht aus einer unveränderlichen JSONL-Datei und einem kanonisch
+SHA-256-gebundenen Manifest. Die Bundle-Datei ist selbst gültiges JSONL und
+besteht aus den unveränderten,
+direkt aneinandergereihten Quellbytes. Das Manifest bindet für jede Quelle den
+Bytebereich, deren SHA-256, die ursprüngliche Reihenfolge der Ereignisse und
+einen eigenen Digest. Dateinamen, Bundle-Digest, Manifest-Digest,
+Quellinventar und Ereignis-IDs werden beim Lesen erneut geprüft. Der streng
+validierte Quelldateiname erlaubt einen Restore unter einem anderen
+Outbox-Wurzelpfad; der ursprüngliche absolute Pfad bleibt nur gebundene
+Provenienz. Unvollständige, verwaiste oder korrupte Artefakte werden nicht
+importiert.
+
+### Auswahlvertrag
+
+Eine lose Quelle ist nur kompaktierbar, wenn alle folgenden Bedingungen zugleich
+erfüllt sind:
+
+1. Die Datei ist vollständiges und gültiges Grabowski-JSONL.
+2. Das letzte Ereignis ist `agent.run.completed` oder `agent.run.blocked`.
+   Eine Datei mit ausschließlich `agent.run.started` bleibt aktiv und wird nie
+   kompaktifiziert.
+3. Die konfigurierte Grace-Periode seit der letzten Dateiänderung ist abgelaufen.
+4. Das vorhandene Receipt ist intakt und exakt an Quellpfad, Quellbytes,
+   Quell-SHA-256 und Ereignis-IDs gebunden.
+5. Jedes Ereignis ist mit identischem kanonischem Payload im tatsächlichen
+   Chronik-Ledger vorhanden.
+6. Geräte-ID, Inode, Größe, Änderungszeit und SHA-256 bleiben während Auswahl,
+   Veröffentlichung und Entfernung unverändert.
+
+Fehlt nur eine Bedingung, bleibt die Quelle liegen. Die Ausgabe zählt die Gründe
+unter `skipped_by_reason` und meldet Fehler mit dem betroffenen Pfad.
+
+### Publish-, Crash- und Race-Vertrag
+
+Der Apply-Pfad legt zuerst ein echtes, nicht verlinktes Bundleverzeichnis an
+und synchronisiert dessen Eintrag im Outbox-Verzeichnis. Danach veröffentlicht
+er zuerst die Bundle-Datei und anschließend das Manifest.
+Beide Artefakte werden über eine temporäre Datei geschrieben, per `fsync`
+gesichert, ohne Ersetzen eines vorhandenen Artefakts veröffentlicht, das
+Verzeichnis wird synchronisiert und die Bytes werden vollständig zurückgelesen.
+Erst nach erfolgreichem Manifest-Readback werden die ausgewählten Quellen erneut
+gegen ihre ursprüngliche Dateiidentität und ihren SHA-256 geprüft und einzeln
+entfernt. Danach wird auch das Quellverzeichnis synchronisiert.
+
+Daraus folgen definierte Crashzustände:
+
+- **Nur Bundle vorhanden:** Das Bundle ist verwaist, wird diagnostiziert und
+  ignoriert. Die losen Quellen bleiben Replay-Evidenz.
+- **Bundle und Manifest vorhanden, Quellen noch vorhanden:** Import liest beide
+  Darstellungen, dedupliziert nur bei exakt gleichen Quellbytes und schlägt bei
+  Abweichung vor jeder Ledgermutation fehl.
+- **Nur ein Teil der Quellen entfernt:** Das gültige Bundle deckt alle
+  ausgewählten Quellen ab; verbliebene identische Quellen werden dedupliziert.
+- **Quelle während des Laufs verändert:** Sie wird nicht entfernt. Weichen lose
+  und gebündelte Bytes danach ab, stoppt der Import fail-closed.
+- **Fehler beim Entfernen oder Verzeichnis-`fsync`:** Der Fehler wird gemeldet.
+  Bereits entfernte Quellen sind durch das zuvor vollständig validierte Bundle
+  replayfähig; nicht entfernte Quellen bleiben erhalten.
+
+Wiederholtes `--apply` ist sicher: Sind keine geeigneten losen Quellen mehr
+vorhanden, entsteht kein neues Bundle und es wird nichts entfernt.
+
+### Wiederherstellung und Rollback
+
+Zur Wiederherstellung dürfen Ledger und Receipts in einer isolierten
+Testumgebung fehlen. `import-outbox` liest dann die gültigen Bundles, rekonstruiert
+alle enthaltenen Ereignisse im leeren Ledger und erzeugt die nichtautoritativen
+Receipts erneut. Ein Restore gilt erst als belegt, wenn Ereigniszahl, Event-IDs
+und Ledger-Integrität mit dem Bundle-Inventar übereinstimmen.
+
+Ein Rollback der Anwendungsversion löscht keine Bundles. Solange eine ältere
+Chronik-Version Bundles nicht versteht, müssen sie zusammen mit dem letzten
+Ledger-Backup erhalten bleiben; die bereits entfernten losen Quellen können aus
+den manifestgebundenen Original-Bytebereichen des Bundles rekonstruiert
+werden. Für das
+Löschen oder Zusammenführen vorhandener Bundles gibt es in diesem Vertrag keine
+automatische Retentionsregel.
+
+Der Outbox-Benchmark misst deshalb getrennt Wiederholungsimporte mit vielen losen
+Dateien, die einmalige Kompaktierung und den anschließenden Import desselben
+Ereignisbestands aus dem Bundle. Er verlangt weiterhin höchstens einen
+vollständigen Ziel-Ledger-Scan je Importlauf.

--- a/tests/test_benchmark_outbox_import.py
+++ b/tests/test_benchmark_outbox_import.py
@@ -33,4 +33,9 @@ def test_benchmark_reports_single_scan_first_and_repeat(tmp_path):
     assert tier["repeat"]["target_scans"] == 1
     assert tier["first"]["events_imported"] == 6
     assert tier["repeat"]["events_skipped_existing"] == 6
+    assert tier["compaction"]["sources_removed"] == 3
+    assert tier["loose_files_before"] == 3
+    assert tier["loose_files_after"] == 0
+    assert tier["bundled_repeat"]["target_scans"] == 1
+    assert tier["bundled_repeat"]["events_skipped_existing"] == 6
     assert tier["passed"] is True

--- a/tests/test_grabowski_outbox_compaction.py
+++ b/tests/test_grabowski_outbox_compaction.py
@@ -1,0 +1,591 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import coding_memory
+import storage
+
+
+def event(kind: str, suffix: str) -> dict:
+    outcome = {
+        "agent.run.started": {"result": "started"},
+        "agent.run.completed": {"result": "completed"},
+        "agent.run.blocked": {"result": "blocked", "blocker_code": "task-failed"},
+    }[kind]
+    return {
+        "schema_version": "agent-run-event.v0",
+        "event_id": "sha256:" + suffix * 64,
+        "kind": kind,
+        "ts": "2026-07-14T10:00:00Z",
+        "source": {
+            "repo": "heimgewebe/grabowski",
+            "component": "grabowski",
+            "run_id": f"task-{suffix}-a1",
+        },
+        "subject": {"repo": "heimgewebe/grabowski"},
+        "trust_tier": "declared" if kind == "agent.run.started" else "observed",
+        "status": "active",
+        "caused_by": [],
+        "evidence_refs": [f"grabowski-task:{suffix}"],
+        "data": outcome,
+    }
+
+
+def configure(tmp_path: Path, monkeypatch) -> tuple[Path, Path, Path, Path]:
+    data = tmp_path / "chronik-data"
+    receipts = tmp_path / "receipts"
+    outbox = tmp_path / "state"
+    source_dir = outbox / "grabowski" / "chronik-outbox"
+    data.mkdir(parents=True)
+    source_dir.mkdir(parents=True)
+    monkeypatch.setattr(storage, "DATA_DIR", data)
+    return data, receipts, outbox, source_dir
+
+
+def write_source(source_dir: Path, name: str, values: list[dict]) -> Path:
+    path = source_dir / name
+    path.write_bytes(
+        b"".join(
+            json.dumps(value, sort_keys=True).encode("utf-8") + b"\n"
+            for value in values
+        )
+    )
+    return path
+
+
+def import_first(outbox: Path, receipts: Path) -> dict:
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+    assert result["errors"] == []
+    return result
+
+
+def compact(outbox: Path, receipts: Path, *, apply: bool = False) -> dict:
+    return coding_memory.compact_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        grace_seconds=0,
+        apply=apply,
+    )
+
+
+def test_dry_run_selects_terminal_sources_without_mutation(tmp_path, monkeypatch):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    one_line = write_source(
+        source_dir, "grabowski_task-one-a1.jsonl", [event("agent.run.completed", "a")]
+    )
+    two_line = write_source(
+        source_dir,
+        "grabowski_task-two-a1.jsonl",
+        [event("agent.run.started", "b"), event("agent.run.blocked", "c")],
+    )
+    active = write_source(
+        source_dir, "grabowski_task-active-a1.jsonl", [event("agent.run.started", "d")]
+    )
+    import_first(outbox, receipts)
+
+    result = compact(outbox, receipts)
+
+    assert result["mode"] == "dry-run"
+    assert result["eligible_sources"] == 2
+    assert result["eligible_events"] == 3
+    assert result["skipped_by_reason"] == {"nonterminal": 1}
+    assert result["sources_removed"] == 0
+    assert one_line.exists() and two_line.exists() and active.exists()
+    assert not (source_dir / "bundles").exists()
+
+
+def test_apply_bundles_sources_and_replays_after_ledger_and_receipt_loss(
+    tmp_path, monkeypatch
+):
+    data, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    write_source(
+        source_dir, "grabowski_task-one-a1.jsonl", [event("agent.run.completed", "a")]
+    )
+    write_source(
+        source_dir,
+        "grabowski_task-two-a1.jsonl",
+        [event("agent.run.started", "b"), event("agent.run.blocked", "c")],
+    )
+    import_first(outbox, receipts)
+
+    applied = compact(outbox, receipts, apply=True)
+
+    assert applied["errors"] == []
+    assert applied["sources_removed"] == 2
+    assert applied["loose_sources_remaining"] == 0
+    assert Path(applied["bundle_path"]).is_file()
+    assert Path(applied["manifest_path"]).is_file()
+    assert applied["bundle_sha256"]
+    assert applied["manifest_sha256"]
+
+    (data / "agent.ledger.jsonl").unlink()
+    for receipt in receipts.glob("*.receipt.json"):
+        receipt.unlink()
+    recovered = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+
+    assert recovered["errors"] == []
+    assert recovered["loose_files_seen"] == 0
+    assert recovered["bundles_valid"] == 1
+    assert recovered["bundled_sources_imported_or_confirmed"] == 2
+    assert recovered["events_imported"] == 3
+    assert len((data / "agent.ledger.jsonl").read_text().splitlines()) == 3
+    assert len(list(receipts.glob("*.receipt.json"))) == 2
+
+
+def test_repeat_apply_is_noop(tmp_path, monkeypatch):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    write_source(
+        source_dir, "grabowski_task-one-a1.jsonl", [event("agent.run.completed", "a")]
+    )
+    import_first(outbox, receipts)
+    first = compact(outbox, receipts, apply=True)
+
+    second = compact(outbox, receipts, apply=True)
+
+    assert first["sources_removed"] == 1
+    assert second["eligible_sources"] == 0
+    assert second["sources_removed"] == 0
+    assert second["errors"] == []
+    assert len(list((source_dir / "bundles").glob("*.manifest.json"))) == 1
+
+
+def test_missing_corrupt_and_stale_receipts_are_not_compacted(tmp_path, monkeypatch):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    paths = [
+        write_source(
+            source_dir,
+            f"grabowski_task-{suffix}-a1.jsonl",
+            [event("agent.run.completed", suffix)],
+        )
+        for suffix in ("a", "b", "c")
+    ]
+    import_first(outbox, receipts)
+    receipt_paths = [coding_memory._receipt_path(path, receipts) for path in paths]
+    receipt_paths[0].unlink()
+    receipt_paths[1].write_text("{broken", encoding="utf-8")
+    stale = json.loads(receipt_paths[2].read_text())
+    stale["source_sha256"] = "0" * 64
+    unsigned = dict(stale)
+    unsigned.pop("receipt_sha256")
+    stale["receipt_sha256"] = coding_memory.sha256_bytes(
+        coding_memory.canonical_bytes(unsigned)
+    )
+    receipt_paths[2].write_text(json.dumps(stale), encoding="utf-8")
+
+    result = compact(outbox, receipts, apply=True)
+
+    assert result["eligible_sources"] == 0
+    assert result["sources_removed"] == 0
+    assert result["skipped_by_reason"]["receipt_invalid_or_missing"] == 3
+    assert result["errors"] == []
+    assert all(path.exists() for path in paths)
+
+
+def test_ledger_loss_blocks_compaction(tmp_path, monkeypatch):
+    data, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    source = write_source(
+        source_dir, "grabowski_task-one-a1.jsonl", [event("agent.run.completed", "a")]
+    )
+    import_first(outbox, receipts)
+    (data / "agent.ledger.jsonl").unlink()
+
+    result = compact(outbox, receipts, apply=True)
+
+    assert result["eligible_sources"] == 0
+    assert result["skipped_by_reason"] == {"ledger_unconfirmed": 1}
+    assert source.exists()
+    assert not (source_dir / "bundles").exists()
+
+
+def test_corrupt_bundle_is_rejected_without_ledger_mutation(tmp_path, monkeypatch):
+    data, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    write_source(
+        source_dir, "grabowski_task-one-a1.jsonl", [event("agent.run.completed", "a")]
+    )
+    import_first(outbox, receipts)
+    applied = compact(outbox, receipts, apply=True)
+    bundle_path = Path(applied["bundle_path"])
+    bundle_path.write_bytes(bundle_path.read_bytes() + b" ")
+    (data / "agent.ledger.jsonl").unlink()
+
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+
+    assert result["events_imported"] == 0
+    assert result["bundles_valid"] == 0
+    assert result["errors"]
+    assert not (data / "agent.ledger.jsonl").exists()
+
+
+def test_manifest_without_bundle_is_rejected(tmp_path, monkeypatch):
+    data, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    write_source(
+        source_dir, "grabowski_task-one-a1.jsonl", [event("agent.run.completed", "a")]
+    )
+    import_first(outbox, receipts)
+    applied = compact(outbox, receipts, apply=True)
+    Path(applied["bundle_path"]).unlink()
+    (data / "agent.ledger.jsonl").unlink()
+
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+
+    assert result["events_imported"] == 0
+    assert result["errors"]
+    assert "cannot inspect bundle file" in result["errors"][0]["error"]
+    assert not (data / "agent.ledger.jsonl").exists()
+
+
+def test_publish_failure_keeps_source(tmp_path, monkeypatch):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    source = write_source(
+        source_dir, "grabowski_task-one-a1.jsonl", [event("agent.run.completed", "a")]
+    )
+    import_first(outbox, receipts)
+
+    def fail_publish(path: Path, data: bytes) -> bool:
+        raise OSError("simulated publish failure")
+
+    monkeypatch.setattr(coding_memory, "_publish_immutable", fail_publish)
+    result = compact(outbox, receipts, apply=True)
+
+    assert result["sources_removed"] == 0
+    assert result["errors"]
+    assert source.exists()
+
+
+def test_unlink_failure_keeps_source_but_publishes_replay_bundle(tmp_path, monkeypatch):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    source = write_source(
+        source_dir, "grabowski_task-one-a1.jsonl", [event("agent.run.completed", "a")]
+    )
+    import_first(outbox, receipts)
+
+    def fail_unlink(path: Path) -> None:
+        raise OSError("simulated unlink failure")
+
+    monkeypatch.setattr(coding_memory, "_unlink_loose_source", fail_unlink)
+    result = compact(outbox, receipts, apply=True)
+
+    assert result["sources_removed"] == 0
+    assert result["skipped_by_reason"] == {"unlink_failed": 1}
+    assert source.exists()
+    assert Path(result["bundle_path"]).exists()
+    assert Path(result["manifest_path"]).exists()
+    readback = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+    assert readback["errors"] == []
+    assert readback["sources_after_deduplication"] == 1
+
+
+def test_source_change_after_publish_is_retained_and_import_fails_closed(
+    tmp_path, monkeypatch
+):
+    data, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    source = write_source(
+        source_dir, "grabowski_task-one-a1.jsonl", [event("agent.run.completed", "a")]
+    )
+    import_first(outbox, receipts)
+    original_publish = coding_memory._publish_immutable
+    changed = False
+
+    def publish_and_change(path: Path, payload: bytes) -> bool:
+        nonlocal changed
+        published = original_publish(path, payload)
+        if path.name.endswith(".manifest.json") and not changed:
+            with source.open("ab") as handle:
+                handle.write(
+                    json.dumps(event("agent.run.started", "b"), sort_keys=True).encode()
+                    + b"\n"
+                )
+            changed = True
+        return published
+
+    monkeypatch.setattr(coding_memory, "_publish_immutable", publish_and_change)
+    result = compact(outbox, receipts, apply=True)
+
+    assert result["sources_removed"] == 0
+    assert result["skipped_by_reason"] == {"source_changed_before_remove": 1}
+    assert source.exists()
+    (data / "agent.ledger.jsonl").unlink()
+    failed_import = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+    assert failed_import["events_imported"] == 0
+    assert failed_import["target_scans"] is None
+    assert "conflicting loose and bundled source bytes" in failed_import["errors"][-1]["error"]
+    assert not (data / "agent.ledger.jsonl").exists()
+
+
+def test_divergent_event_id_across_bundle_and_loose_source_fails_before_append(
+    tmp_path, monkeypatch
+):
+    data, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    original = event("agent.run.completed", "a")
+    write_source(source_dir, "grabowski_task-one-a1.jsonl", [original])
+    import_first(outbox, receipts)
+    compact(outbox, receipts, apply=True)
+    conflicting = event("agent.run.completed", "a")
+    conflicting["subject"] = {"repo": "heimgewebe/other"}
+    write_source(source_dir, "grabowski_task-conflict-a1.jsonl", [conflicting])
+    (data / "agent.ledger.jsonl").unlink()
+
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+
+    assert result["events_imported"] == 0
+    assert result["target_scans"] is None
+    assert "conflicting event_id" in result["errors"][-1]["error"]
+    assert not (data / "agent.ledger.jsonl").exists()
+
+
+def test_orphan_bundle_is_diagnosed_and_ignored(tmp_path, monkeypatch):
+    data, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    bundle_dir = source_dir / "bundles"
+    bundle_dir.mkdir()
+    (bundle_dir / ("grabowski-" + "0" * 64 + ".bundle.jsonl")).write_text(
+        "{}\n", encoding="utf-8"
+    )
+
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+
+    assert result["orphan_bundles"] == 1
+    assert result["events_imported"] == 0
+    assert "orphan bundle" in result["errors"][0]["error"]
+    assert not (data / "agent.ledger.jsonl").exists()
+
+
+def test_compact_cli_is_dry_run_by_default_and_apply_is_explicit(
+    tmp_path, monkeypatch
+):
+    data, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    source = write_source(
+        source_dir, "grabowski_task-one-a1.jsonl", [event("agent.run.completed", "a")]
+    )
+    import_first(outbox, receipts)
+    root = Path(__file__).parents[1]
+    base = [
+        sys.executable,
+        str(root / "tools" / "coding_memory.py"),
+        "--data-dir",
+        str(data),
+        "compact-outbox",
+        "--outbox-root",
+        str(outbox),
+        "--receipt-dir",
+        str(receipts),
+        "--grace-seconds",
+        "0",
+    ]
+
+    dry = subprocess.run(base, text=True, capture_output=True)
+
+    assert dry.returncode == 0
+    assert json.loads(dry.stdout)["mode"] == "dry-run"
+    assert source.exists() is True
+    assert not (source_dir / "bundles").exists()
+
+    applied = subprocess.run(base + ["--apply"], text=True, capture_output=True)
+
+    assert applied.returncode == 0
+    assert json.loads(applied.stdout)["sources_removed"] == 1
+    assert source.exists() is False
+
+
+def test_grace_period_retains_recent_terminal_source(tmp_path, monkeypatch):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    source = write_source(
+        source_dir,
+        "grabowski_task-recent-a1.jsonl",
+        [event("agent.run.completed", "e")],
+    )
+    import_first(outbox, receipts)
+
+    result = coding_memory.compact_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        grace_seconds=86400,
+        apply=True,
+    )
+
+    assert result["eligible_sources"] == 0
+    assert result["sources_removed"] == 0
+    assert result["skipped_by_reason"] == {"grace_pending": 1}
+    assert source.exists()
+
+
+def test_bundle_directory_fsync_failure_keeps_source(tmp_path, monkeypatch):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    source = write_source(
+        source_dir,
+        "grabowski_task-one-a1.jsonl",
+        [event("agent.run.completed", "f")],
+    )
+    import_first(outbox, receipts)
+
+    def fail_fsync(path: Path) -> None:
+        raise OSError("simulated directory fsync failure")
+
+    monkeypatch.setattr(coding_memory, "_fsync_directory", fail_fsync)
+    result = compact(outbox, receipts, apply=True)
+
+    assert result["sources_removed"] == 0
+    assert result["errors"]
+    assert source.exists()
+
+
+def test_source_directory_fsync_failure_is_reported_after_safe_bundle(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    source = write_source(
+        source_dir,
+        "grabowski_task-one-a1.jsonl",
+        [event("agent.run.completed", "1")],
+    )
+    import_first(outbox, receipts)
+    original_fsync = coding_memory._fsync_directory
+    source_dir_fsyncs = 0
+
+    def fail_source_dir_only(path: Path) -> None:
+        nonlocal source_dir_fsyncs
+        if path == source_dir:
+            source_dir_fsyncs += 1
+            if source_dir_fsyncs == 2:
+                raise OSError("simulated source directory fsync failure")
+        original_fsync(path)
+
+    monkeypatch.setattr(coding_memory, "_fsync_directory", fail_source_dir_only)
+    result = compact(outbox, receipts, apply=True)
+
+    assert result["sources_removed"] == 1
+    assert source.exists() is False
+    assert Path(result["bundle_path"]).exists()
+    assert Path(result["manifest_path"]).exists()
+    assert any("source directory fsync failed" in item["error"] for item in result["errors"])
+
+
+def test_corrupt_receipt_does_not_block_authoritative_source_replay(
+    tmp_path, monkeypatch
+):
+    data, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    source = write_source(
+        source_dir,
+        "grabowski_task-corrupt-receipt-a1.jsonl",
+        [event("agent.run.completed", "2")],
+    )
+    import_first(outbox, receipts)
+    receipt = coding_memory._receipt_path(source, receipts)
+    receipt.write_text("{broken", encoding="utf-8")
+    (data / "agent.ledger.jsonl").unlink()
+
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+    )
+
+    assert result["errors"] == []
+    assert result["events_imported"] == 1
+    repaired = json.loads(receipt.read_text())
+    assert repaired["source_sha256"] == coding_memory.sha256_bytes(source.read_bytes())
+
+
+def test_bundle_replay_is_relocatable_without_original_absolute_path(
+    tmp_path, monkeypatch
+):
+    data, receipts, outbox, source_dir = configure(tmp_path / "origin", monkeypatch)
+    write_source(
+        source_dir,
+        "grabowski_task-portable-a1.jsonl",
+        [event("agent.run.completed", "3")],
+    )
+    import_first(outbox, receipts)
+    applied = compact(outbox, receipts, apply=True)
+    assert applied["errors"] == []
+
+    restored_root = tmp_path / "restored" / "state"
+    restored_source_dir = restored_root / "grabowski" / "chronik-outbox"
+    restored_bundle_dir = restored_source_dir / "bundles"
+    restored_bundle_dir.mkdir(parents=True)
+    for artifact in (Path(applied["bundle_path"]), Path(applied["manifest_path"])):
+        (restored_bundle_dir / artifact.name).write_bytes(artifact.read_bytes())
+    restored_data = tmp_path / "restored" / "chronik-data"
+    restored_data.mkdir()
+    restored_receipts = tmp_path / "restored" / "receipts"
+    monkeypatch.setattr(storage, "DATA_DIR", restored_data)
+
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=restored_root,
+        receipt_dir=restored_receipts,
+    )
+
+    assert result["errors"] == []
+    assert result["events_imported"] == 1
+    assert result["bundles_valid"] == 1
+    assert len(list(restored_receipts.glob("*.receipt.json"))) == 1
+    assert len((restored_data / "agent.ledger.jsonl").read_text().splitlines()) == 1
+
+
+def test_bundle_directory_parent_is_fsynced_before_source_unlink(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    source = write_source(
+        source_dir,
+        "grabowski_task-parent-fsync-a1.jsonl",
+        [event("agent.run.completed", "4")],
+    )
+    import_first(outbox, receipts)
+    original_fsync = coding_memory._fsync_directory
+    fsynced: list[Path] = []
+
+    def record_fsync(path: Path) -> None:
+        original_fsync(path)
+        fsynced.append(path)
+
+    def require_parent_fsync(path: Path) -> None:
+        assert source_dir in fsynced
+        path.unlink()
+
+    monkeypatch.setattr(coding_memory, "_fsync_directory", record_fsync)
+    monkeypatch.setattr(coding_memory, "_unlink_loose_source", require_parent_fsync)
+
+    result = compact(outbox, receipts, apply=True)
+
+    assert result["errors"] == []
+    assert result["sources_removed"] == 1
+    assert source.exists() is False
+
+
+def test_symlink_bundle_directory_is_rejected_before_publication(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    source = write_source(
+        source_dir,
+        "grabowski_task-symlink-a1.jsonl",
+        [event("agent.run.completed", "5")],
+    )
+    import_first(outbox, receipts)
+    outside = tmp_path / "outside-bundles"
+    outside.mkdir()
+    (source_dir / "bundles").symlink_to(outside, target_is_directory=True)
+
+    result = compact(outbox, receipts, apply=True)
+
+    assert result["sources_removed"] == 0
+    assert result["errors"]
+    assert "real directory" in result["errors"][0]["error"]
+    assert source.exists()
+    assert list(outside.iterdir()) == []

--- a/tools/benchmark_outbox_import.py
+++ b/tools/benchmark_outbox_import.py
@@ -88,6 +88,28 @@ def _measure(outbox_root: Path, receipt_dir: Path) -> dict:
     }
 
 
+def _measure_compaction(outbox_root: Path, receipt_dir: Path) -> dict:
+    started = time.perf_counter()
+    result = coding_memory.compact_grabowski_outbox(
+        outbox_root=outbox_root,
+        receipt_dir=receipt_dir,
+        grace_seconds=0,
+        apply=True,
+    )
+    elapsed = time.perf_counter() - started
+    return {
+        "elapsed_seconds": round(elapsed, 6),
+        "eligible_sources": result["eligible_sources"],
+        "eligible_events": result["eligible_events"],
+        "sources_removed": result["sources_removed"],
+        "loose_sources_remaining": result["loose_sources_remaining"],
+        "bundle_bytes": result["bundle_bytes"],
+        "bundle_sha256": result["bundle_sha256"],
+        "ledger_records_scanned": result["ledger_records_scanned"],
+        "errors": result["errors"],
+    }
+
+
 def benchmark_tier(
     *,
     name: str,
@@ -120,12 +142,33 @@ def benchmark_tier(
         receipt_dir = temp_root / "receipts"
         first = _measure(outbox_root, receipt_dir)
         repeat = _measure(outbox_root, receipt_dir)
-        worst_seconds = max(first["elapsed_seconds"], repeat["elapsed_seconds"])
+        loose_files_before = len(list(source_dir.glob("*.jsonl")))
+        compaction = _measure_compaction(outbox_root, receipt_dir)
+        loose_files_after = len(list(source_dir.glob("*.jsonl")))
+        bundled_repeat = _measure(outbox_root, receipt_dir)
+        worst_seconds = max(
+            first["elapsed_seconds"],
+            repeat["elapsed_seconds"],
+            bundled_repeat["elapsed_seconds"],
+        )
+        loose_seconds = repeat["elapsed_seconds"]
+        bundled_seconds = bundled_repeat["elapsed_seconds"]
+        speedup_ratio = (
+            round(loose_seconds / bundled_seconds, 3)
+            if bundled_seconds > 0
+            else None
+        )
         passed = (
             not first["errors"]
             and not repeat["errors"]
+            and not compaction["errors"]
+            and not bundled_repeat["errors"]
             and first["target_scans"] <= MAX_TARGET_SCANS
             and repeat["target_scans"] <= MAX_TARGET_SCANS
+            and bundled_repeat["target_scans"] <= MAX_TARGET_SCANS
+            and compaction["sources_removed"] == source_files
+            and loose_files_before == source_files
+            and loose_files_after == 0
             and worst_seconds <= max_seconds
             and worst_seconds <= TIMER_BUDGET_SECONDS
         )
@@ -139,6 +182,13 @@ def benchmark_tier(
             "max_target_scans": MAX_TARGET_SCANS,
             "first": first,
             "repeat": repeat,
+            "compaction": compaction,
+            "bundled_repeat": bundled_repeat,
+            "loose_files_before": loose_files_before,
+            "loose_files_after": loose_files_after,
+            "loose_repeat_seconds": loose_seconds,
+            "bundled_repeat_seconds": bundled_seconds,
+            "loose_to_bundled_speedup_ratio": speedup_ratio,
             "worst_seconds": worst_seconds,
             "passed": passed,
         }
@@ -147,7 +197,7 @@ def benchmark_tier(
 def run_benchmark(tiers: tuple[dict, ...] = DEFAULT_TIERS) -> dict:
     results = [benchmark_tier(**tier) for tier in tiers]
     return {
-        "schema_version": "chronik-outbox-import-benchmark.v1",
+        "schema_version": "chronik-outbox-import-benchmark.v2",
         "machine": {
             "platform": platform.platform(),
             "python": platform.python_version(),

--- a/tools/coding_memory.py
+++ b/tools/coding_memory.py
@@ -14,7 +14,7 @@ if root_path in sys.path:
     sys.path.remove(root_path)
 sys.path.insert(0, root_path)
 
-import coding_memory
+import coding_memory  # noqa: E402
 
 
 def load(path: Path):
@@ -104,6 +104,12 @@ def main(argv=None):
     outbox.add_argument("--outbox-root", type=Path, default=Path.home() / ".local/state")
     outbox.add_argument("--receipt-dir", type=Path)
 
+    compact = sub.add_parser("compact-outbox")
+    compact.add_argument("--outbox-root", type=Path, default=Path.home() / ".local/state")
+    compact.add_argument("--receipt-dir", type=Path)
+    compact.add_argument("--grace-seconds", type=int, default=86400)
+    compact.add_argument("--apply", action="store_true")
+
     summary = sub.add_parser("summary")
     summary.add_argument("--since")
     summary.add_argument("--limit", type=int, default=20)
@@ -148,6 +154,14 @@ def main(argv=None):
                     outbox_root=args.outbox_root,
                     receipt_dir=receipt_dir.expanduser(),
                 )
+            elif args.command == "compact-outbox":
+                receipt_dir = args.receipt_dir or data_path / "import-receipts"
+                result = coding_memory.compact_grabowski_outbox(
+                    outbox_root=args.outbox_root,
+                    receipt_dir=receipt_dir.expanduser(),
+                    grace_seconds=args.grace_seconds,
+                    apply=args.apply,
+                )
             elif args.command == "query":
                 result = coding_memory.query_history(**query_filters)
             elif args.command == "summary":
@@ -159,7 +173,7 @@ def main(argv=None):
         return 2
 
     print(json.dumps(result, indent=2, sort_keys=True))
-    if args.command == "import-outbox" and result["errors"]:
+    if args.command in {"import-outbox", "compact-outbox"} and result["errors"]:
         return 2
     return 0
 


### PR DESCRIPTION
## Summary
- add explicit `compact-outbox` with dry-run by default and mutation only through `--apply`
- compact only terminal, grace-aged, stable, receipt-bound sources whose exact events exist in the actual Chronik ledger
- publish immutable digest-bound JSONL bundles plus canonical manifests before removing loose sources
- import valid loose sources and bundles with conflict detection, relocatable recovery and nonauthoritative receipt reconstruction
- document authority, crash, race, recovery and rollback contracts

## Governance
- Bureau task: `CHRONIK-ECOSYSTEM-CLOSEOUT-V1-T009`
- Bureau PR #657 merged as `b76deacaeca7b97caaad6d25ab9eff1d1a43b5c0`

## Exact review binding
- head: `2bba3d27557dc0b0c5122529f2053fe78c737572`
- base: `173275240d004ac2f3155d7652abcf67dcb894a2`
- reviewed diff SHA-256: `d1922804e20fc8c0b39887287384633ef3166a5554ec2c7f8796ec47b72580e7`
- changed paths: six expected code, CLI, test, benchmark and documentation files

## Validation
- 345 tests passed
- role contract: OK
- Ruff checks: passed
- local Health, Version, Ingest and Events smoke: passed
- live-shaped benchmark: 2,650 loose sources removed in 3.56 s; bundled repeat import 4.59 s; one ledger scan; no errors
- scale benchmark: 10,000 loose sources removed in 13.26 s; bundled repeat import 17.27 s; one ledger scan; no errors
- empty-ledger plus missing-receipt recovery restores all bundled events

## Boundaries
- no live outbox source was changed while preparing this PR
- no automatic compaction timer is introduced
- receipts remain nonauthoritative
- the ledger remains operational authority
- bundle retention and bundle-to-bundle rollup are intentionally outside this slice