### PR TITLE
Guard compacted Grabowski outbox sources with a reconstructed archive index

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -32,6 +32,8 @@ GRABOWSKI_TERMINAL_KINDS = frozenset({"agent.run.completed", "agent.run.blocked"
 GRABOWSKI_BUNDLE_DIRNAME = "bundles"
 GRABOWSKI_BUNDLE_ENTRY_SCHEMA = "chronik-grabowski-outbox-bundle-source.v1"
 GRABOWSKI_BUNDLE_MANIFEST_SCHEMA = "chronik-grabowski-outbox-bundle-manifest.v1"
+GRABOWSKI_ARCHIVE_INDEX_FILENAME = "archive-index.v1.json"
+GRABOWSKI_ARCHIVE_INDEX_SCHEMA = "chronik-grabowski-outbox-archive-index.v1"
 
 
 def canonical_bytes(value: Any) -> bytes:
@@ -524,6 +526,226 @@ def _load_grabowski_bundle(
     }
 
 
+def _grabowski_archive_index_document(
+    bundle_metadata: Iterable[dict[str, Any]],
+) -> dict[str, Any]:
+    metadata = sorted(bundle_metadata, key=lambda item: item["manifest_path"])
+    manifests = [
+        {
+            "file": Path(item["manifest_path"]).name,
+            "sha256": item["manifest_sha256"],
+        }
+        for item in metadata
+    ]
+    sources: list[dict[str, Any]] = []
+    seen_names: set[str] = set()
+    for manifest_index, item in enumerate(metadata):
+        for source in item["sources"]:
+            source_name = source["source_name"]
+            if source_name in seen_names:
+                raise ValueError(f"duplicate archived source name: {source_name}")
+            seen_names.add(source_name)
+            sources.append(
+                {
+                    "source_name": source_name,
+                    "source_sha256": source["source_sha256"],
+                    "event_ids": list(source["event_ids"]),
+                    "manifest_index": manifest_index,
+                }
+            )
+    sources.sort(key=lambda item: item["source_name"])
+    index = {
+        "schema_version": GRABOWSKI_ARCHIVE_INDEX_SCHEMA,
+        "domain": DOMAIN,
+        "manifest_count": len(manifests),
+        "source_count": len(sources),
+        "manifests": manifests,
+        "sources": sources,
+        "historical_only": True,
+        "authoritative": False,
+        "reconstructible": True,
+        "does_not_establish": [
+            *DOES_NOT_ESTABLISH,
+            "bundle_or_source_authority",
+            "future_outbox_write_suppression",
+        ],
+    }
+    index["index_sha256"] = sha256_bytes(canonical_bytes(index))
+    return index
+
+
+def _validate_grabowski_archive_index(
+    raw: bytes,
+    *,
+    path: Path,
+    expected: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not raw.endswith(b"\n"):
+        raise ValueError(f"incomplete archive index: {path}")
+    try:
+        index = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid archive index JSON: {path}") from exc
+    expected_keys = {
+        "schema_version",
+        "domain",
+        "manifest_count",
+        "source_count",
+        "manifests",
+        "sources",
+        "historical_only",
+        "authoritative",
+        "reconstructible",
+        "does_not_establish",
+        "index_sha256",
+    }
+    if not isinstance(index, dict) or set(index) != expected_keys:
+        raise ValueError(f"invalid archive index fields: {path}")
+    if (
+        index["schema_version"] != GRABOWSKI_ARCHIVE_INDEX_SCHEMA
+        or index["domain"] != DOMAIN
+        or index["historical_only"] is not True
+        or index["authoritative"] is not False
+        or index["reconstructible"] is not True
+        or index["does_not_establish"]
+        != [
+            *DOES_NOT_ESTABLISH,
+            "bundle_or_source_authority",
+            "future_outbox_write_suppression",
+        ]
+    ):
+        raise ValueError(f"invalid archive index contract: {path}")
+    claimed_sha256 = index.get("index_sha256")
+    if not isinstance(claimed_sha256, str):
+        raise ValueError(f"invalid archive index digest: {path}")
+    unsigned = dict(index)
+    unsigned.pop("index_sha256")
+    if claimed_sha256 != sha256_bytes(canonical_bytes(unsigned)):
+        raise ValueError(f"archive index digest mismatch: {path}")
+
+    def valid_sha256(value: Any) -> bool:
+        return (
+            isinstance(value, str)
+            and len(value) == 64
+            and all(character in "0123456789abcdef" for character in value)
+        )
+
+    manifests = index.get("manifests")
+    if not isinstance(manifests, list):
+        raise ValueError(f"invalid archive index manifests: {path}")
+    manifest_files: list[str] = []
+    for manifest in manifests:
+        if not isinstance(manifest, dict) or set(manifest) != {"file", "sha256"}:
+            raise ValueError(f"invalid archive index manifest fields: {path}")
+        manifest_file = manifest.get("file")
+        if (
+            not isinstance(manifest_file, str)
+            or Path(manifest_file).name != manifest_file
+            or not manifest_file.endswith(".manifest.json")
+            or not valid_sha256(manifest.get("sha256"))
+        ):
+            raise ValueError(f"invalid archive index manifest contract: {path}")
+        manifest_files.append(manifest_file)
+    if manifest_files != sorted(manifest_files) or len(manifest_files) != len(
+        set(manifest_files)
+    ):
+        raise ValueError(f"archive index manifests are not unique and sorted: {path}")
+
+    sources = index.get("sources")
+    if not isinstance(sources, list):
+        raise ValueError(f"invalid archive index sources: {path}")
+    names: list[str] = []
+    source_keys = {"source_name", "source_sha256", "event_ids", "manifest_index"}
+    for source in sources:
+        if not isinstance(source, dict) or set(source) != source_keys:
+            raise ValueError(f"invalid archive index source fields: {path}")
+        source_name = source.get("source_name")
+        event_ids = source.get("event_ids")
+        manifest_index = source.get("manifest_index")
+        if (
+            not isinstance(source_name, str)
+            or Path(source_name).name != source_name
+            or not source_name.endswith(".jsonl")
+            or not valid_sha256(source.get("source_sha256"))
+            or not isinstance(event_ids, list)
+            or not event_ids
+            or len(event_ids) != len(set(event_ids))
+            or any(
+                not isinstance(event_id, str)
+                or not event_id.startswith("sha256:")
+                or not valid_sha256(event_id.removeprefix("sha256:"))
+                for event_id in event_ids
+            )
+            or type(manifest_index) is not int
+            or manifest_index < 0
+            or manifest_index >= len(manifests)
+        ):
+            raise ValueError(f"invalid archive index source contract: {path}")
+        names.append(source_name)
+    if names != sorted(names) or len(names) != len(set(names)):
+        raise ValueError(f"archive index source names are not unique and sorted: {path}")
+    if (
+        type(index.get("manifest_count")) is not int
+        or index["manifest_count"] != len(manifests)
+        or type(index.get("source_count")) is not int
+        or index["source_count"] != len(sources)
+    ):
+        raise ValueError(f"archive index inventory mismatch: {path}")
+    if expected is not None and index != expected:
+        raise ValueError(f"archive index readback mismatch: {path}")
+    return index
+
+
+def _refresh_grabowski_archive_index(
+    *,
+    source_dir: Path,
+    bundle_dir: Path,
+    receipt_dir: Path,
+) -> dict[str, Any] | None:
+    manifest_paths = (
+        sorted(bundle_dir.glob("*.manifest.json")) if bundle_dir.is_dir() else []
+    )
+    if not manifest_paths:
+        return None
+    metadata: list[dict[str, Any]] = []
+    for manifest_path in manifest_paths:
+        _, item = _load_grabowski_bundle(
+            manifest_path,
+            source_dir=source_dir,
+            receipt_dir=receipt_dir,
+        )
+        metadata.append(item)
+    index = _grabowski_archive_index_document(metadata)
+    index_path = bundle_dir / GRABOWSKI_ARCHIVE_INDEX_FILENAME
+    raw = canonical_bytes(index) + b"\n"
+    published = True
+    try:
+        existing_state = index_path.lstat()
+    except FileNotFoundError:
+        existing = None
+    else:
+        if not stat.S_ISREG(existing_state.st_mode):
+            raise ValueError(f"archive index must be a regular file: {index_path}")
+        existing = index_path.read_bytes()
+    if existing == raw:
+        published = False
+    else:
+        _atomic_write(index_path, raw)
+        _fsync_directory(bundle_dir)
+    readback = _read_immutable_artifact(index_path, label="archive index")
+    validated = _validate_grabowski_archive_index(
+        readback, path=index_path, expected=index
+    )
+    return {
+        "path": str(index_path),
+        "index_sha256": validated["index_sha256"],
+        "file_sha256": sha256_bytes(readback),
+        "manifest_count": validated["manifest_count"],
+        "source_count": validated["source_count"],
+        "published": published,
+    }
+
+
 def _merge_prepared_grabowski_sources(
     prepared_sources: Iterable[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -976,6 +1198,12 @@ def compact_grabowski_outbox(
         "bundle_bytes": 0,
         "manifest_path": None,
         "manifest_sha256": None,
+        "archive_index_path": str(bundle_dir / GRABOWSKI_ARCHIVE_INDEX_FILENAME),
+        "archive_index_sha256": None,
+        "archive_index_file_sha256": None,
+        "archive_index_published": False,
+        "archive_manifests_indexed": 0,
+        "archived_sources_indexed": 0,
         "bundle_published": False,
         "manifest_published": False,
         "bundle_reused": False,
@@ -985,7 +1213,34 @@ def compact_grabowski_outbox(
         "historical_only": True,
         "does_not_establish": DOES_NOT_ESTABLISH,
     }
-    if not apply or not eligible:
+    if not apply:
+        return result
+    if not eligible:
+        try:
+            archive_index = _refresh_grabowski_archive_index(
+                source_dir=source_dir,
+                bundle_dir=bundle_dir,
+                receipt_dir=receipt_dir,
+            )
+        except (OSError, ValueError, storage.StorageError) as exc:
+            errors.append(
+                {
+                    "source_path": str(bundle_dir / GRABOWSKI_ARCHIVE_INDEX_FILENAME),
+                    "error": str(exc),
+                }
+            )
+        else:
+            if archive_index is not None:
+                result.update(
+                    {
+                        "archive_index_path": archive_index["path"],
+                        "archive_index_sha256": archive_index["index_sha256"],
+                        "archive_index_file_sha256": archive_index["file_sha256"],
+                        "archive_index_published": archive_index["published"],
+                        "archive_manifests_indexed": archive_index["manifest_count"],
+                        "archived_sources_indexed": archive_index["source_count"],
+                    }
+                )
         return result
     stable: list[dict[str, Any]] = []
     for prepared in eligible:
@@ -1025,6 +1280,7 @@ def compact_grabowski_outbox(
             "manifest_path": str(manifest_path),
         }
     )
+    failure_path = manifest_path
     try:
         _ensure_bundle_directory(source_dir, bundle_dir)
         result["bundle_published"] = _publish_immutable(bundle_path, bundle_raw)
@@ -1073,8 +1329,26 @@ def compact_grabowski_outbox(
         }:
             raise ValueError("published bundle readback does not match source bytes")
         result["manifest_sha256"] = metadata["manifest_sha256"]
+        failure_path = bundle_dir / GRABOWSKI_ARCHIVE_INDEX_FILENAME
+        archive_index = _refresh_grabowski_archive_index(
+            source_dir=source_dir,
+            bundle_dir=bundle_dir,
+            receipt_dir=receipt_dir,
+        )
+        if archive_index is None:
+            raise ValueError("archive index was not created for published bundle")
+        result.update(
+            {
+                "archive_index_path": archive_index["path"],
+                "archive_index_sha256": archive_index["index_sha256"],
+                "archive_index_file_sha256": archive_index["file_sha256"],
+                "archive_index_published": archive_index["published"],
+                "archive_manifests_indexed": archive_index["manifest_count"],
+                "archived_sources_indexed": archive_index["source_count"],
+            }
+        )
     except (OSError, ValueError, storage.StorageError) as exc:
-        errors.append({"source_path": str(manifest_path), "error": str(exc)})
+        errors.append({"source_path": str(failure_path), "error": str(exc)})
         return result
     removed = 0
     for prepared in stable:

--- a/docs/chronik/direct-operator-memory-v1.md
+++ b/docs/chronik/direct-operator-memory-v1.md
@@ -199,6 +199,21 @@ Erst `--apply` erlaubt die Veröffentlichung eines Bundles und das anschließend
 Entfernen geeigneter loser Quellen. Der Import-Timer führt diese Kompaktierung
 nicht implizit aus.
 
+Vor dem ersten Entfernen veröffentlicht Chronik zusätzlich
+`bundles/archive-index.v1.json`. Diese kompakte, atomar ersetzte Projektion
+ordnet jeden archivierten Quelldateinamen seinem Quell-Digest, seinen Event-IDs
+und dem gebundenen Manifest zu. Chronik rekonstruiert und validiert den Index
+bei jedem Apply aus sämtlichen gültigen Bundle-Manifesten; fehlt er, wird er
+auch dann wiederhergestellt, wenn keine lose Quelle mehr kompaktierbar ist.
+Ein beschädigter, widersprüchlicher oder nicht lesbar zurückgeprüfter Index
+blockiert das Entfernen der Quelle.
+
+Der Archivindex ist keine zusätzliche Historien- oder Taskautorität. Die
+unveränderlichen Bundle-Dateien und ihre Manifeste bleiben die maßgebliche
+Replay-Evidenz. Der Index ist eine rekonstruierbare Schreibschutzprojektion,
+damit der Grabowski-Produzent nach einer Kompaktierung denselben logischen
+Quellpfad nicht erneut als verkürzte Teilhistorie anlegt.
+
 ### Autoritätsgrenzen
 
 - Der Chronik-Ledger bleibt die operative Import- und Abfrageautorität.

--- a/tests/test_grabowski_outbox_compaction.py
+++ b/tests/test_grabowski_outbox_compaction.py
@@ -154,6 +154,105 @@ def test_repeat_apply_is_noop(tmp_path, monkeypatch):
     assert len(list((source_dir / "bundles").glob("*.manifest.json"))) == 1
 
 
+def test_archive_index_is_published_and_validated_before_source_unlink(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    source = write_source(
+        source_dir,
+        "grabowski_task-indexed-a1.jsonl",
+        [event("agent.run.started", "a"), event("agent.run.completed", "b")],
+    )
+    import_first(outbox, receipts)
+    original_unlink = coding_memory._unlink_loose_source
+    observed = {}
+
+    def guarded_unlink(path):
+        index_path = source_dir / "bundles" / coding_memory.GRABOWSKI_ARCHIVE_INDEX_FILENAME
+        raw = index_path.read_bytes()
+        index = coding_memory._validate_grabowski_archive_index(
+            raw, path=index_path
+        )
+        observed.update(index)
+        assert index["source_count"] == 1
+        assert index["sources"][0]["source_name"] == source.name
+        assert index["sources"][0]["event_ids"] == [
+            event("agent.run.started", "a")["event_id"],
+            event("agent.run.completed", "b")["event_id"],
+        ]
+        original_unlink(path)
+
+    monkeypatch.setattr(coding_memory, "_unlink_loose_source", guarded_unlink)
+
+    result = compact(outbox, receipts, apply=True)
+
+    assert result["errors"] == []
+    assert result["sources_removed"] == 1
+    assert result["archive_index_published"] is True
+    assert result["archive_manifests_indexed"] == 1
+    assert result["archived_sources_indexed"] == 1
+    assert result["archive_index_sha256"] == observed["index_sha256"]
+    assert not source.exists()
+
+
+def test_repeat_apply_rebuilds_missing_archive_index_without_loose_sources(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    write_source(
+        source_dir,
+        "grabowski_task-rebuild-a1.jsonl",
+        [event("agent.run.completed", "a")],
+    )
+    import_first(outbox, receipts)
+    first = compact(outbox, receipts, apply=True)
+    index_path = Path(first["archive_index_path"])
+    original = index_path.read_bytes()
+    index_path.unlink()
+
+    rebuilt = compact(outbox, receipts, apply=True)
+    unchanged = compact(outbox, receipts, apply=True)
+
+    assert rebuilt["eligible_sources"] == 0
+    assert rebuilt["sources_removed"] == 0
+    assert rebuilt["archive_index_published"] is True
+    assert rebuilt["archived_sources_indexed"] == 1
+    assert index_path.read_bytes() == original
+    assert unchanged["archive_index_published"] is False
+    assert unchanged["archive_index_file_sha256"] == rebuilt["archive_index_file_sha256"]
+
+
+def test_archive_index_readback_failure_retains_loose_source(tmp_path, monkeypatch):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    source = write_source(
+        source_dir,
+        "grabowski_task-index-failure-a1.jsonl",
+        [event("agent.run.completed", "a")],
+    )
+    import_first(outbox, receipts)
+    original_atomic_write = coding_memory._atomic_write
+
+    def corrupt_index(path, data):
+        if path.name == coding_memory.GRABOWSKI_ARCHIVE_INDEX_FILENAME:
+            original_atomic_write(path, b"{broken\n")
+            return
+        original_atomic_write(path, data)
+
+    monkeypatch.setattr(coding_memory, "_atomic_write", corrupt_index)
+
+    result = compact(outbox, receipts, apply=True)
+
+    assert result["sources_removed"] == 0
+    assert source.exists()
+    assert Path(result["bundle_path"]).exists()
+    assert Path(result["manifest_path"]).exists()
+    assert result["archive_index_sha256"] is None
+    assert result["errors"][-1]["source_path"].endswith(
+        coding_memory.GRABOWSKI_ARCHIVE_INDEX_FILENAME
+    )
+    assert "invalid archive index JSON" in result["errors"][-1]["error"]
+
+
 def test_missing_corrupt_and_stale_receipts_are_not_compacted(tmp_path, monkeypatch):
     _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
     paths = [

--- a/tools/benchmark_outbox_import.py
+++ b/tools/benchmark_outbox_import.py
@@ -105,6 +105,14 @@ def _measure_compaction(outbox_root: Path, receipt_dir: Path) -> dict:
         "loose_sources_remaining": result["loose_sources_remaining"],
         "bundle_bytes": result["bundle_bytes"],
         "bundle_sha256": result["bundle_sha256"],
+        "archive_index_bytes": (
+            Path(result["archive_index_path"]).stat().st_size
+            if result["archive_index_sha256"] is not None
+            else 0
+        ),
+        "archive_index_sha256": result["archive_index_sha256"],
+        "archive_manifests_indexed": result["archive_manifests_indexed"],
+        "archived_sources_indexed": result["archived_sources_indexed"],
         "ledger_records_scanned": result["ledger_records_scanned"],
         "errors": result["errors"],
     }
@@ -167,6 +175,9 @@ def benchmark_tier(
             and repeat["target_scans"] <= MAX_TARGET_SCANS
             and bundled_repeat["target_scans"] <= MAX_TARGET_SCANS
             and compaction["sources_removed"] == source_files
+            and compaction["archive_index_sha256"] is not None
+            and compaction["archive_manifests_indexed"] == 1
+            and compaction["archived_sources_indexed"] == source_files
             and loose_files_before == source_files
             and loose_files_after == 0
             and worst_seconds <= max_seconds


### PR DESCRIPTION
## Summary
- publish an atomic, reconstructed `archive-index.v1.json` from validated bundle manifests before any loose source is removed
- rebuild a missing index even when no loose source remains eligible
- fail closed and retain the loose source when the index cannot be written or read back exactly
- expose index inventory in compaction results and the scaling benchmark

## Verification
- exact base: `dc90cd3c3bd8bf4bb73d7c62f0fbe42c2498b8b6`
- exact head: `407c28e931d7dbda853dc9c9b6b1742766121f03`
- focused tests: 24 passed
- full tests: 348 collected; final run completed with exit 0
- role contract and local API smoke: PASS
- modified Python files: Ruff PASS
- 10,000-source benchmark: PASS; compaction 19.185466 s; worst phase 21.065273 s; 10,000 sources removed and indexed
- field review SHA-256: `b4bc80b7dec7daa1a1958ff3b800f1c91625371860c8602529bfcd3da5f2c221`
- diff SHA-256: `1b0f8cf366ecfaf3e11d9d7e5b5a9152c79bc0ae6c516bea09dc7ee916708047`
- patch: `/home/alex/iCloud/Drive/halde/chronik-postbundle-rewrite-guard-v1.patch`

## Authority boundary
The index is explicitly non-authoritative and reconstructible. Bundle files and their manifests remain the replay evidence. This PR supplies the Chronik half of the post-bundle rewrite guard; the Grabowski writer half remains separate while another active Grabowski repository lease exists.