### PR TITLE
fix: preserve distinct outbox source generations

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -144,10 +144,32 @@ def _file_identity(value: os.stat_result) -> tuple[int, int, int, int]:
     return (value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns)
 
 
-def _receipt_path(source: Path, receipt_dir: Path) -> Path:
+def _legacy_receipt_path(source: Path, receipt_dir: Path) -> Path:
     source_key = sha256_bytes(str(source.resolve()).encode("utf-8"))
     return receipt_dir / f"{source_key}.receipt.json"
 
+
+def _receipt_path(
+    source: Path, receipt_dir: Path, source_sha256: str | None = None
+) -> Path:
+    digest = source_sha256
+    if digest is None:
+        digest = sha256_bytes(source.read_bytes())
+    if (
+        not isinstance(digest, str)
+        or len(digest) != 64
+        or any(character not in "0123456789abcdef" for character in digest)
+    ):
+        raise ValueError("source_sha256 must be a SHA-256 hex digest")
+    source_key = sha256_bytes(
+        canonical_bytes(
+            {
+                "source_path": str(source.resolve()),
+                "source_sha256": digest,
+            }
+        )
+    )
+    return receipt_dir / f"{source_key}.receipt.json"
 
 def _load_receipt(path: Path) -> dict[str, Any] | None:
     try:
@@ -188,17 +210,29 @@ def _prepare_grabowski_source_bytes(
     for event in events:
         _validate_grabowski_source(event)
     source_sha256 = sha256_bytes(raw)
-    receipt_path = _receipt_path(source, receipt_dir)
+    receipt_path = _receipt_path(source, receipt_dir, source_sha256)
+    previous_receipt_path = receipt_path
     try:
         previous = _load_receipt(receipt_path)
     except ValueError:
         previous = None
+    if previous is None and not receipt_path.exists():
+        legacy_path = _legacy_receipt_path(source, receipt_dir)
+        try:
+            legacy = _load_receipt(legacy_path)
+        except ValueError:
+            legacy = None
+        if legacy is not None:
+            previous = legacy
+            previous_receipt_path = legacy_path
+            receipt_path = legacy_path
     return {
         "source": source,
         "raw": raw,
         "events": events,
         "source_sha256": source_sha256,
         "receipt_path": receipt_path,
+        "previous_receipt_path": previous_receipt_path,
         "previous_receipt": previous,
         "source_unchanged": previous is not None and previous.get("source_sha256") == source_sha256,
         "source_origin": source_origin,
@@ -538,22 +572,26 @@ def _grabowski_archive_index_document(
         for item in metadata
     ]
     sources: list[dict[str, Any]] = []
-    seen_names: set[str] = set()
+    seen_generations: set[tuple[str, str]] = set()
     for manifest_index, item in enumerate(metadata):
         for source in item["sources"]:
             source_name = source["source_name"]
-            if source_name in seen_names:
-                raise ValueError(f"duplicate archived source name: {source_name}")
-            seen_names.add(source_name)
+            source_sha256 = source["source_sha256"]
+            generation = (source_name, source_sha256)
+            if generation in seen_generations:
+                raise ValueError(
+                    f"duplicate archived source generation: {source_name} {source_sha256}"
+                )
+            seen_generations.add(generation)
             sources.append(
                 {
                     "source_name": source_name,
-                    "source_sha256": source["source_sha256"],
+                    "source_sha256": source_sha256,
                     "event_ids": list(source["event_ids"]),
                     "manifest_index": manifest_index,
                 }
             )
-    sources.sort(key=lambda item: item["source_name"])
+    sources.sort(key=lambda item: (item["source_name"], item["source_sha256"]))
     index = {
         "schema_version": GRABOWSKI_ARCHIVE_INDEX_SCHEMA,
         "domain": DOMAIN,
@@ -654,7 +692,7 @@ def _validate_grabowski_archive_index(
     sources = index.get("sources")
     if not isinstance(sources, list):
         raise ValueError(f"invalid archive index sources: {path}")
-    names: list[str] = []
+    generations: list[tuple[str, str]] = []
     source_keys = {"source_name", "source_sha256", "event_ids", "manifest_index"}
     for source in sources:
         if not isinstance(source, dict) or set(source) != source_keys:
@@ -681,9 +719,13 @@ def _validate_grabowski_archive_index(
             or manifest_index >= len(manifests)
         ):
             raise ValueError(f"invalid archive index source contract: {path}")
-        names.append(source_name)
-    if names != sorted(names) or len(names) != len(set(names)):
-        raise ValueError(f"archive index source names are not unique and sorted: {path}")
+        generations.append((source_name, source["source_sha256"]))
+    if generations != sorted(generations) or len(generations) != len(
+        set(generations)
+    ):
+        raise ValueError(
+            f"archive index source generations are not unique and sorted: {path}"
+        )
     if (
         type(index.get("manifest_count")) is not int
         or index["manifest_count"] != len(manifests)
@@ -749,18 +791,36 @@ def _refresh_grabowski_archive_index(
 def _merge_prepared_grabowski_sources(
     prepared_sources: Iterable[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    merged: dict[str, dict[str, Any]] = {}
+    merged: dict[tuple[str, str], dict[str, Any]] = {}
     for prepared in prepared_sources:
-        key = str(prepared["source"].resolve())
+        source_path = str(prepared["source"].resolve())
+        source_sha256 = prepared.get("source_sha256")
+        if not isinstance(source_sha256, str):
+            raise ValueError(f"prepared source lacks SHA-256 identity: {source_path}")
+        key = (source_path, source_sha256)
         previous = merged.get(key)
         if previous is None:
             merged[key] = prepared
             continue
         if previous["raw"] != prepared["raw"]:
-            raise ValueError(f"conflicting loose and bundled source bytes: {key}")
-        if previous.get("source_origin") == "bundle" and prepared.get("source_origin") == "loose":
+            raise ValueError(f"source SHA-256 collision: {source_path}")
+        if (
+            previous.get("source_origin") == "bundle"
+            and prepared.get("source_origin") == "loose"
+        ):
             merged[key] = prepared
-    return [merged[key] for key in sorted(merged)]
+    result = [merged[key] for key in sorted(merged)]
+    generation_counts = Counter(str(item["source"].resolve()) for item in result)
+    for prepared in result:
+        source_path = str(prepared["source"].resolve())
+        if generation_counts[source_path] <= 1:
+            continue
+        prepared["receipt_path"] = _receipt_path(
+            prepared["source"],
+            prepared["receipt_path"].parent,
+            prepared["source_sha256"],
+        )
+    return result
 
 
 def _fsync_directory(path: Path) -> None:
@@ -885,6 +945,7 @@ def _write_grabowski_outbox_receipt(
         prepared["source_unchanged"]
         and written == 0
         and skipped == len(events)
+        and prepared.get("previous_receipt_path") == receipt_path
         and _receipt_matches_prepared_source(prepared, previous_receipt)
     ):
         # The authoritative ledger was still scanned above. Reusing this intact

--- a/docs/chronik/direct-operator-memory-v1.md
+++ b/docs/chronik/direct-operator-memory-v1.md
@@ -178,6 +178,9 @@ Jeder Outbox-Import gleicht die Event-IDs weiterhin mit dem maßgeblichen Chroni
 
 `receipt_sha256` im Laufergebnis bindet ausdrücklich die unveränderte Receipt-Datei (`receipt_digest_scope=persisted_receipt`), nicht die aktuellen Laufzähler. `imported`, `skipped_existing` und die Scan-Zähler beschreiben den aktuellen Lauf.
 
+Ein Quellpfad darf nach einer Kompaktierung erneut verwendet werden. Chronik identifiziert deshalb jede Importgeneration durch den kanonischen Quellpfad zusammen mit dem exakten Quell-SHA-256. Generationsgebundene Receipts verwenden beide Werte. Intakte ältere, nur pfadgebundene Receipts bleiben bei einem eindeutigen Quellpfad ohne Dateivermehrung nutzbar; erst wenn mehrere Generationen desselben Pfades gleichzeitig vorliegen, werden sie nach der Ledgerprüfung auf SHA-gebundene Receiptpfade angehoben. Receipts bleiben nichtautoritativ. Byteidentische Generationen werden dedupliziert. Mehrere byteverschiedene Generationen dürfen nebeneinander bestehen, aber der gruppierte Ledger-Writer verwirft weiterhin vor jedem Append jede wiederholte `event_id` mit abweichendem kanonischem Payload.
+Der rekonstruierbare Archive-Index verwendet dieselbe Generationsidentität: `(source_name, source_sha256)` muss eindeutig und sortiert sein. Derselbe Dateiname darf deshalb in mehreren Bundles vorkommen, sofern die Quell-SHA-256 verschieden ist; eine exakt doppelte Generation scheitert geschlossen.
+
 Receipts bleiben nicht maßgeblich. Fehlen Ledger-Daten, werden sie trotz intaktem Receipt aus der Grabowski-Outbox rekonstruiert. Die Quelldateien bleiben deshalb Replay-Evidenz; Löschen oder Kompaktieren benötigt einen eigenen Verlustwiederherstellungsvertrag und folgt nicht aus der Receipt-Wiederverwendung.
 
 ## Terminalitätsgebundene Outbox-Kompaktierung

--- a/tests/test_grabowski_outbox_compaction.py
+++ b/tests/test_grabowski_outbox_compaction.py
@@ -222,6 +222,78 @@ def test_repeat_apply_rebuilds_missing_archive_index_without_loose_sources(
     assert unchanged["archive_index_file_sha256"] == rebuilt["archive_index_file_sha256"]
 
 
+def test_archive_index_allows_same_name_with_distinct_source_generations(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    name = "grabowski_task-generation-a1.jsonl"
+    first_source = write_source(
+        source_dir, name, [event("agent.run.completed", "a")]
+    )
+    first_raw = first_source.read_bytes()
+    import_first(outbox, receipts)
+    first = compact(outbox, receipts, apply=True)
+    assert first["errors"] == []
+
+    second_source = write_source(
+        source_dir, name, [event("agent.run.completed", "b")]
+    )
+    second_raw = second_source.read_bytes()
+    imported = import_first(outbox, receipts)
+    second = compact(outbox, receipts, apply=True)
+    repeated = compact(outbox, receipts, apply=True)
+
+    assert imported["sources_after_deduplication"] == 2
+    assert second["errors"] == []
+    assert second["sources_removed"] == 1
+    assert second["archive_manifests_indexed"] == 2
+    assert second["archived_sources_indexed"] == 2
+    assert repeated["errors"] == []
+    assert repeated["archive_index_published"] is False
+    index_path = Path(second["archive_index_path"])
+    index = coding_memory._validate_grabowski_archive_index(
+        index_path.read_bytes(), path=index_path
+    )
+    generations = [
+        (item["source_name"], item["source_sha256"])
+        for item in index["sources"]
+    ]
+    assert generations == sorted(
+        [
+            (name, coding_memory.sha256_bytes(first_raw)),
+            (name, coding_memory.sha256_bytes(second_raw)),
+        ]
+    )
+    assert len({item["manifest_index"] for item in index["sources"]}) == 2
+
+
+def test_archive_index_rejects_exact_duplicate_source_generation():
+    source = {
+        "source_name": "grabowski_task-duplicate-a1.jsonl",
+        "source_sha256": "a" * 64,
+        "event_ids": ["sha256:" + "b" * 64],
+    }
+    metadata = [
+        {
+            "manifest_path": "/tmp/one.manifest.json",
+            "manifest_sha256": "c" * 64,
+            "sources": [source],
+        },
+        {
+            "manifest_path": "/tmp/two.manifest.json",
+            "manifest_sha256": "d" * 64,
+            "sources": [source],
+        },
+    ]
+
+    try:
+        coding_memory._grabowski_archive_index_document(metadata)
+    except ValueError as exc:
+        assert "duplicate archived source generation" in str(exc)
+    else:
+        raise AssertionError("exact duplicate generation must fail closed")
+
+
 def test_archive_index_readback_failure_retains_loose_source(tmp_path, monkeypatch):
     _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
     source = write_source(
@@ -385,7 +457,7 @@ def test_unlink_failure_keeps_source_but_publishes_replay_bundle(tmp_path, monke
     assert readback["sources_after_deduplication"] == 1
 
 
-def test_source_change_after_publish_is_retained_and_import_fails_closed(
+def test_source_change_after_publish_is_retained_as_new_generation(
     tmp_path, monkeypatch
 ):
     data, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
@@ -415,12 +487,38 @@ def test_source_change_after_publish_is_retained_and_import_fails_closed(
     assert result["skipped_by_reason"] == {"source_changed_before_remove": 1}
     assert source.exists()
     (data / "agent.ledger.jsonl").unlink()
-    failed_import = coding_memory.import_grabowski_outbox(
+    replay = coding_memory.import_grabowski_outbox(
         outbox_root=outbox, receipt_dir=receipts
     )
-    assert failed_import["events_imported"] == 0
-    assert failed_import["target_scans"] is None
-    assert "conflicting loose and bundled source bytes" in failed_import["errors"][-1]["error"]
+    assert replay["errors"] == []
+    assert replay["events_imported"] == 2
+    assert replay["events_skipped_existing"] == 1
+    assert replay["sources_after_deduplication"] == 2
+    assert replay["receipts_written"] == 1
+    assert len(list(receipts.glob("*.receipt.json"))) == 2
+    assert (data / "agent.ledger.jsonl").exists()
+
+
+def test_same_path_same_event_id_with_changed_payload_fails_before_append(
+    tmp_path, monkeypatch
+):
+    data, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    original = event("agent.run.completed", "c")
+    source = write_source(source_dir, "grabowski_task-one-a1.jsonl", [original])
+    import_first(outbox, receipts)
+    compact(outbox, receipts, apply=True)
+    conflicting = dict(original)
+    conflicting["subject"] = {"repo": "heimgewebe/other"}
+    write_source(source_dir, source.name, [conflicting])
+    (data / "agent.ledger.jsonl").unlink()
+
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+
+    assert result["events_imported"] == 0
+    assert result["target_scans"] is None
+    assert "conflicting event_id" in result["errors"][-1]["error"]
     assert not (data / "agent.ledger.jsonl").exists()
 
 

--- a/tests/test_grabowski_outbox_import.py
+++ b/tests/test_grabowski_outbox_import.py
@@ -512,3 +512,34 @@ def test_receipt_failure_preserves_ledger_stats_and_is_recoverable(
     assert recovered["target_scans"] == 1
     assert recovered["errors"] == []
     assert len(list(receipts.glob("*.receipt.json"))) == 1
+
+
+def test_legacy_path_only_receipt_is_reused_for_a_single_generation(tmp_path, monkeypatch):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    source = write_outbox(
+        outbox,
+        [event("agent.run.completed", "c")],
+    )
+    first = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+    assert first["errors"] == []
+    generation_receipt = coding_memory._receipt_path(source, receipts)
+    legacy_receipt = coding_memory._legacy_receipt_path(source, receipts)
+    generation_receipt.replace(legacy_receipt)
+
+    reused = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+    repeated = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox, receipt_dir=receipts
+    )
+
+    assert reused["errors"] == []
+    assert reused["receipts_written"] == 0
+    assert reused["receipts_reused"] == 1
+    assert not generation_receipt.exists()
+    assert legacy_receipt.exists()
+    assert repeated["errors"] == []
+    assert repeated["receipts_written"] == 0
+    assert repeated["receipts_reused"] == 1


### PR DESCRIPTION
## Problem
After source compaction, Grabowski may legitimately reuse a task-bound source pathname. Chronik currently keys loose/bundled deduplication and receipts by pathname alone, so a byte-distinct later generation blocks the batch. PR #229's reconstructed archive index also required source names to be globally unique.

## Change
- identify source generations by canonical path plus source SHA-256
- retain exact-generation deduplication and hard payload-conflict rejection
- use generation-bound receipts, with lazy reuse of intact legacy path-only receipts
- allow identical source names with distinct SHA-256 values in different bundles
- reject exact duplicate archive generations

## Evidence
- reviewed head: c4611564625e73a6eb2b8016c4107cfd86150731
- reviewed diff SHA-256: 71471c0a456ea85a036088caf78ecb8a5b5e14ac7676272a364661f03a9c5897
- focused outbox import/compaction tests: 47 passed
- full validation on top of current main/PR #229: 352 passed, one known external Starlette/httpx warning
- role contract and diff check PASS

The grouped ledger writer remains authoritative and rejects a repeated event_id with any divergent canonical payload before append. Historical conflicting loose files are not modified by this PR.