### PR TITLE
Serialize Chronik compaction with outbox writers

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -1,6 +1,7 @@
 """Local, idempotent coding-history import and evidence-bound queries."""
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import heapq
 import json
@@ -8,6 +9,7 @@ import os
 import stat
 import tempfile
 from collections import Counter
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
@@ -34,6 +36,7 @@ GRABOWSKI_BUNDLE_ENTRY_SCHEMA = "chronik-grabowski-outbox-bundle-source.v1"
 GRABOWSKI_BUNDLE_MANIFEST_SCHEMA = "chronik-grabowski-outbox-bundle-manifest.v1"
 GRABOWSKI_ARCHIVE_INDEX_FILENAME = "archive-index.v1.json"
 GRABOWSKI_ARCHIVE_INDEX_SCHEMA = "chronik-grabowski-outbox-archive-index.v1"
+GRABOWSKI_WRITER_COMPACTION_LOCK_FILENAME = ".writer-compaction.lock"
 
 
 def canonical_bytes(value: Any) -> bytes:
@@ -1184,7 +1187,77 @@ def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str
     }
 
 
+
+@contextmanager
+def _grabowski_writer_compaction_lock(source_dir: Path):
+    source_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        source_stat = source_dir.stat(follow_symlinks=False)
+    except OSError as exc:
+        raise ValueError("Grabowski outbox directory cannot be inspected safely") from exc
+    if (
+        not stat.S_ISDIR(source_stat.st_mode)
+        or source_stat.st_uid != os.geteuid()
+        or source_stat.st_mode & 0o022
+    ):
+        raise ValueError(
+            "Grabowski outbox directory must be real, owned, and not broadly writable"
+        )
+    lock_path = source_dir / GRABOWSKI_WRITER_COMPACTION_LOCK_FILENAME
+    flags = os.O_RDWR | os.O_CREAT | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(lock_path, flags, 0o600)
+    try:
+        file_stat = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(file_stat.st_mode)
+            or file_stat.st_uid != os.geteuid()
+            or file_stat.st_nlink != 1
+        ):
+            raise ValueError(
+                "Grabowski writer-compaction lock must be a private owned file"
+            )
+        os.fchmod(descriptor, 0o600)
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield lock_path
+    finally:
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
+
+
 def compact_grabowski_outbox(
+    *,
+    outbox_root: Path,
+    receipt_dir: Path,
+    grace_seconds: int = 86400,
+    apply: bool = False,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    if not isinstance(apply, bool):
+        raise ValueError("apply must be a boolean")
+    source_dir = outbox_root.expanduser() / "grabowski" / "chronik-outbox"
+    if apply:
+        with _grabowski_writer_compaction_lock(source_dir):
+            return _compact_grabowski_outbox_unlocked(
+                outbox_root=outbox_root,
+                receipt_dir=receipt_dir,
+                grace_seconds=grace_seconds,
+                apply=apply,
+                now=now,
+            )
+    return _compact_grabowski_outbox_unlocked(
+        outbox_root=outbox_root,
+        receipt_dir=receipt_dir,
+        grace_seconds=grace_seconds,
+        apply=apply,
+        now=now,
+    )
+
+
+def _compact_grabowski_outbox_unlocked(
     *,
     outbox_root: Path,
     receipt_dir: Path,

--- a/tests/test_grabowski_outbox_compaction.py
+++ b/tests/test_grabowski_outbox_compaction.py
@@ -1,4 +1,6 @@
+import fcntl
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -193,6 +195,100 @@ def test_archive_index_is_published_and_validated_before_source_unlink(
     assert result["archived_sources_indexed"] == 1
     assert result["archive_index_sha256"] == observed["index_sha256"]
     assert not source.exists()
+
+
+
+def test_apply_holds_writer_compaction_lock_through_source_unlink(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    source = write_source(
+        source_dir,
+        "grabowski_task-locked-a1.jsonl",
+        [event("agent.run.started", "a"), event("agent.run.completed", "b")],
+    )
+    import_first(outbox, receipts)
+    original_unlink = coding_memory._unlink_loose_source
+    observed = {}
+
+    def guarded_unlink(path):
+        lock_path = (
+            source_dir / coding_memory.GRABOWSKI_WRITER_COMPACTION_LOCK_FILENAME
+        )
+        descriptor = os.open(lock_path, os.O_RDWR | os.O_CLOEXEC)
+        try:
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                observed["blocked"] = True
+            else:
+                observed["blocked"] = False
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
+        assert observed["blocked"] is True
+        original_unlink(path)
+
+    monkeypatch.setattr(coding_memory, "_unlink_loose_source", guarded_unlink)
+
+    result = compact(outbox, receipts, apply=True)
+
+    lock_path = source_dir / coding_memory.GRABOWSKI_WRITER_COMPACTION_LOCK_FILENAME
+    assert result["errors"] == []
+    assert result["sources_removed"] == 1
+    assert observed == {"blocked": True}
+    assert lock_path.is_file()
+    assert lock_path.stat().st_mode & 0o777 == 0o600
+    assert not source.exists()
+
+
+def test_apply_rejects_symlinked_outbox_directory(tmp_path, monkeypatch):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    redirected = tmp_path / "redirected-outbox"
+    source_dir.rmdir()
+    redirected.mkdir()
+    source_dir.symlink_to(redirected, target_is_directory=True)
+
+    try:
+        compact(outbox, receipts, apply=True)
+    except ValueError as exc:
+        assert "must be real" in str(exc)
+    else:
+        raise AssertionError("symlinked outbox directory was accepted")
+
+    assert list(redirected.iterdir()) == []
+
+
+def test_apply_rejects_hardlinked_writer_compaction_lock(tmp_path, monkeypatch):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    origin = tmp_path / "shared-lock"
+    origin.write_text("", encoding="utf-8")
+    origin.chmod(0o600)
+    lock_path = source_dir / coding_memory.GRABOWSKI_WRITER_COMPACTION_LOCK_FILENAME
+    lock_path.hardlink_to(origin)
+
+    try:
+        compact(outbox, receipts, apply=True)
+    except ValueError as exc:
+        assert "private owned file" in str(exc)
+    else:
+        raise AssertionError("hardlinked compaction lock was accepted")
+
+
+def test_dry_run_does_not_create_writer_compaction_lock(tmp_path, monkeypatch):
+    _, receipts, outbox, source_dir = configure(tmp_path, monkeypatch)
+    write_source(
+        source_dir,
+        "grabowski_task-dry-lock-a1.jsonl",
+        [event("agent.run.completed", "a")],
+    )
+    import_first(outbox, receipts)
+
+    result = compact(outbox, receipts, apply=False)
+
+    lock_path = source_dir / coding_memory.GRABOWSKI_WRITER_COMPACTION_LOCK_FILENAME
+    assert result["mode"] == "dry-run"
+    assert not lock_path.exists()
 
 
 def test_repeat_apply_rebuilds_missing_archive_index_without_loose_sources(


### PR DESCRIPTION
## Zweck
Schließt das verbleibende TOCTOU-Fenster zwischen Grabowski-Outbox-Writer und Chronik-Kompaktierung durch einen gemeinsamen exklusiven `.writer-compaction.lock`.

## Vertrag
- Apply-Kompaktierung hält den Lock von der Quellinventur bis nach Indexveröffentlichung und Source-Unlink.
- Dry-run bleibt rein lesend und erzeugt keinen Lock.
- Symlinkgebundene oder breit beschreibbare Outbox-Verzeichnisse sowie mehrfach verlinkte Locks werden abgewiesen.

## Validierung
- 356 Pytest-Tests grün
- 30 fokussierte Kompaktierungstests grün
- Ruff und `git diff --check` grün
- Vollständiger Diff: SHA-256 `72ad4bb00272afbd55b0541df772506d4cab8db05f569e856ceb806bd70f9cf0`

Ersetzt PR #231 ohne Umschreiben des bereits veröffentlichten Branchverlaufs.