### PR TITLE
docs: define explicit Chronik service activation gate

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -42,15 +42,27 @@ These checks do not start or enable a user service.
 
 ## Runtime activation gate
 
-Any command that installs, enables, starts, restarts, deploys, or wires Chronik as a live service is a separate runtime action. It requires explicit approval and should include:
+Preparing or reviewing this gate performs no service, deployment, fleet, or secret action. Every listed effect requires explicit approval:
 
-1. current Git head and clean worktree evidence,
-2. non-secret env-file existence and permission checks,
-3. a health/version smoke,
-4. one append/read smoke against `agent.ledger`,
-5. rollback steps for stopping/disabling the user service.
+- `systemctl enable`, `systemctl start`, `systemctl restart`, or another user-service state change;
+- installing or deploying a unit, runner, environment file, or repository revision;
+- any fleet mutation, including copying artifacts or changing a remote host;
+- secret handling, including creating, reading, replacing, copying, or deleting an environment or token file.
 
-Do not print tokens or secret env values in receipts.
+Approval must identify the target host, unit, source revision, intended effects, and secret paths without disclosing secret values. Approval for one target or effect does not authorize another.
+
+A proposed activation must freeze and review this evidence before execution:
+
+1. the exact Git head and a clean source worktree;
+2. the target host, unit name, bind address, port, and data directory;
+3. non-secret file metadata and permissions for the unit, runner, and environment file;
+4. a health/version smoke after separately approved activation;
+5. one append/read smoke against `agent.ledger` using a generated non-secret event;
+6. rollback triggers and the exact stop, disable, file-restore, daemon-reload, process, and port checks.
+
+The rollback plan must restore the previous hash-bound artifacts or remove only files created by the approved activation, then prove that the exact unit is inactive and disabled and that no Chronik process or listener remains. Rollback execution is itself part of the approved runtime action; this preparation task does not execute it.
+
+Receipts must contain hashes and non-secret metadata only. They must not contain tokens, secret environment values, or environment-file contents.
 
 ## Related documents
 

--- a/tests/test_service_artifacts.py
+++ b/tests/test_service_artifacts.py
@@ -68,3 +68,25 @@ def test_operator_docs_close_ai_context_loop():
     assert "not an orchestrator" in runbook
     assert "requires explicit approval" in runbook
     assert "CHRONIK_TOKEN=dev" in runbook
+
+
+def test_runtime_activation_gate_requires_explicit_effect_scope_and_rollback():
+    runbook = (ROOT / "docs" / "runbook.md").read_text(encoding="utf-8")
+
+    for effect in (
+        "systemctl enable",
+        "systemctl start",
+        "systemctl restart",
+        "installing or deploying",
+        "fleet mutation",
+        "secret handling",
+    ):
+        assert effect in runbook
+
+    assert "performs no service, deployment, fleet, or secret action" in runbook
+    assert "health/version smoke" in runbook
+    assert "append/read smoke" in runbook
+    assert "rollback triggers" in runbook
+    assert "inactive and disabled" in runbook
+    assert "no Chronik process or listener remains" in runbook
+    assert "must not contain tokens" in runbook


### PR DESCRIPTION
## Task

CHRONIK-ECOSYSTEM-CLOSEOUT-V1-T003 — Prepare Chronik local service activation gate.

## Änderung

- stellt ausdrücklich klar, dass die Gate-Vorbereitung keine Service-, Deployment-, Fleet- oder Secret-Wirkung ausführt
- verlangt getrennte Freigabe für `systemctl`-Zustandsänderungen, Install/Deploy, Fleet-Mutationen und Geheimnisbehandlung
- bindet Freigaben an Zielhost, Unit, Source-Revision, beabsichtigte Effekte und Secret-Pfade ohne Secret-Werte
- definiert vorab einzufrierende Smoke- und Rollback-Evidenz
- ergänzt einen Regressionstest für die vollständige Aktivierungsgrenze

## Validierung

- `python scripts/check_role.py .ai-context.yml`: PASS
- `python -m pytest -q tests/test_service_artifacts.py`: 7 passed
- `python -m pytest -q`: 357 passed, 1 bestehende Deprecation-Warnung
- `git diff --check`: PASS

## Nicht ausgeführt

- kein Installieren, Starten, Aktivieren oder Neustarten von `chronik.service`
- kein Deployment und keine Fleet-Mutation
- keine Token- oder Environment-Datei gelesen, erzeugt oder verändert
- Live-Readback: `chronik.service` ist `not-found`/`inactive`, Port 8788 ohne Listener

Base: `73a8df1ea5ac0a0b0cfa064d0d010dce2f3b6b6f`
Head: `f7f085967ecf55656aecb1ba52a8ba065fecfe24`