### PR TITLE
fix: bound Chronik ingest memory and cursors

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ from slowapi.util import get_remote_address
 from storage import (
     DomainError,
     StorageError,
+    StorageCursorError,
     StorageFullError,
     StorageBusyError,
     read_tail,
@@ -669,6 +670,10 @@ async def events_v1(
 
     try:
         events, next_cursor, has_more = await run_in_threadpool(_fetch_events_helper, dom, cursor, limit)
+    except StorageCursorError as exc:
+        raise HTTPException(
+            status_code=400, detail="cursor must point to a record boundary"
+        ) from exc
     except StorageBusyError as exc:
         raise HTTPException(status_code=429, detail="busy, try again") from exc
     except StorageError as exc:

--- a/storage.py
+++ b/storage.py
@@ -19,6 +19,7 @@ __all__ = [
     "DATA_DIR",
     "DomainError",
     "StorageError",
+    "StorageCursorError",
     "StorageFullError",
     "StorageBusyError",
     "StorageRecoveryError",
@@ -47,6 +48,10 @@ class DomainError(ValueError):
 
 class StorageError(Exception):
     """Base class for storage-related errors."""
+
+
+class StorageCursorError(StorageError):
+    """Raised when a byte cursor does not point to a JSONL record boundary."""
 
 
 class StorageFullError(StorageError):
@@ -466,6 +471,9 @@ def scan_domain(domain: str, start_offset: int = 0) -> Iterator[Tuple[int, int, 
 
     If start_offset is beyond EOF, yields nothing.
     """
+    if type(start_offset) is not int or start_offset < 0:
+        raise StorageCursorError("start_offset must be a non-negative integer")
+
     try:
         target_path = safe_target_path(domain)
     except DomainError as exc:
@@ -477,6 +485,15 @@ def scan_domain(domain: str, start_offset: int = 0) -> Iterator[Tuple[int, int, 
     try:
         # Use safe open to prevent symlink attacks, but no file lock
         with _safe_open_read(target_path) as fh:
+            observed_size = os.fstat(fh.fileno()).st_size
+            if start_offset > observed_size:
+                return
+            if start_offset:
+                fh.seek(start_offset - 1)
+                if fh.read(1) != b"\n":
+                    raise StorageCursorError(
+                        "start_offset must point to a JSONL record boundary"
+                    )
             fh.seek(start_offset)
             while True:
                 # Capture start offset before reading
@@ -663,6 +680,11 @@ def _parse_unique_payload(
     return identity if isinstance(identity, str) else None, canonical_payload
 
 
+def _payload_fingerprint(canonical_payload: bytes) -> tuple[int, bytes]:
+    """Return one bounded content identity for an already canonical payload."""
+    return len(canonical_payload), hashlib.sha256(canonical_payload).digest()
+
+
 def write_payload_unique_groups(
     domain: str,
     groups: Iterable[tuple[str, Iterable[str]]],
@@ -704,6 +726,7 @@ def write_payload_unique_groups(
             "skipped": 0,
             "target_scans": 0,
             "target_records_scanned": 0,
+            "target_identity_index_entries": 0,
             "groups": [
                 {"group_id": gid, "requested": len(lines), "written": 0, "skipped": 0}
                 for gid, lines in materialized
@@ -715,7 +738,10 @@ def write_payload_unique_groups(
         raise StorageError("invalid target path") from exc
     with _locked_open(target_path, "a+") as fh:
         fh.seek(0)
-        existing = {}
+        # Preserve global conflict detection without retaining every historical
+        # payload. Chronik already uses SHA-256 as a content-identity primitive;
+        # length plus the binary digest bounds the per-record index value.
+        existing: dict[str, tuple[int, bytes]] = {}
         target_records_scanned = 0
         for raw in fh:
             target_records_scanned += 1
@@ -724,14 +750,17 @@ def write_payload_unique_groups(
             except (TypeError, ValueError):
                 continue
             if identity:
+                fingerprint = _payload_fingerprint(canonical_payload)
                 previous = existing.get(identity)
-                if previous is not None and previous != canonical_payload:
+                if previous is not None and previous != fingerprint:
                     raise StorageError(f"conflicting {identity_key}: {identity}")
-                existing.setdefault(identity, canonical_payload)
+                existing.setdefault(identity, fingerprint)
+        target_identity_index_entries = len(existing)
         for _, parsed in parsed_groups:
             for identity, _, canonical_payload in parsed:
+                fingerprint = _payload_fingerprint(canonical_payload)
                 previous = existing.get(identity)
-                if previous is not None and previous != canonical_payload:
+                if previous is not None and previous != fingerprint:
                     raise StorageError(f"conflicting {identity_key}: {identity}")
         total_written = 0
         total_skipped = 0
@@ -745,8 +774,9 @@ def write_payload_unique_groups(
                     group_skipped += 1
                     total_skipped += 1
                     continue
+                fingerprint = _payload_fingerprint(canonical_payload)
                 append_lines.append(line)
-                existing[identity] = canonical_payload
+                existing[identity] = fingerprint
                 group_written += 1
                 total_written += 1
             group_results.append(
@@ -763,6 +793,7 @@ def write_payload_unique_groups(
         "skipped": total_skipped,
         "target_scans": 1,
         "target_records_scanned": target_records_scanned,
+        "target_identity_index_entries": target_identity_index_entries,
         "groups": group_results,
     }
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -98,6 +98,19 @@ def test_get_events_pagination(client, mock_storage):
     # Next cursor should remain same (idempotent)
     assert data["next_cursor"] == cursor3
 
+def test_get_events_rejects_cursor_inside_record(client, mock_storage):
+    domain = "test.cursor-boundary"
+    create_event_file(mock_storage, domain, [b'{"id":1}\n', b'{"id":2}\n'])
+
+    response = client.get(
+        f"/v1/events?domain={domain}&limit=1&cursor=1",
+        headers={"X-Auth": "test-token"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "cursor must point to a record boundary"
+
+
 def test_get_events_boundary_condition(client, mock_storage):
     """
     Test reading exactly to the end of file with limit > remaining.

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -107,6 +107,7 @@ def test_write_payload_unique_groups_scans_once_and_allocates_counts(mock_data_d
     )
     assert result["target_scans"] == 1
     assert result["target_records_scanned"] == 1
+    assert result["target_identity_index_entries"] == 1
     assert result["written"] == 2
     assert result["skipped"] == 2
     assert result["groups"] == [
@@ -114,6 +115,58 @@ def test_write_payload_unique_groups_scans_once_and_allocates_counts(mock_data_d
         {"group_id": "second", "requested": 2, "written": 1, "skipped": 1},
     ]
     assert len((mock_data_dir / "agent.ledger.jsonl").read_text().splitlines()) == 3
+
+
+def test_write_payload_unique_groups_indexes_history_with_bounded_fingerprints(
+    mock_data_dir,
+):
+    historical = [
+        _unique_line(f"old-{index}", "x" * 2048)
+        for index in range(128)
+    ]
+    historical.append(_unique_line("candidate", "same"))
+    storage.write_payload("agent.ledger", historical)
+
+    result = storage.write_payload_unique_groups(
+        "agent.ledger",
+        [("batch", [_unique_line("candidate", "same"), _unique_line("new", "value")])],
+    )
+
+    assert result["target_records_scanned"] == 129
+    assert result["target_identity_index_entries"] == 129
+    assert result["written"] == 1
+    assert result["skipped"] == 1
+
+
+def test_write_payload_unique_groups_rejects_unrelated_historical_conflict(
+    mock_data_dir,
+):
+    storage.write_payload(
+        "agent.ledger",
+        [_unique_line("damaged", "first"), _unique_line("damaged", "second")],
+    )
+
+    with pytest.raises(storage.StorageError, match="conflicting event_id: damaged"):
+        storage.write_payload_unique_groups(
+            "agent.ledger", [("batch", [_unique_line("new", "value")])]
+        )
+
+
+def test_scan_domain_rejects_cursor_inside_record(mock_data_dir):
+    storage.write_payload("agent.ledger", ['{"id":1}', '{"id":2}'])
+
+    with pytest.raises(storage.StorageCursorError, match="record boundary"):
+        list(storage.scan_domain("agent.ledger", start_offset=1))
+
+
+def test_scan_domain_accepts_emitted_record_boundary(mock_data_dir):
+    first = '{"id":1}'
+    storage.write_payload("agent.ledger", [first, '{"id":2}'])
+    boundary = len(first.encode("utf-8")) + 1
+
+    assert list(storage.scan_domain("agent.ledger", start_offset=boundary)) == [
+        (boundary, boundary + len('{"id":2}'.encode("utf-8")) + 1, '{"id":2}')
+    ]
 
 
 def test_write_payload_unique_groups_rejects_cross_group_conflict_before_write(


### PR DESCRIPTION
## Zweck

Chroniks gruppierter idempotenter Import behielt bislang jeden historischen kanonischen Payload vollständig im Speicher. Außerdem akzeptierte die Ereignis-API Byte-Cursor mitten in einer JSONL-Zeile und konnte dadurch einen Datensatz still überspringen.

## Änderung

- historische Payloads im Importindex durch `(Länge, SHA-256)`-Fingerprints ersetzen;
- globale Konflikterkennung für alle vorhandenen IDs beibehalten;
- Indexgröße im Ergebnis ausweisen;
- nicht ausgerichtete Cursor fail-closed als HTTP 400 ablehnen;
- fokussierte Tests für globale Konflikte, Speicherindex und Cursorgrenzen ergänzen.

## Belege

- Basis: `8a954eab4667336adea362c730834aff5b3f89fe`
- Head: `8583b8e9f5659c0124f86e315a1308401c3d1f83`
- Diff SHA-256: `0286a6fbffe30ec3029d962a3a164b0190313c909629c6df3ee604cf4dd049ba`
- Rollenvertrag: PASS
- Fokustests: 70 bestanden
- Vollsuite: 362 bestanden
- `git diff --check`: PASS
- Self-Review: PASS, exakt an Head und Diff gebunden
- Externer Reviewversuch: durch kanonische 0-USD-Provider-Sperre blockiert; keine Umgehung

## Messung

Synthetischer `tracemalloc`-Vergleich mit 4.001 historischen Datensätzen und 2-KiB-Payloads:

- vorher: 8.857.196 Byte Peak
- nachher: 998.897 Byte Peak
- Reduktion: 88,72 %

Die Messung belegt Python-Allokationen im getesteten Hot Path, nicht den Produktions-RSS. Der vollständige Ledger-Scan bleibt zeitlich O(Historie).

## Nicht enthalten

- keine Service-Aktivierung;
- kein Deployment;
- kein persistenter On-Disk-Index.