### PR TITLE
docs: separate Chronik activation gate phases

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -42,27 +42,60 @@ These checks do not start or enable a user service.
 
 ## Runtime activation gate
 
-Preparing or reviewing this gate performs no service, deployment, fleet, or secret action. Every listed effect requires explicit approval:
+Preparing or reviewing this gate performs no service, deployment, fleet, or secret action.
 
-- `systemctl enable`, `systemctl start`, `systemctl restart`, or another user-service state change;
-- installing or deploying a unit, runner, environment file, or repository revision;
-- any fleet mutation, including copying artifacts or changing a remote host;
-- secret handling, including creating, reading, replacing, copying, or deleting an environment or token file.
+### Effects requiring separate approval
 
-Approval must identify the target host, unit, source revision, intended effects, and secret paths without disclosing secret values. Approval for one target or effect does not authorize another.
+Each effect below is a separate runtime action and requires its own explicit approval:
 
-A proposed activation must freeze and review this evidence before execution:
+- `systemctl enable`, `systemctl start`, `systemctl restart`, or another user-service state change.
+- Installation or deployment of a unit file, runner, environment file, package, or repository revision.
+- Any fleet mutation, including copying artifacts or changing a remote host.
+- Secret handling, including creating, reading, replacing, copying, or deleting an environment or token file.
 
-1. the exact Git head and a clean source worktree;
-2. the target host, unit name, bind address, port, and data directory;
-3. non-secret file metadata and permissions for the unit, runner, and environment file;
-4. a health/version smoke after separately approved activation;
-5. one append/read smoke against `agent.ledger` using a generated non-secret event;
-6. rollback triggers and the exact stop, disable, file-restore, daemon-reload, process, and port checks.
+Approval must identify the target host, unit, exact source revision, intended effects, and secret paths without disclosing secret values. Approval for one target or effect does not authorize another.
 
-The rollback plan must restore the previous hash-bound artifacts or remove only files created by the approved activation, then prove that the exact unit is inactive and disabled and that no Chronik process or listener remains. Rollback execution is itself part of the approved runtime action; this preparation task does not execute it.
+### Evidence required before approval
 
-Receipts must contain hashes and non-secret metadata only. They must not contain tokens, secret environment values, or environment-file contents.
+The approval request must bind immutable review-time evidence:
+
+1. The exact Git commit ID and proof of a clean source worktree.
+2. The target host, unit name, bind address, port, data directory, and destination paths.
+3. SHA-256 hashes of every non-secret artifact proposed for installation or deployment, including the unit file, runner, package, or repository export as applicable.
+4. Non-secret file metadata and permissions for all affected files. For a secret environment file, record only its path, owner, group, mode, size, and existence state.
+5. A complete rollback plan with explicit triggers, previous artifact identities, and the exact stop, disable, restore, daemon-reload, process, and port checks.
+
+This evidence must be reviewed before approval. Any source, artifact, target, permission, or rollback-plan drift invalidates the approval request and requires a new review.
+
+### Approved execution boundary
+
+Execution may begin only after an approval matches the frozen evidence and explicitly authorizes every intended effect. The executor must fail closed if the source revision, artifact hashes, target identity, permissions, or requested effects differ from the approved record.
+
+Preparing or reviewing this gate does not execute the activation or its rollback.
+
+### Verification after approved activation
+
+Only after the separately approved activation has executed:
+
+- Run an authenticated health/version smoke test.
+- Run one append/read smoke test against `agent.ledger` using a generated non-secret event.
+- Record the exact unit state, process identity, and listener state for the approved host and port.
+
+These runtime smokes are post-activation verification. They are not pre-approval preparation checks.
+
+### Rollback plan and execution
+
+The rollback plan is reviewed before approval. The activation approval must also authorize execution of that exact rollback when a documented trigger occurs.
+
+The rollback must restore the previous hash-bound non-secret artifacts or remove only files created by the approved activation. It must then prove that the exact unit is inactive and disabled and that no Chronik process or listener remains on the approved port.
+
+Preparing or reviewing the rollback plan does not execute it. Rollback execution occurs only within the separately approved runtime action and only when an approved trigger occurs.
+
+### Receipt requirements
+
+Receipts must bind the exact Git commit ID and SHA-256 hashes of installed or restored non-secret artifacts, together with target paths, non-secret metadata, command outcomes, unit state, process checks, and listener checks.
+
+For secret files, receipts may contain only paths and non-secret metadata. They must not contain tokens, secret values, environment-file contents, or hashes derived from secret contents.
 
 ## Related documents
 

--- a/tests/test_service_artifacts.py
+++ b/tests/test_service_artifacts.py
@@ -1,7 +1,27 @@
+import re
 from pathlib import Path
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def _markdown_section(document: str, heading: str) -> str:
+    marker = f"### {heading}\n"
+    if marker not in document:
+        raise AssertionError(f"Runbook is missing section: {heading}")
+
+    tail = document.split(marker, 1)[1]
+    next_heading = re.search(r"^### ", tail, flags=re.MULTILINE)
+    if next_heading is not None:
+        tail = tail[: next_heading.start()]
+    return tail.strip()
+
+
+@pytest.fixture(scope="module")
+def runbook_content() -> str:
+    return (ROOT / "docs" / "runbook.md").read_text(encoding="utf-8")
 
 
 def test_service_file_exists_and_names_chronik():
@@ -57,36 +77,100 @@ def test_outbox_import_units_are_direct_bounded_and_hardened():
     assert "WantedBy=timers.target" in timer
 
 
-def test_operator_docs_close_ai_context_loop():
+def test_operator_docs_close_ai_context_loop(runbook_content: str):
     agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
-    runbook = (ROOT / "docs" / "runbook.md").read_text(encoding="utf-8")
     ai_context = (ROOT / ".ai-context.yml").read_text(encoding="utf-8")
 
     assert "append-only event ledger" in agents
     assert "Runtime activation" in agents
     assert "docs/runbook.md" in ai_context
-    assert "not an orchestrator" in runbook
-    assert "requires explicit approval" in runbook
-    assert "CHRONIK_TOKEN=dev" in runbook
+    assert "not an orchestrator" in runbook_content
+    assert "requires its own explicit approval" in runbook_content
+    assert "CHRONIK_TOKEN=dev" in runbook_content
 
 
-def test_runtime_activation_gate_requires_explicit_effect_scope_and_rollback():
-    runbook = (ROOT / "docs" / "runbook.md").read_text(encoding="utf-8")
+def test_runtime_activation_gate_has_ordered_phases(runbook_content: str):
+    headings = (
+        "### Effects requiring separate approval",
+        "### Evidence required before approval",
+        "### Approved execution boundary",
+        "### Verification after approved activation",
+        "### Rollback plan and execution",
+        "### Receipt requirements",
+    )
+    positions = [runbook_content.index(heading) for heading in headings]
+    assert positions == sorted(positions), "Runtime activation phases are out of order"
 
-    for effect in (
-        "systemctl enable",
-        "systemctl start",
-        "systemctl restart",
-        "installing or deploying",
+
+@pytest.mark.parametrize(
+    "effect",
+    (
+        "`systemctl enable`",
+        "`systemctl start`",
+        "`systemctl restart`",
+        "Installation or deployment",
         "fleet mutation",
-        "secret handling",
-    ):
-        assert effect in runbook
+        "Secret handling",
+    ),
+)
+def test_runtime_effects_require_separate_approval(runbook_content: str, effect: str):
+    section = _markdown_section(runbook_content, "Effects requiring separate approval")
+    assert effect in section, f"Approval section is missing effect: {effect}"
+    assert "separate runtime action" in section
+    assert "requires its own explicit approval" in section
 
-    assert "performs no service, deployment, fleet, or secret action" in runbook
-    assert "health/version smoke" in runbook
-    assert "append/read smoke" in runbook
-    assert "rollback triggers" in runbook
-    assert "inactive and disabled" in runbook
-    assert "no Chronik process or listener remains" in runbook
-    assert "must not contain tokens" in runbook
+
+def test_pre_approval_evidence_is_immutable_and_contains_no_runtime_smokes(runbook_content: str):
+    section = _markdown_section(runbook_content, "Evidence required before approval")
+
+    assert "exact Git commit ID" in section
+    assert "SHA-256 hashes of every non-secret artifact" in section
+    assert "path, owner, group, mode, size, and existence state" in section
+    assert "complete rollback plan" in section
+    assert "drift invalidates the approval request" in section
+    assert "health/version smoke" not in section
+    assert "append/read smoke" not in section
+
+
+def test_execution_is_bound_to_approved_evidence_and_fails_closed(runbook_content: str):
+    section = _markdown_section(runbook_content, "Approved execution boundary")
+
+    assert "only after an approval matches the frozen evidence" in section
+    assert "fail closed" in section
+    assert "does not execute the activation or its rollback" in section
+
+
+def test_runtime_smokes_are_post_activation_only(runbook_content: str):
+    section = _markdown_section(runbook_content, "Verification after approved activation")
+
+    assert "Only after the separately approved activation has executed" in section
+    assert "health/version smoke test" in section
+    assert "append/read smoke test" in section
+    assert "post-activation verification" in section
+    assert "not pre-approval preparation checks" in section
+
+
+def test_rollback_plan_is_pre_reviewed_but_execution_is_separately_authorized(runbook_content: str):
+    section = _markdown_section(runbook_content, "Rollback plan and execution")
+
+    assert "reviewed before approval" in section
+    assert "authorize execution of that exact rollback" in section
+    assert "previous hash-bound non-secret artifacts" in section
+    assert "inactive and disabled" in section
+    assert "no Chronik process or listener remains" in section
+    assert "does not execute it" in section
+    assert "only when an approved trigger occurs" in section
+
+
+def test_receipts_bind_non_secret_artifacts_without_secret_derivatives(runbook_content: str):
+    section = _markdown_section(runbook_content, "Receipt requirements")
+
+    assert "exact Git commit ID" in section
+    assert "SHA-256 hashes of installed or restored non-secret artifacts" in section
+    assert "target paths" in section
+    assert "unit state" in section
+    assert "process checks" in section
+    assert "listener checks" in section
+    assert "only paths and non-secret metadata" in section
+    assert "must not contain tokens" in section
+    assert "hashes derived from secret contents" in section


### PR DESCRIPTION
## Kontext

Review-Nachtrag zu PR #233 und `CHRONIK-ECOSYSTEM-CLOSEOUT-V1-T003`.

## Änderungen

- trennt explizit Genehmigungspflicht, Vorab-Evidenz, genehmigte Ausführung, Post-Activation-Verifikation, Rollback und Receipts
- verschiebt Health/Version- und Append/Read-Smokes eindeutig in die Nachprüfung nach einer separat genehmigten Aktivierung
- bindet Genehmigungen an unveränderliche Review-Evidenz und lässt die Ausführung bei Drift fail-closed abbrechen
- verlangt SHA-256-Identitäten für nicht-geheime Installationsartefakte
- verbietet Secret-Inhalte und daraus abgeleitete Hashes in Receipts
- ersetzt globale Wortsuche durch abschnitts- und phasenbezogene pytest-Prüfungen mit Parametrisierung und Modul-Fixture

## Validierung

- `python -m py_compile tests/test_service_artifacts.py`: PASS
- `python scripts/check_role.py .ai-context.yml`: PASS
- `python -m pytest -q tests/test_service_artifacts.py`: 18 passed
- `python -m pytest -q`: 373 passed, 1 bestehende Deprecation-Warnung
- `git diff --check`: PASS

## Grenzen

- keine Service-, Deployment-, Fleet- oder Secret-Aktion
- keine Runtime-Aktivierung
- geändert wurden ausschließlich `docs/runbook.md` und `tests/test_service_artifacts.py`

Base: `a13ae15148bffa7bb8758316d6e8bd4f43beb18a`
Head: `256a88ac827fcdb94f31c20dcd207cd63fc80b79`