### PR TITLE
perf: compact Chronik hot-path fingerprints

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -471,7 +471,11 @@ def scan_domain(domain: str, start_offset: int = 0) -> Iterator[Tuple[int, int, 
 
     If start_offset is beyond EOF, yields nothing.
     """
-    if type(start_offset) is not int or start_offset < 0:
+    if (
+        isinstance(start_offset, bool)
+        or not isinstance(start_offset, int)
+        or start_offset < 0
+    ):
         raise StorageCursorError("start_offset must be a non-negative integer")
 
     try:
@@ -485,16 +489,26 @@ def scan_domain(domain: str, start_offset: int = 0) -> Iterator[Tuple[int, int, 
     try:
         # Use safe open to prevent symlink attacks, but no file lock
         with _safe_open_read(target_path) as fh:
-            observed_size = os.fstat(fh.fileno()).st_size
-            if start_offset > observed_size:
-                return
             if start_offset:
-                fh.seek(start_offset - 1)
-                if fh.read(1) != b"\n":
+                try:
+                    fh.seek(start_offset - 1)
+                except (OverflowError, ValueError):
+                    return
+                except OSError as exc:
+                    if exc.errno in {errno.EINVAL, errno.EOVERFLOW}:
+                        return
+                    raise
+                previous = fh.read(1)
+                if not previous:
+                    # Preserve the documented polling contract: a cursor beyond
+                    # the current EOF yields no records and can be retried later.
+                    return
+                if previous != b"\n":
                     raise StorageCursorError(
                         "start_offset must point to a JSONL record boundary"
                     )
-            fh.seek(start_offset)
+                # Reading the boundary byte already positions the handle exactly
+                # at start_offset; a second seek would be redundant.
             while True:
                 # Capture start offset before reading
                 current_start = fh.tell()
@@ -680,9 +694,12 @@ def _parse_unique_payload(
     return identity if isinstance(identity, str) else None, canonical_payload
 
 
-def _payload_fingerprint(canonical_payload: bytes) -> tuple[int, bytes]:
-    """Return one bounded content identity for an already canonical payload."""
-    return len(canonical_payload), hashlib.sha256(canonical_payload).digest()
+def _payload_fingerprint(canonical_payload: bytes) -> bytes:
+    """Return a fixed-width length-and-SHA-256 content identity."""
+    return (
+        len(canonical_payload).to_bytes(8, "big", signed=False)
+        + hashlib.sha256(canonical_payload).digest()
+    )
 
 
 def write_payload_unique_groups(
@@ -702,7 +719,7 @@ def write_payload_unique_groups(
         seen_group_ids.add(group_id)
         materialized.append((group_id, list(lines)))
     parsed_groups = []
-    candidate_payloads = {}
+    candidate_payloads: dict[str, bytes] = {}
     candidate_count = 0
     for group_id, lines in materialized:
         parsed = []
@@ -714,10 +731,11 @@ def write_payload_unique_groups(
             if not identity:
                 raise StorageError(f"missing {identity_key}")
             previous = candidate_payloads.get(identity)
-            if previous is not None and previous != canonical_payload:
+            if previous is None:
+                candidate_payloads[identity] = canonical_payload
+            elif previous != canonical_payload:
                 raise StorageError(f"conflicting {identity_key}: {identity}")
-            candidate_payloads.setdefault(identity, canonical_payload)
-            parsed.append((identity, line, canonical_payload))
+            parsed.append((identity, line, _payload_fingerprint(canonical_payload)))
             candidate_count += 1
         parsed_groups.append((group_id, parsed))
     if candidate_count == 0:
@@ -732,6 +750,9 @@ def write_payload_unique_groups(
                 for gid, lines in materialized
             ],
         }
+    # Exact candidate conflict checks are complete; release their full
+    # canonical payloads before scanning a potentially large historical ledger.
+    del candidate_payloads
     try:
         target_path = safe_target_path(domain)
     except DomainError as exc:
@@ -741,7 +762,7 @@ def write_payload_unique_groups(
         # Preserve global conflict detection without retaining every historical
         # payload. Chronik already uses SHA-256 as a content-identity primitive;
         # length plus the binary digest bounds the per-record index value.
-        existing: dict[str, tuple[int, bytes]] = {}
+        existing: dict[str, bytes] = {}
         target_records_scanned = 0
         for raw in fh:
             target_records_scanned += 1
@@ -752,13 +773,13 @@ def write_payload_unique_groups(
             if identity:
                 fingerprint = _payload_fingerprint(canonical_payload)
                 previous = existing.get(identity)
-                if previous is not None and previous != fingerprint:
+                if previous is None:
+                    existing[identity] = fingerprint
+                elif previous != fingerprint:
                     raise StorageError(f"conflicting {identity_key}: {identity}")
-                existing.setdefault(identity, fingerprint)
         target_identity_index_entries = len(existing)
         for _, parsed in parsed_groups:
-            for identity, _, canonical_payload in parsed:
-                fingerprint = _payload_fingerprint(canonical_payload)
+            for identity, _, fingerprint in parsed:
                 previous = existing.get(identity)
                 if previous is not None and previous != fingerprint:
                     raise StorageError(f"conflicting {identity_key}: {identity}")
@@ -769,12 +790,11 @@ def write_payload_unique_groups(
         for group_id, parsed in parsed_groups:
             group_written = 0
             group_skipped = 0
-            for identity, line, canonical_payload in parsed:
+            for identity, line, fingerprint in parsed:
                 if identity in existing:
                     group_skipped += 1
                     total_skipped += 1
                     continue
-                fingerprint = _payload_fingerprint(canonical_payload)
                 append_lines.append(line)
                 existing[identity] = fingerprint
                 group_written += 1

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -96,6 +96,40 @@ def _unique_line(event_id: str, value: str) -> str:
     )
 
 
+def test_payload_fingerprint_is_fixed_width_and_length_bound():
+    small = storage._payload_fingerprint(b"payload")
+    large_payload = b"payload" * 100_000
+    large = storage._payload_fingerprint(large_payload)
+
+    assert len(small) == 40
+    assert len(large) == 40
+    assert int.from_bytes(small[:8], "big") == len(b"payload")
+    assert int.from_bytes(large[:8], "big") == len(large_payload)
+    assert small[8:] != large[8:]
+
+
+def test_write_payload_unique_groups_does_not_rehash_parsed_candidates(
+    mock_data_dir, monkeypatch
+):
+    storage.write_payload("agent.ledger", [_unique_line("existing", "same")])
+    calls = []
+    real_fingerprint = storage._payload_fingerprint
+
+    def counted_fingerprint(payload):
+        calls.append(payload)
+        return real_fingerprint(payload)
+
+    monkeypatch.setattr(storage, "_payload_fingerprint", counted_fingerprint)
+    result = storage.write_payload_unique_groups(
+        "agent.ledger",
+        [("batch", [_unique_line("existing", "same"), _unique_line("new", "value")])],
+    )
+
+    assert result["written"] == 1
+    assert result["skipped"] == 1
+    assert len(calls) == 3  # two candidates plus one historical record
+
+
 def test_write_payload_unique_groups_scans_once_and_allocates_counts(mock_data_dir):
     storage.write_payload("agent.ledger", [_unique_line("existing", "same")])
     result = storage.write_payload_unique_groups(
@@ -150,6 +184,55 @@ def test_write_payload_unique_groups_rejects_unrelated_historical_conflict(
         storage.write_payload_unique_groups(
             "agent.ledger", [("batch", [_unique_line("new", "value")])]
         )
+
+
+def test_scan_domain_accepts_crlf_record_boundary(mock_data_dir):
+    first = b'{"id":1}\r\n'
+    second = b'{"id":2}\r\n'
+    (mock_data_dir / "agent.ledger.jsonl").write_bytes(first + second)
+
+    records = list(storage.scan_domain("agent.ledger", start_offset=len(first)))
+
+    assert records[0][:2] == (len(first), len(first) + len(second))
+    assert json.loads(records[0][2]) == {"id": 2}
+
+
+def test_scan_domain_accepts_boundary_after_empty_record(mock_data_dir):
+    prefix = b'{"id":1}\n\n'
+    final = b'{"id":3}\n'
+    (mock_data_dir / "agent.ledger.jsonl").write_bytes(prefix + final)
+
+    assert [
+        json.loads(item[2])
+        for item in storage.scan_domain("agent.ledger", start_offset=len(prefix))
+    ] == [{"id": 3}]
+
+
+def test_scan_domain_rejects_boolean_cursor(mock_data_dir):
+    storage.write_payload("agent.ledger", ['{"id":1}'])
+
+    with pytest.raises(storage.StorageCursorError, match="non-negative integer"):
+        list(storage.scan_domain("agent.ledger", start_offset=True))
+
+
+def test_scan_domain_accepts_integer_subclass_cursor(mock_data_dir):
+    class Cursor(int):
+        pass
+
+    first = '{"id":1}'
+    storage.write_payload("agent.ledger", [first, '{"id":2}'])
+    boundary = Cursor(len(first.encode("utf-8")) + 1)
+
+    assert [item[2] for item in storage.scan_domain("agent.ledger", boundary)] == [
+        '{"id":2}'
+    ]
+
+
+def test_scan_domain_cursor_beyond_eof_remains_retryable(mock_data_dir):
+    storage.write_payload("agent.ledger", ['{"id":1}'])
+
+    assert list(storage.scan_domain("agent.ledger", start_offset=10_000)) == []
+    assert list(storage.scan_domain("agent.ledger", start_offset=1 << 100)) == []
 
 
 def test_scan_domain_rejects_cursor_inside_record(mock_data_dir):


### PR DESCRIPTION
## Ziel

Verifizierte Folgeoptimierung zu PR #234. Der Patch übernimmt nur die belastbaren Punkte aus dem nachgereichten Review und bewahrt bestehende Cursor- und Konfliktverträge.

## Änderungen

- Fingerprint als fester 40-Byte-Wert: 8 Byte Payloadlänge + vollständiger SHA-256-Digest.
- Kandidaten-Fingerprint nur beim Parsen berechnen; kein erneutes Hashen in Konflikt- und Schreibphase.
- Historische ID nur einmal im Dictionary nachschlagen; kein `get` plus `setdefault`.
- Vollständige Kandidaten-Payloads vor dem historischen Ledger-Scan freigeben.
- Cursorprüfung ohne vorgelagerten `fstat`-Snapshot und ohne redundantes zweites `seek`.
- `bool` explizit ablehnen, echte `int`-Unterklassen akzeptieren.
- Große Cursor außerhalb des darstellbaren Datei-Offsets bleiben entsprechend dem dokumentierten Polling-Vertrag retrybar und liefern keine Records.

## Review-Einordnung

Nicht bestätigt wurden behauptete Fehler für Offset 0, CRLF und Grenzen nach Leerzeilen; diese Fälle waren bereits logisch korrekt und sind nun explizit getestet. Eine SHA-256-Kürzung und ein `lru_cache` wurden verworfen, weil sie Sicherheits- beziehungsweise Speicherprämissen verschlechtern würden. Der bestehende Vertrag „Cursor jenseits EOF liefert leer“ bleibt erhalten.

## Prüfung

- Rollenvertrag: PASS
- Fokustests: 77 bestanden
- Vollsuite: 380 bestanden
- `git diff --check`: PASS
- Commit: `c049b772db2bb4d99a71ccda8b0cafd614731519`
- Diff SHA-256: `c909225be10731e4bb2f74f06ceaa8d05a60d086409f53858e8d5db24f683780`

## Messung

Synthetischer Einzelvergleich mit 20.001 historischen IDs:

- vorher: 4.178.472 Byte Peak-Allokation
- nachher: 3.218.316 Byte
- Reduktion: 22,98 %
- Laufzeit: 0,444 s vs. 0,448 s; kein Geschwindigkeitsgewinn behauptet

## Restgrenze

Der gruppierte Import scannt und parst weiterhin das gesamte historische Ledger einmal je Aufruf. Ein persistenter, rebuildbarer Identitätsindex bleibt die eigentliche asymptotische Folgeaufgabe.