### PR TITLE
feat: add persistent Chronik identity index

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -1022,6 +1022,8 @@ def _write_grabowski_outbox_receipt(
 
 def _import_prepared_grabowski_sources(
     prepared_sources: list[dict[str, Any]],
+    *,
+    authoritative_replay: bool = False,
 ) -> tuple[list[dict[str, Any]], dict[str, object], list[tuple[str, Exception]]]:
     grouped = storage.write_payload_unique_groups(
         DOMAIN,
@@ -1029,6 +1031,7 @@ def _import_prepared_grabowski_sources(
             (str(index), _envelope_lines(prepared["events"]))
             for index, prepared in enumerate(prepared_sources)
         ],
+        authoritative_replay=authoritative_replay,
     )
     raw_group_results = grouped.get("groups")
     if not isinstance(raw_group_results, list):
@@ -1128,20 +1131,39 @@ def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str
     )
     target_scans: int | None = 0
     target_records_scanned: int | None = 0
+    identity_index_mode: str | None = "unused"
+    identity_index_full_rebuild: bool | None = False
+    identity_index_entries_after: int | None = 0
     prepared_sources: list[dict[str, Any]] = []
     try:
         prepared_sources = _merge_prepared_grabowski_sources(all_prepared)
     except ValueError as exc:
         target_scans = None
         target_records_scanned = None
+        identity_index_mode = None
+        identity_index_full_rebuild = None
+        identity_index_entries_after = None
         errors.append({"source_path": "<batch>", "error": str(exc)})
     if prepared_sources and target_scans is not None:
         try:
+            target_path = storage.safe_target_path(DOMAIN)
+            target_missing_or_empty = (
+                not target_path.exists() or target_path.stat().st_size == 0
+            )
+            authoritative_replay = target_missing_or_empty and not errors
             results, grouped, receipt_errors = _import_prepared_grabowski_sources(
-                prepared_sources
+                prepared_sources,
+                authoritative_replay=authoritative_replay,
             )
             target_scans = int(grouped.get("target_scans", 0))
             target_records_scanned = int(grouped.get("target_records_scanned", 0))
+            identity_index_mode = str(grouped.get("identity_index_mode", "unknown"))
+            identity_index_full_rebuild = bool(
+                grouped.get("identity_index_full_rebuild", False)
+            )
+            identity_index_entries_after = int(
+                grouped.get("identity_index_entries_after", 0)
+            )
             errors.extend(
                 {
                     "source_path": source_path,
@@ -1152,6 +1174,9 @@ def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str
         except (OSError, ValueError, storage.StorageError) as exc:
             target_scans = None
             target_records_scanned = None
+            identity_index_mode = None
+            identity_index_full_rebuild = None
+            identity_index_entries_after = None
             errors.append({"source_path": "<batch>", "error": str(exc)})
     bundled_sources_seen = sum(int(item["source_count"]) for item in bundle_metadata)
     return {
@@ -1180,6 +1205,9 @@ def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str
         "events_skipped_existing": sum(int(result.get("skipped_existing", 0)) for result in results),
         "target_scans": target_scans,
         "target_records_scanned": target_records_scanned,
+        "identity_index_mode": identity_index_mode,
+        "identity_index_full_rebuild": identity_index_full_rebuild,
+        "identity_index_entries_after": identity_index_entries_after,
         "bundle_inventory": bundle_metadata,
         "errors": errors,
         "historical_only": True,

--- a/docs/proofs/chronik-ecosystem-closeout-v1-t010.md
+++ b/docs/proofs/chronik-ecosystem-closeout-v1-t010.md
@@ -1,0 +1,180 @@
+# CHRONIK-ECOSYSTEM-CLOSEOUT-V1-T010 proof
+
+## Scope and identities
+
+- Bureau task: `CHRONIK-ECOSYSTEM-CLOSEOUT-V1-T010`
+- Bureau task merge: `bebabf6480504c4ffc8872c2ca69022286b72a49`
+- Chronik implementation base: `362dc58521d11951242d115f0213e8db8140a057`
+- Source optimization diff: `c909225be10731e4bb2f74f06ceaa8d05a60d086409f53858e8d5db24f683780`
+- Runtime deployment: not part of this proof and not authorized by this task phase.
+
+## Truth boundary
+
+The append-only JSONL ledger remains the only event authority. The SQLite file
+under `.chronik-identity-index-v1/` is a derived acceleration structure. It can
+be deleted and rebuilt without changing ledger bytes. The index cannot authorize
+an event that is absent from the ledger.
+
+A stored identity consists of:
+
+- the identity key and identity value;
+- the full 40-byte payload fingerprint (8-byte canonical payload length plus the
+  full 32-byte SHA-256 digest);
+- the exact first ledger record byte range that established the identity;
+- a SHA-256 digest over the complete index-row binding.
+
+The index state binds:
+
+- ledger device and inode;
+- ledger `mtime_ns` and `ctime_ns`;
+- processed byte offset;
+- a SHA-256 record chain over the processed prefix;
+- total ledger record count;
+- exact indexed-identity count;
+- last record byte start and SHA-256 digest;
+- a SHA-256 digest over all state fields.
+
+Trigger-maintained identity counts are compared with the state-bound count in
+O(1). Every candidate hit is re-read from its exact ledger byte range and its
+identity and full payload fingerprint are recomputed before it is trusted.
+
+## Operating modes
+
+- `rebuild`: no state exists; scan the complete ledger and derive the index.
+- `steady`: verify file identity, metadata, boundary, state digest, identity
+  count and candidate rows without scanning ledger history.
+- `verify`: metadata changed without growth; verify the complete stored prefix
+  before rebinding metadata.
+- `verify-catchup`: the ledger is ahead of the index; verify the complete old
+  prefix, then index the tail. This is an exceptional recovery or legacy-append
+  path, not the ordinary write path.
+- `unused`: no candidate records were supplied.
+
+The returned storage and outbox-import results expose the mode, rebuild flag,
+records scanned and entry count. A steady-state grouped write reports zero full
+ledger scans and zero historical records scanned.
+
+## Crash and rollback ordering
+
+The writer holds the existing ledger file lock for ledger and index operations.
+The effect order is:
+
+1. synchronize and verify the derived index against the durable ledger;
+2. check candidates with full fingerprints and ledger-backed index hits;
+3. begin an immediate SQLite transaction;
+4. append and fsync the JSONL ledger through the existing rollback-capable
+   append transaction;
+5. stage index rows and the new ledger-bound state;
+6. commit SQLite with `synchronous=FULL` and fsync the private index directory.
+
+Consequences:
+
+- failure before the ledger append leaves both stores unchanged;
+- append failure uses the existing ledger rollback and rolls back SQLite;
+- index staging failure rolls back SQLite and truncates/fsyncs the ledger to its
+  exact pre-append size;
+- a hard crash after durable ledger append but before SQLite commit leaves only
+  a lagging index; the next run uses `verify-catchup`;
+- an uncertain SQLite commit never triggers ledger rollback, because that could
+  let an actually committed index lead the ledger. The call fails and the next
+  run establishes either `steady` or `verify-catchup` from the ledger.
+
+## Corruption and drift checks
+
+Focused tests cover:
+
+- malformed or schema-foreign SQLite files;
+- symlinked or non-private index paths;
+- ledger truncation and inode replacement;
+- same-size in-place ledger changes;
+- prefix mutation combined with a later append;
+- incomplete final JSONL records;
+- state-hash manipulation;
+- identity-row fingerprint and offset manipulation;
+- identity-row deletion through the trigger-bound count mismatch;
+- historical conflicts unrelated to the current candidates;
+- invalid JSON and records without the configured identity;
+- failed index staging, uncertain index commit and ledger rollback;
+- a real child-process hard crash after durable ledger append and before the
+  SQLite commit, followed by automatic lagging-index recovery;
+- more than the SQLite parameter limit of candidate identities;
+- a canonical payload of roughly 700 kB with a fixed-width index fingerprint.
+
+A corrupted existing index is not silently replaced. A missing index is rebuilt.
+A missing ledger remains fail-closed for general storage callers.
+
+The Grabowski outbox batch importer has one narrower recovery permission: after
+it has validated a complete, error-free source inventory, it may reset only the
+derived index while reconstructing a missing or empty ledger. Direct single-file
+imports and ordinary storage callers cannot request this recovery path.
+
+## Deterministic scale measurement
+
+Local synthetic measurement on the implementation worktree:
+
+- 100,000 unique historical events;
+- each historical `value` contains 128 ASCII bytes;
+- one duplicate and one new candidate during rebuild;
+- one duplicate and one new candidate during steady state;
+- Python allocation peak measured with `tracemalloc` around each grouped write;
+- elapsed time measured with `time.perf_counter`;
+- temporary ledger and index removed after measurement.
+
+Observed raw values:
+
+| phase | elapsed seconds | Python peak bytes | ledger records scanned | written | skipped |
+|---|---:|---:|---:|---:|---:|
+| rebuild | 3.6420401600189507 | 62,691 | 100,000 | 1 | 1 |
+| steady | 0.0028964472003281116 | 29,065 | 0 | 1 | 1 |
+
+Artifact sizes after the steady write:
+
+- ledger: 18,188,996 bytes;
+- SQLite index: 11,890,688 bytes;
+- indexed identities after the steady write: 100,002.
+
+This measurement proves the local algorithmic path and bounded Python
+allocation for this fixture. It does not establish production latency, RSS,
+filesystem durability beyond the tested platform, or live importer throughput.
+
+## Verification
+
+The uncommitted implementation snapshot passed:
+
+- 61 focused persistent-index and storage tests, including the hard-crash
+  subprocess case;
+- 52 focused outbox-import, compaction and benchmark-contract tests;
+- the complete Chronik suite: 408 passed, one existing Starlette/httpx2
+  deprecation warning;
+- `compileall` for `identity_index.py`, `storage.py` and `coding_memory.py`;
+- the Chronik role contract;
+- `git diff --check`.
+
+These results bind the implementation snapshot at the time this proof was
+written. They must be repeated against the final commit after any rebase or
+content change and do not establish GitHub CI, merge or deployment on their own.
+
+## Compatibility and rollback
+
+Existing ledgers need no migration. The first indexed write derives the database
+from the ledger. Older Chronik versions ignore the private index directory and
+continue using the JSONL ledger. Rollback therefore consists of reverting the
+code and, if desired, securely removing the derived index files; no ledger record
+is rewritten or deleted.
+
+## Residual boundaries
+
+- `verify-catchup` intentionally performs an O(history) prefix verification. It
+  is exceptional; the ordinary `steady` path remains independent of total
+  history except for candidate-record reads.
+- The index protects against accidental corruption and unauthorized index-only
+  mutation within the process trust boundary. A same-user adversary able to
+  rewrite both ledger and index and recompute every digest is outside this local
+  integrity model.
+- SQLite schema shape, state digests, trigger-bound counts and accessed rows are
+  checked. The steady path does not perform an O(index) database-wide integrity
+  scan on every call; unread-page corruption is detected when accessed or during
+  explicit database diagnostics.
+- The index adds disk usage in exchange for exact candidate lookups and
+  ledger-backed corruption checks.
+- No production deployment or activation evidence is claimed here.

--- a/identity_index.py
+++ b/identity_index.py
@@ -22,6 +22,61 @@ INDEX_APPLICATION_ID = 0x43485249  # "CHRI"
 INDEX_DIR_NAME = ".chronik-identity-index-v1"
 ZERO_DIGEST = b"\x00" * 32
 
+_EXPECTED_SCHEMA_SQL = {
+    ("table", "identities"): """
+        CREATE TABLE identities (
+            identity_key TEXT NOT NULL,
+            identity TEXT NOT NULL,
+            fingerprint BLOB NOT NULL CHECK(length(fingerprint) = 40),
+            record_start INTEGER NOT NULL CHECK(record_start >= 0),
+            record_end INTEGER NOT NULL CHECK(record_end > record_start),
+            row_digest BLOB NOT NULL CHECK(length(row_digest) = 32),
+            PRIMARY KEY(identity_key, identity)
+        ) WITHOUT ROWID
+    """,
+    ("table", "identity_counts"): """
+        CREATE TABLE identity_counts (
+            identity_key TEXT PRIMARY KEY,
+            entry_count INTEGER NOT NULL CHECK(entry_count >= 0)
+        ) WITHOUT ROWID
+    """,
+    ("table", "index_state"): """
+        CREATE TABLE index_state (
+            identity_key TEXT PRIMARY KEY,
+            ledger_dev TEXT NOT NULL,
+            ledger_ino TEXT NOT NULL,
+            ledger_mtime_ns TEXT NOT NULL,
+            ledger_ctime_ns TEXT NOT NULL,
+            indexed_offset INTEGER NOT NULL CHECK(indexed_offset >= 0),
+            chain_digest BLOB NOT NULL CHECK(length(chain_digest) = 32),
+            record_count INTEGER NOT NULL CHECK(record_count >= 0),
+            identity_count INTEGER NOT NULL CHECK(identity_count >= 0),
+            last_record_start INTEGER NOT NULL,
+            last_record_digest BLOB NOT NULL CHECK(length(last_record_digest) = 32),
+            state_digest BLOB NOT NULL CHECK(length(state_digest) = 32)
+        ) WITHOUT ROWID
+    """,
+    ("trigger", "identities_count_insert"): """
+        CREATE TRIGGER identities_count_insert
+        AFTER INSERT ON identities
+        BEGIN
+            INSERT INTO identity_counts(identity_key, entry_count)
+            VALUES (NEW.identity_key, 1)
+            ON CONFLICT(identity_key) DO UPDATE SET
+                entry_count = entry_count + 1;
+        END
+    """,
+    ("trigger", "identities_count_delete"): """
+        CREATE TRIGGER identities_count_delete
+        AFTER DELETE ON identities
+        BEGIN
+            UPDATE identity_counts
+            SET entry_count = entry_count - 1
+            WHERE identity_key = OLD.identity_key;
+        END
+    """,
+}
+
 
 class IdentityIndexError(Exception):
     """Base class for persistent identity-index failures."""
@@ -221,6 +276,24 @@ def _table_columns(connection: sqlite3.Connection, table: str) -> list[tuple[str
     return [(str(row[1]), str(row[2]).upper(), int(row[5])) for row in rows]
 
 
+def _normalize_schema_sql(value: str) -> str:
+    return " ".join(value.split()).casefold()
+
+
+def _schema_sql(connection: sqlite3.Connection) -> dict[tuple[str, str], str]:
+    rows = connection.execute(
+        """
+        SELECT type, name, sql
+        FROM sqlite_master
+        WHERE type IN ('table', 'trigger') AND name NOT LIKE 'sqlite_%'
+        """
+    ).fetchall()
+    return {
+        (str(object_type), str(name)): _normalize_schema_sql(str(sql))
+        for object_type, name, sql in rows
+    }
+
+
 class IdentityIndex:
     """One securely validated SQLite acceleration database."""
 
@@ -378,6 +451,14 @@ class IdentityIndex:
                 raise IdentityIndexCorruptError("identity index schema tables mismatch")
             if triggers != {"identities_count_insert", "identities_count_delete"}:
                 raise IdentityIndexCorruptError("identity index schema triggers mismatch")
+            expected_schema_sql = {
+                key: _normalize_schema_sql(value)
+                for key, value in _EXPECTED_SCHEMA_SQL.items()
+            }
+            if _schema_sql(self.connection) != expected_schema_sql:
+                raise IdentityIndexCorruptError(
+                    "identity index schema definitions mismatch"
+                )
             if _table_columns(self.connection, "identities") != [
                 ("identity_key", "TEXT", 1),
                 ("identity", "TEXT", 2),

--- a/identity_index.py
+++ b/identity_index.py
@@ -1,0 +1,1024 @@
+"""Ledger-bound persistent identity index for Chronik JSONL storage.
+
+The JSONL ledger remains the event authority.  This SQLite database is only a
+rebuildable acceleration structure.  The writer orders effects as ledger first,
+index second, so a crash can leave the index behind but can never make it claim
+an event that was not durably appended to the ledger.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+import stat
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, Iterator, Sequence
+
+INDEX_SCHEMA_VERSION = 1
+INDEX_APPLICATION_ID = 0x43485249  # "CHRI"
+INDEX_DIR_NAME = ".chronik-identity-index-v1"
+ZERO_DIGEST = b"\x00" * 32
+
+
+class IdentityIndexError(Exception):
+    """Base class for persistent identity-index failures."""
+
+
+class IdentityIndexCorruptError(IdentityIndexError):
+    """Raised when an existing index artifact cannot be trusted."""
+
+
+class IdentityIndexDriftError(IdentityIndexError):
+    """Raised when ledger identity or indexed-prefix binding has drifted."""
+
+
+class IdentityIndexCommitUncertain(IdentityIndexError):
+    """Raised when SQLite cannot establish the outcome of the final commit."""
+
+
+@dataclass(frozen=True)
+class IndexState:
+    identity_key: str
+    ledger_dev: int
+    ledger_ino: int
+    ledger_mtime_ns: int
+    ledger_ctime_ns: int
+    indexed_offset: int
+    chain_digest: bytes
+    record_count: int
+    identity_count: int
+    last_record_start: int
+    last_record_digest: bytes
+
+
+@dataclass(frozen=True)
+class IndexSyncResult:
+    mode: str
+    records_scanned: int
+    entry_count: int
+    state: IndexState
+
+
+PayloadParser = Callable[[str | bytes, str], tuple[str | None, bytes]]
+PayloadFingerprint = Callable[[bytes], bytes]
+
+
+def _digest_fields(*fields: object) -> bytes:
+    digest = hashlib.sha256()
+    for field in fields:
+        if isinstance(field, bytes):
+            encoded = field
+        else:
+            encoded = str(field).encode("utf-8")
+        digest.update(len(encoded).to_bytes(8, "big", signed=False))
+        digest.update(encoded)
+    return digest.digest()
+
+
+def _identity_row_digest(
+    identity_key: str,
+    identity: str,
+    fingerprint: bytes,
+    record_start: int,
+    record_end: int,
+) -> bytes:
+    return _digest_fields(
+        "chronik-identity-row-v1",
+        identity_key,
+        identity,
+        fingerprint,
+        record_start,
+        record_end,
+    )
+
+
+def _state_digest(state: IndexState) -> bytes:
+    return _digest_fields(
+        "chronik-identity-state-v1",
+        state.identity_key,
+        state.ledger_dev,
+        state.ledger_ino,
+        state.ledger_mtime_ns,
+        state.ledger_ctime_ns,
+        state.indexed_offset,
+        state.chain_digest,
+        state.record_count,
+        state.identity_count,
+        state.last_record_start,
+        state.last_record_digest,
+    )
+
+
+def index_path_for_target(target_path: Path) -> Path:
+    """Return the deterministic private SQLite path for one ledger."""
+    digest = hashlib.sha256(target_path.name.encode("utf-8")).hexdigest()
+    return target_path.parent / INDEX_DIR_NAME / f"{digest}.sqlite3"
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_DIRECTORY", 0)
+    try:
+        fd = os.open(path, flags)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+    except OSError as exc:
+        raise IdentityIndexError("identity index directory sync failed") from exc
+
+
+def _ensure_private_index_root(data_dir: Path) -> Path:
+    root = data_dir / INDEX_DIR_NAME
+    created = False
+    try:
+        os.mkdir(root, 0o700)
+        created = True
+    except FileExistsError:
+        pass
+    except OSError as exc:
+        raise IdentityIndexError("identity index directory creation failed") from exc
+
+    try:
+        info = os.lstat(root)
+    except OSError as exc:
+        raise IdentityIndexError("identity index directory unavailable") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise IdentityIndexCorruptError("identity index directory is not a real directory")
+    if info.st_uid != os.geteuid() or info.st_mode & 0o077:
+        raise IdentityIndexCorruptError("identity index directory is not private")
+    if created:
+        _fsync_directory(data_dir)
+    return root
+
+
+def reset_identity_index_for_authoritative_replay(target_path: Path) -> bool:
+    """Remove only the derived index before a proven full-source ledger replay.
+
+    The caller must hold the ledger writer lock and must separately prove that
+    the opened ledger is empty.  This function never removes or rewrites ledger
+    bytes and rejects unsafe index paths instead of following them.
+    """
+    root = target_path.parent / INDEX_DIR_NAME
+    try:
+        root_info = os.lstat(root)
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise IdentityIndexError("identity index directory unavailable") from exc
+    if stat.S_ISLNK(root_info.st_mode) or not stat.S_ISDIR(root_info.st_mode):
+        raise IdentityIndexCorruptError("identity index directory is not a real directory")
+    if root_info.st_uid != os.geteuid() or root_info.st_mode & 0o077:
+        raise IdentityIndexCorruptError("identity index directory is not private")
+
+    database = index_path_for_target(target_path)
+    removed = False
+    for candidate in (
+        database,
+        Path(str(database) + "-journal"),
+        Path(str(database) + "-wal"),
+        Path(str(database) + "-shm"),
+    ):
+        try:
+            info = os.lstat(candidate)
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise IdentityIndexError("identity index artifact unavailable") from exc
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+            raise IdentityIndexCorruptError("identity index artifact is not a regular file")
+        if info.st_uid != os.geteuid() or info.st_mode & 0o077:
+            raise IdentityIndexCorruptError("identity index artifact is not private")
+        try:
+            os.unlink(candidate)
+        except OSError as exc:
+            raise IdentityIndexError("identity index reset failed") from exc
+        removed = True
+    if removed:
+        _fsync_directory(root)
+    return removed
+
+
+def _validate_existing_database_path(path: Path) -> os.stat_result | None:
+    try:
+        info = os.lstat(path)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise IdentityIndexError("identity index metadata unavailable") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise IdentityIndexCorruptError("identity index is not a regular file")
+    if info.st_uid != os.geteuid() or info.st_mode & 0o077:
+        raise IdentityIndexCorruptError("identity index file is not private")
+    return info
+
+
+def _table_columns(connection: sqlite3.Connection, table: str) -> list[tuple[str, str, int]]:
+    rows = connection.execute(f"PRAGMA table_info({table})").fetchall()
+    return [(str(row[1]), str(row[2]).upper(), int(row[5])) for row in rows]
+
+
+class IdentityIndex:
+    """One securely validated SQLite acceleration database."""
+
+    def __init__(self, target_path: Path, *, timeout: int) -> None:
+        self.target_path = target_path
+        self.root = _ensure_private_index_root(target_path.parent)
+        self.path = index_path_for_target(target_path)
+        before = _validate_existing_database_path(self.path)
+        existed = before is not None
+        try:
+            self.connection = sqlite3.connect(
+                self.path,
+                timeout=max(1, timeout),
+                isolation_level=None,
+            )
+        except sqlite3.DatabaseError as exc:
+            raise IdentityIndexCorruptError("identity index cannot be opened") from exc
+        except OSError as exc:
+            raise IdentityIndexError("identity index cannot be opened") from exc
+
+        try:
+            if not existed:
+                os.chmod(self.path, 0o600)
+            after = _validate_existing_database_path(self.path)
+            if after is None:
+                raise IdentityIndexCorruptError("identity index disappeared after open")
+            if before is not None and (before.st_dev, before.st_ino) != (
+                after.st_dev,
+                after.st_ino,
+            ):
+                raise IdentityIndexCorruptError("identity index identity changed during open")
+            self._configure()
+            self._initialize_or_validate_schema()
+            if not existed:
+                _fsync_directory(self.root)
+        except BaseException:
+            self.connection.close()
+            raise
+
+    def _configure(self) -> None:
+        try:
+            mode = self.connection.execute("PRAGMA journal_mode=DELETE").fetchone()
+            if not mode or str(mode[0]).lower() != "delete":
+                raise IdentityIndexCorruptError("identity index journal mode is unsafe")
+            self.connection.execute("PRAGMA synchronous=FULL")
+            self.connection.execute("PRAGMA foreign_keys=ON")
+            self.connection.execute("PRAGMA trusted_schema=OFF")
+            self.connection.execute("PRAGMA busy_timeout=30000")
+        except sqlite3.DatabaseError as exc:
+            raise IdentityIndexCorruptError("identity index configuration failed") from exc
+
+    def _initialize_or_validate_schema(self) -> None:
+        try:
+            user_version = int(self.connection.execute("PRAGMA user_version").fetchone()[0])
+            application_id = int(
+                self.connection.execute("PRAGMA application_id").fetchone()[0]
+            )
+            tables = {
+                str(row[0])
+                for row in self.connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+                if not str(row[0]).startswith("sqlite_")
+            }
+            if user_version == 0 and application_id == 0 and not tables:
+                self.connection.execute("BEGIN IMMEDIATE")
+                try:
+                    self.connection.execute(
+                        """
+                        CREATE TABLE identities (
+                            identity_key TEXT NOT NULL,
+                            identity TEXT NOT NULL,
+                            fingerprint BLOB NOT NULL CHECK(length(fingerprint) = 40),
+                            record_start INTEGER NOT NULL CHECK(record_start >= 0),
+                            record_end INTEGER NOT NULL CHECK(record_end > record_start),
+                            row_digest BLOB NOT NULL CHECK(length(row_digest) = 32),
+                            PRIMARY KEY(identity_key, identity)
+                        ) WITHOUT ROWID
+                        """
+                    )
+                    self.connection.execute(
+                        """
+                        CREATE TABLE identity_counts (
+                            identity_key TEXT PRIMARY KEY,
+                            entry_count INTEGER NOT NULL CHECK(entry_count >= 0)
+                        ) WITHOUT ROWID
+                        """
+                    )
+                    self.connection.execute(
+                        """
+                        CREATE TRIGGER identities_count_insert
+                        AFTER INSERT ON identities
+                        BEGIN
+                            INSERT INTO identity_counts(identity_key, entry_count)
+                            VALUES (NEW.identity_key, 1)
+                            ON CONFLICT(identity_key) DO UPDATE SET
+                                entry_count = entry_count + 1;
+                        END
+                        """
+                    )
+                    self.connection.execute(
+                        """
+                        CREATE TRIGGER identities_count_delete
+                        AFTER DELETE ON identities
+                        BEGIN
+                            UPDATE identity_counts
+                            SET entry_count = entry_count - 1
+                            WHERE identity_key = OLD.identity_key;
+                        END
+                        """
+                    )
+                    self.connection.execute(
+                        """
+                        CREATE TABLE index_state (
+                            identity_key TEXT PRIMARY KEY,
+                            ledger_dev TEXT NOT NULL,
+                            ledger_ino TEXT NOT NULL,
+                            ledger_mtime_ns TEXT NOT NULL,
+                            ledger_ctime_ns TEXT NOT NULL,
+                            indexed_offset INTEGER NOT NULL CHECK(indexed_offset >= 0),
+                            chain_digest BLOB NOT NULL CHECK(length(chain_digest) = 32),
+                            record_count INTEGER NOT NULL CHECK(record_count >= 0),
+                            identity_count INTEGER NOT NULL CHECK(identity_count >= 0),
+                            last_record_start INTEGER NOT NULL,
+                            last_record_digest BLOB NOT NULL CHECK(length(last_record_digest) = 32),
+                            state_digest BLOB NOT NULL CHECK(length(state_digest) = 32)
+                        ) WITHOUT ROWID
+                        """
+                    )
+                    self.connection.execute(
+                        f"PRAGMA application_id={INDEX_APPLICATION_ID}"
+                    )
+                    self.connection.execute(
+                        f"PRAGMA user_version={INDEX_SCHEMA_VERSION}"
+                    )
+                    self.connection.commit()
+                except BaseException:
+                    self.connection.rollback()
+                    raise
+                user_version = INDEX_SCHEMA_VERSION
+                application_id = INDEX_APPLICATION_ID
+                tables = {"identities", "identity_counts", "index_state"}
+
+            triggers = {
+                str(row[0])
+                for row in self.connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type='trigger'"
+                )
+            }
+            if user_version != INDEX_SCHEMA_VERSION:
+                raise IdentityIndexCorruptError("identity index schema version mismatch")
+            if application_id != INDEX_APPLICATION_ID:
+                raise IdentityIndexCorruptError("identity index application id mismatch")
+            if tables != {"identities", "identity_counts", "index_state"}:
+                raise IdentityIndexCorruptError("identity index schema tables mismatch")
+            if triggers != {"identities_count_insert", "identities_count_delete"}:
+                raise IdentityIndexCorruptError("identity index schema triggers mismatch")
+            if _table_columns(self.connection, "identities") != [
+                ("identity_key", "TEXT", 1),
+                ("identity", "TEXT", 2),
+                ("fingerprint", "BLOB", 0),
+                ("record_start", "INTEGER", 0),
+                ("record_end", "INTEGER", 0),
+                ("row_digest", "BLOB", 0),
+            ]:
+                raise IdentityIndexCorruptError("identity table schema mismatch")
+            if _table_columns(self.connection, "identity_counts") != [
+                ("identity_key", "TEXT", 1),
+                ("entry_count", "INTEGER", 0),
+            ]:
+                raise IdentityIndexCorruptError("identity count schema mismatch")
+            if _table_columns(self.connection, "index_state") != [
+                ("identity_key", "TEXT", 1),
+                ("ledger_dev", "TEXT", 0),
+                ("ledger_ino", "TEXT", 0),
+                ("ledger_mtime_ns", "TEXT", 0),
+                ("ledger_ctime_ns", "TEXT", 0),
+                ("indexed_offset", "INTEGER", 0),
+                ("chain_digest", "BLOB", 0),
+                ("record_count", "INTEGER", 0),
+                ("identity_count", "INTEGER", 0),
+                ("last_record_start", "INTEGER", 0),
+                ("last_record_digest", "BLOB", 0),
+                ("state_digest", "BLOB", 0),
+            ]:
+                raise IdentityIndexCorruptError("identity index state schema mismatch")
+        except sqlite3.DatabaseError as exc:
+            raise IdentityIndexCorruptError("identity index schema is unreadable") from exc
+
+    def close(self) -> None:
+        self.connection.close()
+
+    def _identity_count(self, identity_key: str) -> int:
+        try:
+            row = self.connection.execute(
+                "SELECT entry_count FROM identity_counts WHERE identity_key = ?",
+                (identity_key,),
+            ).fetchone()
+        except sqlite3.DatabaseError as exc:
+            raise IdentityIndexCorruptError("identity index count cannot be read") from exc
+        if row is None:
+            return 0
+        try:
+            value = int(row[0])
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise IdentityIndexCorruptError("identity index count is invalid") from exc
+        if value < 0:
+            raise IdentityIndexCorruptError("identity index count is negative")
+        return value
+
+    def _read_identity_row(
+        self, identity_key: str, identity: str
+    ) -> tuple[bytes, int, int] | None:
+        try:
+            row = self.connection.execute(
+                """
+                SELECT fingerprint, record_start, record_end, row_digest
+                FROM identities WHERE identity_key = ? AND identity = ?
+                """,
+                (identity_key, identity),
+            ).fetchone()
+        except sqlite3.DatabaseError as exc:
+            raise IdentityIndexCorruptError("identity index row cannot be read") from exc
+        if row is None:
+            return None
+        try:
+            fingerprint = bytes(row[0])
+            record_start = int(row[1])
+            record_end = int(row[2])
+            row_digest = bytes(row[3])
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise IdentityIndexCorruptError("identity index row has invalid values") from exc
+        if (
+            len(fingerprint) != 40
+            or record_start < 0
+            or record_end <= record_start
+            or len(row_digest) != 32
+            or row_digest
+            != _identity_row_digest(
+                identity_key,
+                identity,
+                fingerprint,
+                record_start,
+                record_end,
+            )
+        ):
+            raise IdentityIndexCorruptError("identity index row digest mismatch")
+        return fingerprint, record_start, record_end
+
+    def _insert_identity(
+        self,
+        *,
+        identity_key: str,
+        identity: str,
+        fingerprint: bytes,
+        record_start: int,
+        record_end: int,
+    ) -> None:
+        try:
+            self.connection.execute(
+                """
+                INSERT INTO identities(
+                    identity_key, identity, fingerprint,
+                    record_start, record_end, row_digest
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    identity_key,
+                    identity,
+                    fingerprint,
+                    record_start,
+                    record_end,
+                    _identity_row_digest(
+                        identity_key,
+                        identity,
+                        fingerprint,
+                        record_start,
+                        record_end,
+                    ),
+                ),
+            )
+        except sqlite3.DatabaseError as exc:
+            raise IdentityIndexCorruptError("identity index row insert failed") from exc
+
+    def _verify_identity_against_ledger(
+        self,
+        fh,
+        *,
+        state: IndexState,
+        identity_key: str,
+        identity: str,
+        row: tuple[bytes, int, int],
+        parse_payload: PayloadParser,
+        fingerprint_payload: PayloadFingerprint,
+    ) -> bytes:
+        fingerprint, record_start, record_end = row
+        if record_end > state.indexed_offset:
+            raise IdentityIndexCorruptError("identity index row exceeds indexed ledger")
+        fh.seek(record_start)
+        raw = fh.read(record_end - record_start)
+        if len(raw) != record_end - record_start or not raw.endswith(b"\n"):
+            raise IdentityIndexCorruptError("identity index ledger range is incomplete")
+        try:
+            observed_identity, canonical_payload = parse_payload(raw, identity_key)
+        except (TypeError, ValueError) as exc:
+            raise IdentityIndexCorruptError(
+                "identity index row references an invalid ledger record"
+            ) from exc
+        if observed_identity != identity:
+            raise IdentityIndexCorruptError("identity index row identity mismatch")
+        if fingerprint_payload(canonical_payload) != fingerprint:
+            raise IdentityIndexCorruptError("identity index row fingerprint mismatch")
+        return fingerprint
+
+    def _load_state(self, identity_key: str) -> IndexState | None:
+        try:
+            row = self.connection.execute(
+                """
+                SELECT ledger_dev, ledger_ino, ledger_mtime_ns, ledger_ctime_ns,
+                       indexed_offset, chain_digest, record_count, identity_count,
+                       last_record_start, last_record_digest, state_digest
+                FROM index_state WHERE identity_key = ?
+                """,
+                (identity_key,),
+            ).fetchone()
+        except sqlite3.DatabaseError as exc:
+            raise IdentityIndexCorruptError("identity index state cannot be read") from exc
+        if row is None:
+            return None
+        try:
+            state = IndexState(
+                identity_key=identity_key,
+                ledger_dev=int(row[0]),
+                ledger_ino=int(row[1]),
+                ledger_mtime_ns=int(row[2]),
+                ledger_ctime_ns=int(row[3]),
+                indexed_offset=int(row[4]),
+                chain_digest=bytes(row[5]),
+                record_count=int(row[6]),
+                identity_count=int(row[7]),
+                last_record_start=int(row[8]),
+                last_record_digest=bytes(row[9]),
+            )
+            stored_digest = bytes(row[10])
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise IdentityIndexCorruptError("identity index state has invalid values") from exc
+        if (
+            state.indexed_offset < 0
+            or state.record_count < 0
+            or state.identity_count < 0
+            or state.identity_count > state.record_count
+            or len(state.chain_digest) != 32
+            or len(state.last_record_digest) != 32
+            or len(stored_digest) != 32
+            or stored_digest != _state_digest(state)
+            or (state.indexed_offset == 0 and state.last_record_start != -1)
+            or (
+                state.indexed_offset > 0
+                and not 0 <= state.last_record_start < state.indexed_offset
+            )
+        ):
+            raise IdentityIndexCorruptError("identity index state digest mismatch")
+        if self._identity_count(identity_key) != state.identity_count:
+            raise IdentityIndexCorruptError("identity index count binding mismatch")
+        return state
+
+    @staticmethod
+    def _ledger_stat(fh) -> os.stat_result:
+        try:
+            info = os.fstat(fh.fileno())
+        except OSError as exc:
+            raise IdentityIndexDriftError("ledger stat unavailable") from exc
+        if not stat.S_ISREG(info.st_mode):
+            raise IdentityIndexDriftError("ledger is not a regular file")
+        return info
+
+    @staticmethod
+    def _require_complete_tail(fh, size: int) -> None:
+        if size == 0:
+            return
+        fh.seek(size - 1)
+        if fh.read(1) != b"\n":
+            raise IdentityIndexDriftError("ledger has an incomplete final record")
+
+    @staticmethod
+    def _verify_state_binding(
+        fh, ledger: os.stat_result, state: IndexState
+    ) -> bool:
+        if (state.ledger_dev, state.ledger_ino) != (ledger.st_dev, ledger.st_ino):
+            raise IdentityIndexDriftError("ledger identity changed")
+        if state.indexed_offset > ledger.st_size:
+            raise IdentityIndexDriftError("ledger was truncated behind the index")
+        metadata_changed = state.indexed_offset == ledger.st_size and (
+            state.ledger_mtime_ns != ledger.st_mtime_ns
+            or state.ledger_ctime_ns != ledger.st_ctime_ns
+        )
+        if state.indexed_offset == 0:
+            if state.record_count != 0 or state.last_record_digest != ZERO_DIGEST:
+                raise IdentityIndexCorruptError("empty index state is inconsistent")
+            return metadata_changed
+        fh.seek(state.indexed_offset - 1)
+        if fh.read(1) != b"\n":
+            raise IdentityIndexDriftError("indexed offset is not a record boundary")
+        fh.seek(state.last_record_start)
+        raw = fh.read(state.indexed_offset - state.last_record_start)
+        if not raw.endswith(b"\n") or hashlib.sha256(raw).digest() != state.last_record_digest:
+            raise IdentityIndexDriftError("indexed ledger boundary digest changed")
+        return metadata_changed
+
+    @staticmethod
+    def _records(fh, start: int, end: int) -> Iterator[tuple[int, int, bytes]]:
+        fh.seek(start)
+        while fh.tell() < end:
+            record_start = fh.tell()
+            raw = fh.readline(end - record_start)
+            if not raw or not raw.endswith(b"\n"):
+                raise IdentityIndexDriftError("ledger contains an incomplete record")
+            record_end = fh.tell()
+            if record_end > end:
+                raise IdentityIndexDriftError("ledger record crossed snapshot boundary")
+            yield record_start, record_end, raw
+        if fh.tell() != end:
+            raise IdentityIndexDriftError("ledger snapshot boundary is inconsistent")
+
+    def _apply_records(
+        self,
+        fh,
+        *,
+        identity_key: str,
+        start: int,
+        end: int,
+        chain_digest: bytes,
+        record_count: int,
+        last_record_start: int,
+        last_record_digest: bytes,
+        parse_payload: PayloadParser,
+        fingerprint_payload: PayloadFingerprint,
+    ) -> tuple[bytes, int, int, bytes, int]:
+        scanned = 0
+        chain = chain_digest
+        last_start = last_record_start
+        last_digest = last_record_digest
+        for record_start, record_end, raw in self._records(fh, start, end):
+            scanned += 1
+            chain = hashlib.sha256(chain + raw).digest()
+            last_start = record_start
+            last_digest = hashlib.sha256(raw).digest()
+            try:
+                identity, canonical_payload = parse_payload(raw, identity_key)
+            except (TypeError, ValueError):
+                continue
+            if not identity:
+                continue
+            fingerprint = fingerprint_payload(canonical_payload)
+            row = self._read_identity_row(identity_key, identity)
+            if row is None:
+                self._insert_identity(
+                    identity_key=identity_key,
+                    identity=identity,
+                    fingerprint=fingerprint,
+                    record_start=record_start,
+                    record_end=record_end,
+                )
+            elif row[0] != fingerprint:
+                raise IdentityIndexDriftError(
+                    f"conflicting {identity_key}: {identity}"
+                )
+        return chain, record_count + scanned, last_start, last_digest, scanned
+
+    def _store_state(self, state: IndexState) -> None:
+        try:
+            self.connection.execute(
+                """
+                INSERT INTO index_state(
+                    identity_key, ledger_dev, ledger_ino,
+                    ledger_mtime_ns, ledger_ctime_ns, indexed_offset,
+                    chain_digest, record_count, identity_count,
+                    last_record_start, last_record_digest, state_digest
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(identity_key) DO UPDATE SET
+                    ledger_dev=excluded.ledger_dev,
+                    ledger_ino=excluded.ledger_ino,
+                    ledger_mtime_ns=excluded.ledger_mtime_ns,
+                    ledger_ctime_ns=excluded.ledger_ctime_ns,
+                    indexed_offset=excluded.indexed_offset,
+                    chain_digest=excluded.chain_digest,
+                    record_count=excluded.record_count,
+                    identity_count=excluded.identity_count,
+                    last_record_start=excluded.last_record_start,
+                    last_record_digest=excluded.last_record_digest,
+                    state_digest=excluded.state_digest
+                """,
+                (
+                    state.identity_key,
+                    str(state.ledger_dev),
+                    str(state.ledger_ino),
+                    str(state.ledger_mtime_ns),
+                    str(state.ledger_ctime_ns),
+                    state.indexed_offset,
+                    state.chain_digest,
+                    state.record_count,
+                    state.identity_count,
+                    state.last_record_start,
+                    state.last_record_digest,
+                    _state_digest(state),
+                ),
+            )
+        except sqlite3.DatabaseError as exc:
+            raise IdentityIndexCorruptError("identity index state update failed") from exc
+
+    def synchronize(
+        self,
+        fh,
+        *,
+        identity_key: str,
+        parse_payload: PayloadParser,
+        fingerprint_payload: PayloadFingerprint,
+    ) -> IndexSyncResult:
+        ledger = self._ledger_stat(fh)
+        self._require_complete_tail(fh, ledger.st_size)
+        state = self._load_state(identity_key)
+        mode = "steady"
+        start = ledger.st_size
+        if state is None:
+            mode = "rebuild"
+            start = 0
+            state = IndexState(
+                identity_key=identity_key,
+                ledger_dev=ledger.st_dev,
+                ledger_ino=ledger.st_ino,
+                ledger_mtime_ns=ledger.st_mtime_ns,
+                ledger_ctime_ns=ledger.st_ctime_ns,
+                indexed_offset=0,
+                chain_digest=ZERO_DIGEST,
+                record_count=0,
+                identity_count=0,
+                last_record_start=-1,
+                last_record_digest=ZERO_DIGEST,
+            )
+        else:
+            metadata_changed = self._verify_state_binding(fh, ledger, state)
+            start = state.indexed_offset
+            if start < ledger.st_size:
+                mode = "verify-catchup"
+            elif metadata_changed:
+                mode = "verify"
+
+        scanned = 0
+        if mode != "steady":
+            try:
+                if mode == "verify":
+                    scanned = self._verify_full_prefix_contents(fh, state)
+                    chain = state.chain_digest
+                    record_count = state.record_count
+                    last_start = state.last_record_start
+                    last_digest = state.last_record_digest
+                else:
+                    prefix_scanned = 0
+                    if mode == "verify-catchup":
+                        prefix_scanned = self._verify_full_prefix_contents(fh, state)
+                    self.connection.execute("BEGIN IMMEDIATE")
+                    if mode == "rebuild":
+                        self.connection.execute(
+                            "DELETE FROM identities WHERE identity_key = ?", (identity_key,)
+                        )
+                    chain, record_count, last_start, last_digest, tail_scanned = self._apply_records(
+                        fh,
+                        identity_key=identity_key,
+                        start=start,
+                        end=ledger.st_size,
+                        chain_digest=state.chain_digest,
+                        record_count=state.record_count,
+                        last_record_start=state.last_record_start,
+                        last_record_digest=state.last_record_digest,
+                        parse_payload=parse_payload,
+                        fingerprint_payload=fingerprint_payload,
+                    )
+                    scanned = prefix_scanned + tail_scanned
+                identity_count = self._identity_count(identity_key)
+                if not self.connection.in_transaction:
+                    self.connection.execute("BEGIN IMMEDIATE")
+                state = IndexState(
+                    identity_key=identity_key,
+                    ledger_dev=ledger.st_dev,
+                    ledger_ino=ledger.st_ino,
+                    ledger_mtime_ns=ledger.st_mtime_ns,
+                    ledger_ctime_ns=ledger.st_ctime_ns,
+                    indexed_offset=ledger.st_size,
+                    chain_digest=chain,
+                    record_count=record_count,
+                    identity_count=identity_count,
+                    last_record_start=last_start,
+                    last_record_digest=last_digest,
+                )
+                self._store_state(state)
+                self.commit()
+            except IdentityIndexError:
+                self.connection.rollback()
+                raise
+            except sqlite3.DatabaseError as exc:
+                self.connection.rollback()
+                raise IdentityIndexCorruptError("identity index synchronization failed") from exc
+            except BaseException:
+                self.connection.rollback()
+                raise
+
+        fh.seek(0, os.SEEK_END)
+        return IndexSyncResult(
+            mode=mode,
+            records_scanned=scanned,
+            entry_count=state.identity_count,
+            state=state,
+        )
+
+    def _verify_full_prefix_contents(self, fh, state: IndexState) -> int:
+        chain = ZERO_DIGEST
+        records = 0
+        last_start = -1
+        last_digest = ZERO_DIGEST
+        for record_start, _, raw in self._records(fh, 0, state.indexed_offset):
+            records += 1
+            chain = hashlib.sha256(chain + raw).digest()
+            last_start = record_start
+            last_digest = hashlib.sha256(raw).digest()
+        if (
+            chain != state.chain_digest
+            or records != state.record_count
+            or last_start != state.last_record_start
+            or last_digest != state.last_record_digest
+        ):
+            raise IdentityIndexDriftError("ledger prefix verification failed")
+        fh.seek(0, os.SEEK_END)
+        return records
+
+    def verify_full_prefix(self, fh, state: IndexState) -> None:
+        """Explicitly verify the complete ledger prefix against the stored chain."""
+        ledger = self._ledger_stat(fh)
+        self._verify_state_binding(fh, ledger, state)
+        self._verify_full_prefix_contents(fh, state)
+
+    def lookup(
+        self,
+        fh,
+        *,
+        state: IndexState,
+        identity_key: str,
+        identities: Iterable[str],
+        parse_payload: PayloadParser,
+        fingerprint_payload: PayloadFingerprint,
+    ) -> dict[str, bytes]:
+        unique = list(dict.fromkeys(identities))
+        found: dict[str, bytes] = {}
+        try:
+            for offset in range(0, len(unique), 500):
+                chunk = unique[offset : offset + 500]
+                if not chunk:
+                    continue
+                placeholders = ",".join("?" for _ in chunk)
+                rows = self.connection.execute(
+                    f"SELECT identity, fingerprint, record_start, record_end, row_digest "
+                    f"FROM identities WHERE identity_key = ? "
+                    f"AND identity IN ({placeholders})",
+                    (identity_key, *chunk),
+                )
+                for identity_value, fingerprint_value, start_value, end_value, digest_value in rows:
+                    identity = str(identity_value)
+                    try:
+                        fingerprint = bytes(fingerprint_value)
+                        record_start = int(start_value)
+                        record_end = int(end_value)
+                        row_digest = bytes(digest_value)
+                    except (TypeError, ValueError, OverflowError) as exc:
+                        raise IdentityIndexCorruptError(
+                            "identity index row has invalid values"
+                        ) from exc
+                    if (
+                        len(fingerprint) != 40
+                        or record_start < 0
+                        or record_end <= record_start
+                        or len(row_digest) != 32
+                        or row_digest
+                        != _identity_row_digest(
+                            identity_key,
+                            identity,
+                            fingerprint,
+                            record_start,
+                            record_end,
+                        )
+                    ):
+                        raise IdentityIndexCorruptError(
+                            "identity index row digest mismatch"
+                        )
+                    found[identity] = self._verify_identity_against_ledger(
+                        fh,
+                        state=state,
+                        identity_key=identity_key,
+                        identity=identity,
+                        row=(fingerprint, record_start, record_end),
+                        parse_payload=parse_payload,
+                        fingerprint_payload=fingerprint_payload,
+                    )
+        except IdentityIndexError:
+            raise
+        except sqlite3.DatabaseError as exc:
+            raise IdentityIndexCorruptError("identity index lookup failed") from exc
+        finally:
+            fh.seek(0, os.SEEK_END)
+        return found
+
+    def begin_append(self) -> None:
+        try:
+            self.connection.execute("BEGIN IMMEDIATE")
+        except sqlite3.DatabaseError as exc:
+            raise IdentityIndexError("identity index append transaction failed") from exc
+
+    def stage_append(
+        self,
+        *,
+        state: IndexState,
+        ledger_stat: os.stat_result,
+        identity_key: str,
+        rows: Sequence[tuple[str, bytes]],
+        raw_records: Sequence[bytes],
+    ) -> IndexState:
+        if (ledger_stat.st_dev, ledger_stat.st_ino) != (
+            state.ledger_dev,
+            state.ledger_ino,
+        ):
+            raise IdentityIndexDriftError("ledger identity changed during append")
+        expected_size = state.indexed_offset + sum(len(raw) for raw in raw_records)
+        if ledger_stat.st_size != expected_size:
+            raise IdentityIndexDriftError("ledger append size does not match index plan")
+        if len(rows) != len(raw_records):
+            raise IdentityIndexDriftError("identity index append plan length mismatch")
+        chain = state.chain_digest
+        last_start = state.last_record_start
+        last_digest = state.last_record_digest
+        cursor = state.indexed_offset
+        for (identity, fingerprint), raw in zip(rows, raw_records):
+            if not raw.endswith(b"\n"):
+                raise IdentityIndexDriftError("planned ledger record is incomplete")
+            record_start = cursor
+            record_end = cursor + len(raw)
+            existing = self._read_identity_row(identity_key, identity)
+            if existing is None:
+                self._insert_identity(
+                    identity_key=identity_key,
+                    identity=identity,
+                    fingerprint=fingerprint,
+                    record_start=record_start,
+                    record_end=record_end,
+                )
+            elif existing[0] != fingerprint:
+                raise IdentityIndexDriftError(
+                    f"conflicting {identity_key}: {identity}"
+                )
+            chain = hashlib.sha256(chain + raw).digest()
+            last_start = record_start
+            last_digest = hashlib.sha256(raw).digest()
+            cursor = record_end
+        identity_count = self._identity_count(identity_key)
+        next_state = IndexState(
+            identity_key=identity_key,
+            ledger_dev=ledger_stat.st_dev,
+            ledger_ino=ledger_stat.st_ino,
+            ledger_mtime_ns=ledger_stat.st_mtime_ns,
+            ledger_ctime_ns=ledger_stat.st_ctime_ns,
+            indexed_offset=ledger_stat.st_size,
+            chain_digest=chain,
+            record_count=state.record_count + len(raw_records),
+            identity_count=identity_count,
+            last_record_start=last_start,
+            last_record_digest=last_digest,
+        )
+        self._store_state(next_state)
+        return next_state
+
+    def rollback(self) -> None:
+        try:
+            if self.connection.in_transaction:
+                self.connection.rollback()
+        except sqlite3.DatabaseError as exc:
+            raise IdentityIndexCommitUncertain("identity index rollback failed") from exc
+
+    def commit(self) -> None:
+        try:
+            self.connection.commit()
+            _fsync_directory(self.root)
+        except (sqlite3.DatabaseError, IdentityIndexError) as exc:
+            raise IdentityIndexCommitUncertain(
+                "identity index commit outcome is uncertain"
+            ) from exc
+
+
+@contextmanager
+def open_identity_index(target_path: Path, *, timeout: int) -> Iterator[IdentityIndex]:
+    index = IdentityIndex(target_path, timeout=timeout)
+    try:
+        yield index
+    finally:
+        index.close()

--- a/storage.py
+++ b/storage.py
@@ -15,6 +15,14 @@ from typing import Final, Iterable, Iterator, Tuple
 
 from filelock import FileLock, Timeout
 
+from identity_index import (
+    IdentityIndexCommitUncertain,
+    IdentityIndexDriftError,
+    IdentityIndexError,
+    open_identity_index,
+    reset_identity_index_for_authoritative_replay,
+)
+
 __all__ = [
     "DATA_DIR",
     "DomainError",
@@ -702,13 +710,27 @@ def _payload_fingerprint(canonical_payload: bytes) -> bytes:
     )
 
 
+def _raise_identity_index_error(exc: IdentityIndexError) -> None:
+    """Map derived-index failures without weakening ledger conflict semantics."""
+    message = str(exc)
+    if isinstance(exc, IdentityIndexDriftError) and message.startswith("conflicting "):
+        raise StorageError(message) from exc
+    raise StorageRecoveryError(f"identity index unavailable: {message}") from exc
+
+
 def write_payload_unique_groups(
     domain: str,
     groups: Iterable[tuple[str, Iterable[str]]],
     *,
     identity_key: str = "event_id",
+    authoritative_replay: bool = False,
 ) -> dict[str, object]:
-    """Append grouped JSON lines with one target-ledger scan under one lock."""
+    """Append grouped JSON lines through a ledger-authoritative persistent index.
+
+    authoritative_replay is reserved for callers that have validated a complete
+    source inventory and are reconstructing an absent ledger.  It may reset only
+    the derived index and only while the newly opened ledger is empty.
+    """
     materialized = []
     seen_group_ids = set()
     for group_id, lines in groups:
@@ -718,6 +740,7 @@ def write_payload_unique_groups(
             raise StorageError(f"duplicate group_id: {group_id}")
         seen_group_ids.add(group_id)
         materialized.append((group_id, list(lines)))
+
     parsed_groups = []
     candidate_payloads: dict[str, bytes] = {}
     candidate_count = 0
@@ -738,6 +761,7 @@ def write_payload_unique_groups(
             parsed.append((identity, line, _payload_fingerprint(canonical_payload)))
             candidate_count += 1
         parsed_groups.append((group_id, parsed))
+
     if candidate_count == 0:
         return {
             "written": 0,
@@ -745,77 +769,144 @@ def write_payload_unique_groups(
             "target_scans": 0,
             "target_records_scanned": 0,
             "target_identity_index_entries": 0,
+            "identity_index_mode": "unused",
+            "identity_index_full_rebuild": False,
+            "identity_index_entries_after": 0,
             "groups": [
                 {"group_id": gid, "requested": len(lines), "written": 0, "skipped": 0}
                 for gid, lines in materialized
             ],
         }
-    # Exact candidate conflict checks are complete; release their full
-    # canonical payloads before scanning a potentially large historical ledger.
+
     del candidate_payloads
     try:
         target_path = safe_target_path(domain)
     except DomainError as exc:
         raise StorageError("invalid target path") from exc
+
     with _locked_open(target_path, "a+") as fh:
-        fh.seek(0)
-        # Preserve global conflict detection without retaining every historical
-        # payload. Chronik already uses SHA-256 as a content-identity primitive;
-        # length plus the binary digest bounds the per-record index value.
-        existing: dict[str, bytes] = {}
-        target_records_scanned = 0
-        for raw in fh:
-            target_records_scanned += 1
-            try:
-                identity, canonical_payload = _parse_unique_payload(raw, identity_key)
-            except (TypeError, ValueError):
-                continue
-            if identity:
-                fingerprint = _payload_fingerprint(canonical_payload)
-                previous = existing.get(identity)
-                if previous is None:
-                    existing[identity] = fingerprint
-                elif previous != fingerprint:
-                    raise StorageError(f"conflicting {identity_key}: {identity}")
-        target_identity_index_entries = len(existing)
-        for _, parsed in parsed_groups:
-            for identity, _, fingerprint in parsed:
-                previous = existing.get(identity)
-                if previous is not None and previous != fingerprint:
-                    raise StorageError(f"conflicting {identity_key}: {identity}")
-        total_written = 0
-        total_skipped = 0
-        group_results = []
-        append_lines = []
-        for group_id, parsed in parsed_groups:
-            group_written = 0
-            group_skipped = 0
-            for identity, line, fingerprint in parsed:
-                if identity in existing:
-                    group_skipped += 1
-                    total_skipped += 1
-                    continue
-                append_lines.append(line)
-                existing[identity] = fingerprint
-                group_written += 1
-                total_written += 1
-            group_results.append(
-                {
-                    "group_id": group_id,
-                    "requested": len(parsed),
-                    "written": group_written,
-                    "skipped": group_skipped,
+        try:
+            if authoritative_replay:
+                replay_stat = _target_stat_for_fd(target_path, fh.fileno())
+                if replay_stat.st_size != 0:
+                    raise StorageRecoveryError(
+                        "authoritative replay requires an empty reconstructed ledger"
+                    )
+                reset_identity_index_for_authoritative_replay(target_path)
+            with open_identity_index(target_path, timeout=LOCK_TIMEOUT) as index:
+                sync = index.synchronize(
+                    fh,
+                    identity_key=identity_key,
+                    parse_payload=_parse_unique_payload,
+                    fingerprint_payload=_payload_fingerprint,
+                )
+                candidate_ids = [
+                    identity
+                    for _, parsed in parsed_groups
+                    for identity, _, _ in parsed
+                ]
+                existing = index.lookup(
+                    fh,
+                    state=sync.state,
+                    identity_key=identity_key,
+                    identities=candidate_ids,
+                    parse_payload=_parse_unique_payload,
+                    fingerprint_payload=_payload_fingerprint,
+                )
+                for _, parsed in parsed_groups:
+                    for identity, _, fingerprint in parsed:
+                        previous = existing.get(identity)
+                        if previous is not None and previous != fingerprint:
+                            raise StorageError(f"conflicting {identity_key}: {identity}")
+
+                total_written = 0
+                total_skipped = 0
+                group_results = []
+                append_lines: list[str] = []
+                append_rows: list[tuple[str, bytes]] = []
+                planned = set(existing)
+                for group_id, parsed in parsed_groups:
+                    group_written = 0
+                    group_skipped = 0
+                    for identity, line, fingerprint in parsed:
+                        if identity in planned:
+                            group_skipped += 1
+                            total_skipped += 1
+                            continue
+                        append_lines.append(line)
+                        append_rows.append((identity, fingerprint))
+                        planned.add(identity)
+                        group_written += 1
+                        total_written += 1
+                    group_results.append(
+                        {
+                            "group_id": group_id,
+                            "requested": len(parsed),
+                            "written": group_written,
+                            "skipped": group_skipped,
+                        }
+                    )
+
+                final_state = sync.state
+                if append_lines:
+                    pre_append = _target_stat_for_fd(target_path, fh.fileno())
+                    raw_records = [(line + "\n").encode("utf-8") for line in append_lines]
+                    index.begin_append()
+                    ledger_appended = False
+                    try:
+                        _append_jsonl_transaction(fh, target_path, append_lines)
+                        ledger_appended = True
+                        post_append = _target_stat_for_fd(target_path, fh.fileno())
+                        final_state = index.stage_append(
+                            state=sync.state,
+                            ledger_stat=post_append,
+                            identity_key=identity_key,
+                            rows=append_rows,
+                            raw_records=raw_records,
+                        )
+                    except BaseException:
+                        try:
+                            index.rollback()
+                        except IdentityIndexError as rollback_exc:
+                            raise StorageRecoveryError(
+                                "identity index rollback failed; ledger state requires inspection"
+                            ) from rollback_exc
+                        if ledger_appended:
+                            try:
+                                _rollback_append(
+                                    fh.fileno(), target_path, pre_append.st_size
+                                )
+                            except BaseException as rollback_exc:
+                                raise StorageRecoveryError(
+                                    "ledger rollback after identity index failure failed"
+                                ) from rollback_exc
+                        raise
+                    try:
+                        index.commit()
+                    except IdentityIndexCommitUncertain as exc:
+                        # The ledger is already durable.  Do not risk making the
+                        # index lead the authority by rolling the ledger back.
+                        raise StorageRecoveryError(
+                            "identity index commit outcome uncertain; ledger may be ahead"
+                        ) from exc
+
+                return {
+                    "written": total_written,
+                    "skipped": total_skipped,
+                    "target_scans": 0 if sync.mode == "steady" else 1,
+                    "target_records_scanned": sync.records_scanned,
+                    "target_identity_index_entries": sync.entry_count,
+                    "identity_index_mode": sync.mode,
+                    "identity_index_full_rebuild": sync.mode == "rebuild",
+                    "identity_index_entries_after": sync.entry_count + len(append_rows),
+                    "identity_index_offset": final_state.indexed_offset,
+                    "groups": group_results,
                 }
-            )
-        _append_jsonl_transaction(fh, target_path, append_lines)
-    return {
-        "written": total_written,
-        "skipped": total_skipped,
-        "target_scans": 1,
-        "target_records_scanned": target_records_scanned,
-        "target_identity_index_entries": target_identity_index_entries,
-        "groups": group_results,
-    }
+        except StorageError:
+            raise
+        except IdentityIndexError as exc:
+            _raise_identity_index_error(exc)
+
 
 
 def write_payload_unique(

--- a/tests/test_benchmark_outbox_import.py
+++ b/tests/test_benchmark_outbox_import.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 
-def test_benchmark_reports_single_scan_first_and_repeat(tmp_path):
+def test_benchmark_reports_persistent_index_reuse(tmp_path):
     root = Path(__file__).parents[1]
     output = tmp_path / "benchmark.json"
     result = subprocess.run(
@@ -29,13 +29,16 @@ def test_benchmark_reports_single_scan_first_and_repeat(tmp_path):
     report = json.loads(output.read_text())
     tier = report["tiers"][0]
     assert report["passed"] is True
-    assert tier["first"]["target_scans"] == 1
-    assert tier["repeat"]["target_scans"] == 1
+    assert tier["first"]["target_scans"] == 0
+    assert tier["first"]["target_records_scanned"] == 0
+    assert tier["repeat"]["target_scans"] == 0
+    assert tier["repeat"]["target_records_scanned"] == 0
     assert tier["first"]["events_imported"] == 6
     assert tier["repeat"]["events_skipped_existing"] == 6
     assert tier["compaction"]["sources_removed"] == 3
     assert tier["loose_files_before"] == 3
     assert tier["loose_files_after"] == 0
-    assert tier["bundled_repeat"]["target_scans"] == 1
+    assert tier["bundled_repeat"]["target_scans"] == 0
+    assert tier["bundled_repeat"]["target_records_scanned"] == 0
     assert tier["bundled_repeat"]["events_skipped_existing"] == 6
     assert tier["passed"] is True

--- a/tests/test_grabowski_outbox_import.py
+++ b/tests/test_grabowski_outbox_import.py
@@ -145,7 +145,9 @@ def test_missing_receipt_is_rebuilt_after_store_verification(tmp_path, monkeypat
     assert recovered["events_imported"] == 0
     assert recovered["events_skipped_existing"] == 1
     assert recovered["files_unchanged"] == 0
-    assert recovered["target_scans"] == 1
+    assert recovered["target_scans"] == 0
+    assert recovered["target_records_scanned"] == 0
+    assert recovered["identity_index_mode"] == "steady"
     assert recovered["receipts_written"] == 1
     assert recovered["receipts_reused"] == 0
     assert receipt_path.exists()
@@ -168,7 +170,9 @@ def test_stale_receipt_cannot_override_store_verification(tmp_path, monkeypatch)
     assert recovered["events_imported"] == 0
     assert recovered["events_skipped_existing"] == 1
     assert recovered["files_unchanged"] == 0
-    assert recovered["target_records_scanned"] == 1
+    assert recovered["target_scans"] == 0
+    assert recovered["target_records_scanned"] == 0
+    assert recovered["identity_index_mode"] == "steady"
     assert recovered["receipts_written"] == 1
     assert recovered["receipts_reused"] == 0
     refreshed = json.loads(receipt_path.read_text())
@@ -390,8 +394,9 @@ def test_multi_file_batch_scans_target_once_and_repeat_verifies_store(
     assert first["events_imported"] == 3
     assert first["receipts_written"] == 3
     assert first["receipts_reused"] == 0
-    assert second["target_scans"] == 1
-    assert second["target_records_scanned"] == 3
+    assert second["target_scans"] == 0
+    assert second["target_records_scanned"] == 0
+    assert second["identity_index_mode"] == "steady"
     assert second["events_imported"] == 0
     assert second["events_skipped_existing"] == 3
     assert second["files_unchanged"] == 3
@@ -509,7 +514,9 @@ def test_receipt_failure_preserves_ledger_stats_and_is_recoverable(
 
     assert recovered["events_imported"] == 0
     assert recovered["events_skipped_existing"] == 1
-    assert recovered["target_scans"] == 1
+    assert recovered["target_scans"] == 0
+    assert recovered["target_records_scanned"] == 0
+    assert recovered["identity_index_mode"] == "steady"
     assert recovered["errors"] == []
     assert len(list(receipts.glob("*.receipt.json"))) == 1
 

--- a/tests/test_identity_index.py
+++ b/tests/test_identity_index.py
@@ -1,0 +1,462 @@
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import identity_index
+import storage
+
+
+@pytest.fixture
+def mock_data_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(storage, "DATA_DIR", tmp_path)
+    return tmp_path
+
+
+def _line(event_id: str, value: str) -> str:
+    return json.dumps(
+        {"payload": {"event_id": event_id, "value": value}}, sort_keys=True
+    )
+
+
+def _write(domain: str, *lines: str):
+    return storage.write_payload_unique_groups(domain, [("batch", list(lines))])
+
+
+def _target(data_dir: Path, domain: str = "agent.ledger") -> Path:
+    return data_dir / f"{domain}.jsonl"
+
+
+def _index_path(data_dir: Path, domain: str = "agent.ledger") -> Path:
+    return identity_index.index_path_for_target(_target(data_dir, domain))
+
+
+def test_missing_index_rebuilds_once_then_steady_state_skips_full_scan(mock_data_dir):
+    storage.write_payload(
+        "agent.ledger", [_line(f"old-{index}", str(index)) for index in range(50)]
+    )
+
+    rebuilt = _write(
+        "agent.ledger", _line("old-1", "1"), _line("new-1", "value")
+    )
+    steady = _write("agent.ledger", _line("new-2", "value"))
+
+    assert rebuilt["identity_index_mode"] == "rebuild"
+    assert rebuilt["identity_index_full_rebuild"] is True
+    assert rebuilt["target_scans"] == 1
+    assert rebuilt["target_records_scanned"] == 50
+    assert rebuilt["written"] == 1
+    assert rebuilt["skipped"] == 1
+    assert rebuilt["identity_index_offset"] == _target(mock_data_dir).stat().st_size - len(
+        (_line("new-2", "value") + "\n").encode()
+    )
+
+    assert steady["identity_index_mode"] == "steady"
+    assert steady["identity_index_full_rebuild"] is False
+    assert steady["target_scans"] == 0
+    assert steady["target_records_scanned"] == 0
+    assert steady["written"] == 1
+    assert steady["identity_index_offset"] == _target(mock_data_dir).stat().st_size
+
+
+def test_plain_ledger_append_uses_verified_catchup(mock_data_dir):
+    _write("agent.ledger", _line("seed", "same"))
+    storage.write_payload("agent.ledger", [_line("external", "same")])
+
+    result = _write(
+        "agent.ledger", _line("external", "same"), _line("new", "value")
+    )
+
+    assert result["identity_index_mode"] == "verify-catchup"
+    assert result["target_records_scanned"] == 2
+    assert result["written"] == 1
+    assert result["skipped"] == 1
+
+
+def test_invalid_historical_line_is_chained_but_not_indexed(mock_data_dir):
+    _write("agent.ledger", _line("seed", "same"))
+    storage.write_payload("agent.ledger", ["not-json"])
+
+    result = _write("agent.ledger", _line("new", "value"))
+
+    assert result["identity_index_mode"] == "verify-catchup"
+    assert result["target_records_scanned"] == 2
+    assert result["written"] == 1
+
+
+def test_historical_record_without_identity_is_chained_but_not_indexed(
+    mock_data_dir,
+):
+    storage.write_payload(
+        "agent.ledger",
+        [json.dumps({"payload": {"value": "missing identity"}}, sort_keys=True)],
+    )
+
+    result = _write("agent.ledger", _line("new", "value"))
+
+    assert result["identity_index_mode"] == "rebuild"
+    assert result["target_records_scanned"] == 1
+    assert result["target_identity_index_entries"] == 0
+    assert result["identity_index_entries_after"] == 1
+
+
+def test_rebuild_preserves_global_historical_conflict_detection(mock_data_dir):
+    storage.write_payload(
+        "agent.ledger", [_line("damaged", "first"), _line("damaged", "second")]
+    )
+
+    with pytest.raises(storage.StorageError, match="conflicting event_id: damaged"):
+        _write("agent.ledger", _line("new", "value"))
+
+
+def test_truncated_ledger_fails_closed(mock_data_dir):
+    _write("agent.ledger", _line("seed", "same"))
+    _target(mock_data_dir).write_bytes(b"")
+
+    with pytest.raises(storage.StorageRecoveryError, match="truncated"):
+        _write("agent.ledger", _line("new", "value"))
+
+
+def test_replaced_ledger_inode_fails_closed(mock_data_dir):
+    _write("agent.ledger", _line("seed", "same"))
+    replacement = mock_data_dir / "replacement.jsonl"
+    replacement.write_text(_line("seed", "same") + "\n", encoding="utf-8")
+    os.replace(replacement, _target(mock_data_dir))
+
+    with pytest.raises(storage.StorageRecoveryError, match="identity changed"):
+        _write("agent.ledger", _line("new", "value"))
+
+
+def test_same_size_prefix_mutation_triggers_full_verification(mock_data_dir):
+    first = _line("first", "a")
+    second = _line("second", "b")
+    _write("agent.ledger", first, second)
+    target = _target(mock_data_dir)
+    raw = target.read_bytes()
+    mutated = raw.replace(b'"value": "a"', b'"value": "z"', 1)
+    assert len(mutated) == len(raw)
+    target.write_bytes(mutated)
+
+    with pytest.raises(storage.StorageRecoveryError, match="prefix verification failed"):
+        _write("agent.ledger", _line("new", "value"))
+
+
+def test_prefix_mutation_plus_append_fails_verified_catchup(mock_data_dir):
+    first = _line("first", "a")
+    second = _line("second", "b")
+    _write("agent.ledger", first, second)
+    target = _target(mock_data_dir)
+    raw = target.read_bytes()
+    mutated = raw.replace(b'"value": "a"', b'"value": "z"', 1)
+    assert len(mutated) == len(raw)
+    target.write_bytes(mutated)
+    with target.open("ab") as handle:
+        handle.write((_line("external", "same") + "\n").encode("utf-8"))
+        handle.flush()
+        os.fsync(handle.fileno())
+
+    with pytest.raises(storage.StorageRecoveryError, match="prefix verification failed"):
+        _write("agent.ledger", _line("new", "value"))
+
+
+def test_incomplete_ledger_tail_fails_closed(mock_data_dir):
+    _write("agent.ledger", _line("seed", "same"))
+    with _target(mock_data_dir).open("ab") as handle:
+        handle.write(b'{"payload":')
+        handle.flush()
+        os.fsync(handle.fileno())
+
+    with pytest.raises(storage.StorageRecoveryError, match="incomplete final record"):
+        _write("agent.ledger", _line("new", "value"))
+
+
+def test_corrupt_database_is_not_silently_rebuilt(mock_data_dir):
+    _write("agent.ledger", _line("seed", "same"))
+    _index_path(mock_data_dir).write_bytes(b"not a sqlite database")
+
+    with pytest.raises(storage.StorageRecoveryError, match="identity index"):
+        _write("agent.ledger", _line("new", "value"))
+
+
+def test_symlinked_database_is_rejected(mock_data_dir):
+    storage.write_payload("agent.ledger", [_line("seed", "same")])
+    index_path = _index_path(mock_data_dir)
+    index_path.parent.mkdir(mode=0o700)
+    decoy = mock_data_dir / "decoy.sqlite3"
+    decoy.write_bytes(b"")
+    index_path.symlink_to(decoy)
+
+    with pytest.raises(storage.StorageRecoveryError, match="regular file"):
+        _write("agent.ledger", _line("new", "value"))
+
+
+def test_insecure_index_directory_is_rejected(mock_data_dir):
+    storage.write_payload("agent.ledger", [_line("seed", "same")])
+    index_root = mock_data_dir / identity_index.INDEX_DIR_NAME
+    index_root.mkdir(mode=0o700)
+    index_root.chmod(0o755)
+
+    with pytest.raises(storage.StorageRecoveryError, match="not private"):
+        _write("agent.ledger", _line("new", "value"))
+
+
+def test_general_storage_write_does_not_reset_index_after_ledger_loss(mock_data_dir):
+    _write("agent.ledger", _line("seed", "same"))
+    _target(mock_data_dir).unlink()
+
+    with pytest.raises(
+        storage.StorageRecoveryError,
+        match="identity changed|truncated behind the index",
+    ):
+        _write("agent.ledger", _line("seed", "same"))
+
+
+def test_batch_replay_recovers_after_failed_general_write_left_empty_ledger(
+    mock_data_dir,
+):
+    _write("agent.ledger", _line("seed", "same"))
+    _target(mock_data_dir).unlink()
+    with pytest.raises(storage.StorageRecoveryError):
+        _write("agent.ledger", _line("seed", "same"))
+    assert _target(mock_data_dir).stat().st_size == 0
+
+    result = storage.write_payload_unique_groups(
+        "agent.ledger",
+        [("replay", [_line("seed", "same")])],
+        authoritative_replay=True,
+    )
+
+    assert result["identity_index_mode"] == "rebuild"
+    assert result["written"] == 1
+
+
+def test_authoritative_replay_resets_only_derived_index_for_empty_ledger(
+    mock_data_dir,
+):
+    _write("agent.ledger", _line("seed", "same"))
+    _target(mock_data_dir).unlink()
+
+    result = storage.write_payload_unique_groups(
+        "agent.ledger",
+        [("replay", [_line("seed", "same")])],
+        authoritative_replay=True,
+    )
+
+    assert result["identity_index_mode"] == "rebuild"
+    assert result["written"] == 1
+    assert result["skipped"] == 0
+
+
+def test_authoritative_replay_rejects_nonempty_ledger(mock_data_dir):
+    _write("agent.ledger", _line("seed", "same"))
+
+    with pytest.raises(
+        storage.StorageRecoveryError,
+        match="requires an empty reconstructed ledger",
+    ):
+        storage.write_payload_unique_groups(
+            "agent.ledger",
+            [("replay", [_line("new", "value")])],
+            authoritative_replay=True,
+        )
+
+
+def test_authoritative_replay_rejects_symlinked_index_artifact(mock_data_dir):
+    _write("agent.ledger", _line("seed", "same"))
+    _target(mock_data_dir).unlink()
+    index_path = _index_path(mock_data_dir)
+    index_path.unlink()
+    decoy = mock_data_dir / "decoy.sqlite3"
+    decoy.write_bytes(b"")
+    index_path.symlink_to(decoy)
+
+    with pytest.raises(storage.StorageRecoveryError, match="regular file"):
+        storage.write_payload_unique_groups(
+            "agent.ledger",
+            [("replay", [_line("seed", "same")])],
+            authoritative_replay=True,
+        )
+
+
+def test_deleted_index_is_rebuilt_from_unchanged_ledger(mock_data_dir):
+    _write("agent.ledger", _line("seed", "same"))
+    _index_path(mock_data_dir).unlink()
+
+    result = _write(
+        "agent.ledger", _line("seed", "same"), _line("new", "value")
+    )
+
+    assert result["identity_index_mode"] == "rebuild"
+    assert result["target_records_scanned"] == 1
+    assert result["written"] == 1
+    assert result["skipped"] == 1
+
+
+def test_index_stage_failure_rolls_back_the_ledger(mock_data_dir, monkeypatch):
+    _write("agent.ledger", _line("seed", "same"))
+    target = _target(mock_data_dir)
+    before = target.read_bytes()
+    real_stage = identity_index.IdentityIndex.stage_append
+
+    def fail_stage(self, **kwargs):
+        raise identity_index.IdentityIndexCorruptError("synthetic stage failure")
+
+    monkeypatch.setattr(identity_index.IdentityIndex, "stage_append", fail_stage)
+    with pytest.raises(storage.StorageRecoveryError, match="synthetic stage failure"):
+        _write("agent.ledger", _line("new", "value"))
+    assert target.read_bytes() == before
+
+    monkeypatch.setattr(identity_index.IdentityIndex, "stage_append", real_stage)
+    recovered = _write("agent.ledger", _line("new", "value"))
+    assert recovered["identity_index_mode"] == "verify"
+    assert recovered["written"] == 1
+
+
+def test_hard_crash_after_ledger_append_recovers_lagging_index(
+    mock_data_dir,
+):
+    _write("agent.ledger", _line("seed", "same"))
+    child = """
+import json
+import os
+from pathlib import Path
+
+import identity_index
+import storage
+
+storage.DATA_DIR = Path(os.environ["CRASH_DATA_DIR"])
+real_stage = identity_index.IdentityIndex.stage_append
+
+
+def crash_after_stage(self, **kwargs):
+    real_stage(self, **kwargs)
+    os._exit(73)
+
+
+identity_index.IdentityIndex.stage_append = crash_after_stage
+line = json.dumps(
+    {"payload": {"event_id": "crash-event", "value": "durable"}},
+    sort_keys=True,
+)
+storage.write_payload_unique_groups(
+    "agent.ledger",
+    [("crash", [line])],
+)
+"""
+    environment = os.environ.copy()
+    environment["CRASH_DATA_DIR"] = str(mock_data_dir)
+    crashed = subprocess.run(
+        [sys.executable, "-c", child],
+        cwd=Path(__file__).parents[1],
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert crashed.returncode == 73, crashed.stderr
+    assert _line("crash-event", "durable") in _target(mock_data_dir).read_text()
+
+    recovered = _write("agent.ledger", _line("crash-event", "durable"))
+
+    assert recovered["identity_index_mode"] == "verify-catchup"
+    assert recovered["written"] == 0
+    assert recovered["skipped"] == 1
+
+
+def test_uncertain_index_commit_leaves_recoverable_ledger_ahead(
+    mock_data_dir, monkeypatch
+):
+    _write("agent.ledger", _line("seed", "same"))
+    real_commit = identity_index.IdentityIndex.commit
+
+    def fail_commit(self):
+        raise identity_index.IdentityIndexCommitUncertain("synthetic commit uncertainty")
+
+    monkeypatch.setattr(identity_index.IdentityIndex, "commit", fail_commit)
+    with pytest.raises(storage.StorageRecoveryError, match="commit outcome uncertain"):
+        _write("agent.ledger", _line("new", "value"))
+    assert _line("new", "value") in _target(mock_data_dir).read_text()
+
+    monkeypatch.setattr(identity_index.IdentityIndex, "commit", real_commit)
+    recovered = _write("agent.ledger", _line("new", "value"))
+    assert recovered["identity_index_mode"] == "verify-catchup"
+    assert recovered["target_records_scanned"] == 2
+    assert recovered["written"] == 0
+    assert recovered["skipped"] == 1
+
+
+def test_state_hash_tampering_is_rejected_before_use(mock_data_dir):
+    _write("agent.ledger", _line("first", "a"), _line("second", "b"))
+    with sqlite3.connect(_index_path(mock_data_dir)) as connection:
+        connection.execute(
+            "UPDATE index_state SET chain_digest = ? WHERE identity_key = ?",
+            (b"x" * 32, "event_id"),
+        )
+
+    with pytest.raises(storage.StorageRecoveryError, match="state digest mismatch"):
+        _write("agent.ledger", _line("third", "c"))
+
+
+def test_deleted_identity_row_breaks_count_binding(mock_data_dir):
+    _write("agent.ledger", _line("first", "a"), _line("second", "b"))
+    with sqlite3.connect(_index_path(mock_data_dir)) as connection:
+        connection.execute(
+            "DELETE FROM identities WHERE identity_key = ? AND identity = ?",
+            ("event_id", "first"),
+        )
+
+    with pytest.raises(storage.StorageRecoveryError, match="count binding mismatch"):
+        _write("agent.ledger", _line("first", "a"))
+
+
+def test_tampered_identity_row_digest_fails_closed(mock_data_dir):
+    _write("agent.ledger", _line("first", "a"))
+    with sqlite3.connect(_index_path(mock_data_dir)) as connection:
+        connection.execute(
+            "UPDATE identities SET fingerprint = ? WHERE identity_key = ? AND identity = ?",
+            (b"x" * 40, "event_id", "first"),
+        )
+
+    with pytest.raises(storage.StorageRecoveryError, match="row digest mismatch"):
+        _write("agent.ledger", _line("first", "a"))
+
+
+def test_tampered_identity_row_offset_fails_closed(mock_data_dir):
+    _write("agent.ledger", _line("first", "a"))
+    with sqlite3.connect(_index_path(mock_data_dir)) as connection:
+        connection.execute(
+            "UPDATE identities SET record_start = 1 WHERE identity_key = ? AND identity = ?",
+            ("event_id", "first"),
+        )
+
+    with pytest.raises(storage.StorageRecoveryError, match="row digest mismatch"):
+        _write("agent.ledger", _line("first", "a"))
+
+
+def test_lookup_chunks_more_than_sqlite_parameter_limit(mock_data_dir):
+    lines = [_line(f"event-{index}", str(index)) for index in range(1201)]
+    first = _write("agent.ledger", *lines)
+    second = _write("agent.ledger", *lines)
+
+    assert first["written"] == 1201
+    assert second["identity_index_mode"] == "steady"
+    assert second["written"] == 0
+    assert second["skipped"] == 1201
+
+
+def test_large_allowed_payload_keeps_fixed_width_index_fingerprint(mock_data_dir):
+    value = "x" * 700_000
+    result = _write("agent.ledger", _line("large", value))
+
+    assert result["written"] == 1
+    with sqlite3.connect(_index_path(mock_data_dir)) as connection:
+        fingerprint = connection.execute(
+            "SELECT fingerprint FROM identities WHERE identity_key = ? AND identity = ?",
+            ("event_id", "large"),
+        ).fetchone()[0]
+    assert len(fingerprint) == 40

--- a/tests/test_identity_index.py
+++ b/tests/test_identity_index.py
@@ -182,6 +182,30 @@ def test_corrupt_database_is_not_silently_rebuilt(mock_data_dir):
         _write("agent.ledger", _line("new", "value"))
 
 
+def test_same_name_trigger_definition_mutation_fails_closed(mock_data_dir):
+    _write("agent.ledger", _line("seed", "same"))
+    with sqlite3.connect(_index_path(mock_data_dir)) as connection:
+        connection.execute("PRAGMA writable_schema=ON")
+        connection.execute(
+            """
+            UPDATE sqlite_master
+            SET sql = ?
+            WHERE type = 'trigger' AND name = 'identities_count_insert'
+            """,
+            (
+                "CREATE TRIGGER identities_count_insert "
+                "AFTER INSERT ON identities BEGIN SELECT 1; END",
+            ),
+        )
+        connection.execute("PRAGMA writable_schema=OFF")
+
+    with pytest.raises(
+        storage.StorageRecoveryError,
+        match="schema definitions mismatch",
+    ):
+        _write("agent.ledger", _line("new", "value"))
+
+
 def test_symlinked_database_is_rejected(mock_data_dir):
     storage.write_payload("agent.ledger", [_line("seed", "same")])
     index_path = _index_path(mock_data_dir)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -108,7 +108,7 @@ def test_payload_fingerprint_is_fixed_width_and_length_bound():
     assert small[8:] != large[8:]
 
 
-def test_write_payload_unique_groups_does_not_rehash_parsed_candidates(
+def test_write_payload_unique_groups_verifies_index_hits_against_ledger(
     mock_data_dir, monkeypatch
 ):
     storage.write_payload("agent.ledger", [_unique_line("existing", "same")])
@@ -127,7 +127,10 @@ def test_write_payload_unique_groups_does_not_rehash_parsed_candidates(
 
     assert result["written"] == 1
     assert result["skipped"] == 1
-    assert len(calls) == 3  # two candidates plus one historical record
+    existing_payload = b'{"event_id":"existing","value":"same"}'
+    new_payload = b'{"event_id":"new","value":"value"}'
+    assert calls.count(new_payload) == 1
+    assert calls.count(existing_payload) == 3
 
 
 def test_write_payload_unique_groups_scans_once_and_allocates_counts(mock_data_dir):


### PR DESCRIPTION
## Problem

Chronik identity checks currently require linear scans over historical JSONL ledgers. Repeated importer and storage operations therefore scale with the complete history.

## Solution and authority model

This PR adds a persistent SQLite identity index under `.chronik-identity-index-v1/<sha256(filename)>.sqlite3`.

- The JSONL ledger remains the sole authority; SQLite is derived state only.
- Identities bind the complete payload fingerprint and exact ledger byte offsets.
- Device, inode, size/timestamps, offset and a rolling prefix SHA-256 are verified.
- Table and trigger names, columns, primary keys and normalized `CREATE TABLE` / `CREATE TRIGGER` definitions are bound exactly.
- Symlinks, wrong ownership or modes, corrupt schema and inconsistent state fail closed.
- Normal steady state does not rescan historical records.
- `verify-catchup` is explicitly exceptional and may perform linear verification.

## Crash and corruption model

The write order preserves ledger authority. A hard-crash test kills a subprocess after ledger `fsync` but before SQLite commit; the next run safely catches the derived index up. Ledger truncation, replacement, prefix mutation, same-name schema mutation, index loss and index corruption are rejected or rebuilt only through a fully validated authoritative replay. The local trust boundary protects against operational mistakes and accidental corruption, not an attacker who can rewrite ledger and index consistently.

## Modes

- `rebuild`
- `steady`
- `verify`
- `verify-catchup`

## Validation on final head

- Full suite: 409 passed, 1 existing Starlette/httpx2 deprecation warning
- Identity-index focus suite after self-review hardening: 29 passed
- `role-contract: OK chronik`
- `compileall`: passed
- `git diff --check`: passed
- Real hard-crash recovery test: covered by the full suite and passed

## 100k local synthetic measurement

Dataset: 100,000 unique historical events, event ID identity, 128-byte values.

- Rebuild: 3.6420401600189507 s; `target_scans=1`; `target_records_scanned=100000`; Python peak 62,691 bytes
- Steady: 0.0028964472003281116 s; `target_scans=0`; `target_records_scanned=0`; Python peak 29,065 bytes
- Ledger: 18,188,996 bytes
- Index: 11,890,688 bytes
- Final entries: 100,002

These values establish the local algorithmic path for this fixture only. They are not production latency, RSS, throughput or durability claims.

## Compatibility, rollback and deployment boundary

Existing call signatures and existing result keys/types remain compatible. The newly exposed index-mode and scan fields add detail, while historical-scan counters now report the indexed execution path rather than preserving prior full-scan behavior. Older Chronik versions ignore the derived index and continue to trust the JSONL ledger. Rollback reverts the code and may remove the derived index without modifying ledger bytes.

This PR does not deploy Chronik, activate `chronik.service`, or authorize either action. Deployment requires a separate review of the live importer, deployed commit, first-build storage requirement, reversibility and ledger-safe rollback.

## Self-review result

The exact review found one material gap: same-name SQLite trigger definitions were not bound. Final commit `44694b86d75d389b73ffbd0c60583c0a3fa40495` now validates the normalized definitions and includes a regression test that mutates a trigger under the same name. No unresolved merge-blocking finding remains.

Residual operational boundary: index files grow with indexed identities and currently have no automatic size-budget, compaction or rebuild-maintenance policy. This does not compromise ledger authority or rollback, but it is follow-up work rather than a production claim.

## Exact evidence binding

- Base: `362dc58521d11951242d115f0213e8db8140a057`
- Head: `44694b86d75d389b73ffbd0c60583c0a3fa40495`
- Raw Git diff SHA-256: `7a4c5b8fee2535f0030c0520e86ec6731c4c970ef9af8f0a021ecc8e010fa43f`
- Raw Git diff size: 92,755 bytes
- Exact immutable diff: https://gist.githubusercontent.com/alexdermohr/8b5195d836c07356e13358a0af08d21a/raw/247ea5f03de25ffd9bd2882e7611f728b76c5742/chronik-persistent-identity-index-t010-final.diff
