### PR TITLE
feat(coding-memory): add explicit subject component filter

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -1652,6 +1652,12 @@ def _event_source_component(event: dict[str, Any]) -> str | None:
     return source.get("component") if isinstance(source, dict) else None
 
 
+def _event_subject_component(event: dict[str, Any]) -> str | None:
+    """Return the task-context component from the event subject."""
+    subject = event.get("subject")
+    return subject.get("component") if isinstance(subject, dict) else None
+
+
 def _target(*, repo: str | None, host: str | None) -> dict[str, str]:
     if repo is not None:
         return {"scope": "repository", "repo": repo}
@@ -1665,7 +1671,7 @@ def _matches_target(subject: dict[str, Any], *, repo: str | None, host: str | No
     return subject.get("scope") == "host" and subject.get("host") == host
 
 
-def validate_query(*, repo: str | None = None, host: str | None = None, component: str | None = None, operation: str | None = None, task_class: str | None = None, outcome: str | None = None, since: str | None = None, limit: int = 20) -> datetime | None:
+def validate_query(*, repo: str | None = None, host: str | None = None, component: str | None = None, subject_component: str | None = None, operation: str | None = None, task_class: str | None = None, outcome: str | None = None, since: str | None = None, limit: int = 20) -> datetime | None:
     if (repo is None) == (host is None):
         raise ValueError("exactly one of repo or host is required")
     if repo is not None and not repo.strip():
@@ -1688,6 +1694,7 @@ def query_history(
     repo: str | None = None,
     host: str | None = None,
     component: str | None = None,
+    subject_component: str | None = None,
     operation: str | None = None,
     task_class: str | None = None,
     outcome: str | None = None,
@@ -1698,6 +1705,7 @@ def query_history(
         repo=repo,
         host=host,
         component=component,
+        subject_component=subject_component,
         operation=operation,
         task_class=task_class,
         outcome=outcome,
@@ -1712,6 +1720,8 @@ def query_history(
         if not _matches_target(subject, repo=repo, host=host):
             return
         if component and _event_source_component(event) != component:
+            return
+        if subject_component and _event_subject_component(event) != subject_component:
             return
         if operation and _event_operation(event) != operation:
             return
@@ -1750,6 +1760,8 @@ def query_history(
         "since": since,
         "limit": limit,
     }
+    if subject_component is not None:
+        query["subject_component"] = subject_component
     return {
         "schema_version": "chronik-coding-history.v1",
         "query": query,

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -78,6 +78,18 @@ def test_query_cli_prefers_repository_module_when_pythonpath_contains_root(tmp_p
     assert not missing.exists()
 
 
+def test_query_cli_subject_component_is_explicit_and_preserves_legacy_shape(tmp_path):
+    import subprocess, sys
+    missing = tmp_path / "missing"
+    tool = str(Path(__file__).parents[1] / "tools" / "coding_memory.py")
+    legacy = subprocess.run([sys.executable, tool, "--data-dir", str(missing), "query", "--repo", "heimgewebe/example"], text=True, capture_output=True)
+    filtered = subprocess.run([sys.executable, tool, "--data-dir", str(missing), "query", "--repo", "heimgewebe/example", "--subject-component", "target-api"], text=True, capture_output=True)
+    assert legacy.returncode == 0 and filtered.returncode == 0
+    assert "subject_component" not in json.loads(legacy.stdout)["query"]
+    assert json.loads(filtered.stdout)["query"]["subject_component"] == "target-api"
+    assert not missing.exists()
+
+
 def test_query_cli_validates_filters_without_creating_data_dir(tmp_path):
     import subprocess, sys
     missing = tmp_path / "missing"
@@ -129,6 +141,34 @@ def test_query_component_never_allows_subject_to_override_present_source(tmp_pat
     coding_memory.import_events([value])
     assert coding_memory.query_history(repo="heimgewebe/example",component="grabowski")["event_ids"]==[]
     assert coding_memory.query_history(repo="heimgewebe/example",component="other-producer")["event_ids"]==[value["event_id"]]
+
+
+def test_query_subject_component_is_separate_from_source_component(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); value=event(component="target-api",source_component="grabowski")
+    coding_memory.import_events([value])
+    result=coding_memory.query_history(
+        repo="heimgewebe/example",
+        component="grabowski",
+        subject_component="target-api",
+    )
+    assert result["event_ids"]==[value["event_id"]]
+    assert result["query"]["component"]=="grabowski"
+    assert result["query"]["subject_component"]=="target-api"
+    assert coding_memory.query_history(repo="heimgewebe/example",subject_component="grabowski")["event_ids"]==[]
+
+
+def test_query_subject_component_supports_host_targets(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); value=event("sha256:"+"e"*64,component="target-runtime",operation="recovery",outcome="blocked")
+    value["kind"]="agent.run.blocked"; value["subject"]={"scope":"host","host":"heim-pc","component":"target-runtime"}
+    value["data"].update({"result":"blocked","operation":"recovery","task_class":"recovery"}); coding_memory.import_events([value])
+    assert coding_memory.query_history(host="heim-pc",subject_component="target-runtime")["event_ids"]==[value["event_id"]]
+    assert coding_memory.query_history(host="heim-pc",subject_component="other")["event_ids"]==[]
+
+
+def test_query_envelope_omits_subject_component_when_unused_for_v1_compatibility(tmp_path,monkeypatch):
+    setup(tmp_path,monkeypatch); coding_memory.import_events([event()])
+    result=coding_memory.query_history(repo="heimgewebe/example",component="grabowski")
+    assert "subject_component" not in result["query"]
 
 
 def test_query_component_has_no_legacy_subject_fallback(tmp_path,monkeypatch):

--- a/tools/coding_memory.py
+++ b/tools/coding_memory.py
@@ -28,7 +28,7 @@ def load(path: Path):
 
 
 def filters(args):
-    return {
+    query_filters = {
         "repo": args.repo,
         "host": args.host,
         "component": args.component,
@@ -38,6 +38,9 @@ def filters(args):
         "since": args.since,
         "limit": args.limit,
     }
+    if args.subject_component is not None:
+        query_filters["subject_component"] = args.subject_component
+    return query_filters
 
 
 def empty_snapshot():
@@ -119,7 +122,8 @@ def main(argv=None):
         target = command.add_mutually_exclusive_group(required=True)
         target.add_argument("--repo")
         target.add_argument("--host")
-        command.add_argument("--component")
+        command.add_argument("--component", help="Filter canonical producer source.component")
+        command.add_argument("--subject-component", help="Filter task-context subject.component")
         command.add_argument("--operation", choices=sorted(coding_memory.OPERATIONS))
         command.add_argument("--task-class", choices=sorted(coding_memory.TASK_CLASSES))
         command.add_argument("--outcome", choices=sorted(coding_memory.OUTCOMES))


### PR DESCRIPTION
Implements PR #409 follow-up candidate PR409-CHRONIK-SUBJECT-COMPONENT-FILTER-V1 (Bureau event 1026).

- keeps `component` bound to canonical `source.component`
- adds explicit `subject_component` / `--subject-component` for task-context filtering
- preserves the legacy v1 query envelope when the new filter is unused
- covers repository and host targets plus CLI compatibility

Validation: 413 pytest tests passed; role contract OK; py_compile and git diff --check passed.