### PR TITLE
fix: bind outbox receipts to exact source prefixes

### DIFF
--- a/docs/chronik/agent-run-event-v0.md
+++ b/docs/chronik/agent-run-event-v0.md
@@ -86,9 +86,12 @@ python -m tools.chronik_outbox --state-root /tmp/chronik-state compact
 
 Regeln:
 
-- `append` validiert gegen das v0-Schema und schreibt eine JSONL-Datei pro Producer/Run.
-- `flush` sendet an `POST /v1/ingest?domain=agent.ledger` und erstellt ein Receipt.
-- `compact` entfernt nur Dateien, für die ein Flush-Receipt existiert.
+- `append` validiert gegen das v0-Schema und schreibt unter einem dateigebundenen Lock in eine JSONL-Datei pro Producer/Run.
+- `flush` sendet nur den noch nicht quittierten JSONL-Suffix an `POST /v1/ingest?domain=agent.ledger`.
+- Ein Receipt bindet den erfolgreich gesendeten Präfix an kanonischen Quellpfad, Byteanzahl, Ereignisanzahl und SHA-256.
+- Ein Append während des Netzaufrufs bleibt als neuer, nicht quittierter Suffix erhalten.
+- `compact` entfernt eine Datei nur, wenn das Receipt exakt den vollständigen aktuellen Dateisnapshot abdeckt.
+- Alte, beschädigte oder nicht snapshotgebundene Receipts berechtigen weder zum erneuten automatischen Flush noch zur Kompaktierung; sie erfordern eine gesonderte Prüfung.
 - Kein Agentenlauf darf vom Outbox-Prototyp abhängig werden.
 
 ## Beispiele

--- a/tests/test_chronik_outbox.py
+++ b/tests/test_chronik_outbox.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from pathlib import Path
 
@@ -12,6 +13,22 @@ FIXTURE = ROOT / "tests" / "fixtures" / "agent-ledger" / "agent-run-completed.v0
 def load_event():
     with FIXTURE.open("r", encoding="utf-8") as handle:
         return json.load(handle)
+
+
+def blocked_event():
+    event = load_event()
+    event["kind"] = "agent.run.blocked"
+    event["event_id"] = "sha256:" + "b" * 64
+    event["ts"] = "2026-07-02T12:10:00Z"
+    event["data"] = {"result": "blocked", "blocker_code": "task-failed"}
+    return event
+
+
+def encoded_event(event):
+    return (
+        json.dumps(event, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        + b"\n"
+    )
 
 
 def test_append_event_writes_one_run_file(tmp_path):
@@ -45,7 +62,7 @@ def test_status_reports_pending_file(tmp_path):
     assert entries[0].flushed is False
 
 
-def test_flush_file_posts_agent_ledger_domain_and_writes_receipt(tmp_path):
+def test_flush_file_posts_agent_ledger_domain_and_writes_bound_receipt(tmp_path):
     event = load_event()
     path = chronik_outbox.append_event(event, tmp_path)
     calls = []
@@ -68,8 +85,12 @@ def test_flush_file_posts_agent_ledger_domain_and_writes_receipt(tmp_path):
     assert calls[0][2] == "secret"
     assert calls[0][3] == 1.5
     receipt_body = json.loads(receipt.read_text(encoding="utf-8"))
+    assert receipt_body["receipt_version"] == chronik_outbox.RECEIPT_VERSION
     assert receipt_body["domain"] == "agent.ledger"
+    assert receipt_body["source_path"] == str(path.resolve())
     assert receipt_body["event_count"] == 1
+    assert receipt_body["source_bytes"] == path.stat().st_size
+    assert receipt_body["source_sha256"] == hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def test_compact_removes_flushed_files_only(tmp_path):
@@ -87,6 +108,135 @@ def test_compact_removes_flushed_files_only(tmp_path):
     assert removed == [path]
     assert not path.exists()
     assert chronik_outbox.receipt_path(path).exists()
+
+
+def test_append_after_flush_invalidates_receipt_and_blocks_compaction(tmp_path):
+    path = chronik_outbox.append_event(load_event(), tmp_path)
+    chronik_outbox.flush_file(
+        path,
+        base_url="http://chronik.test",
+        token="secret",
+        sender=lambda url, payload, token, timeout: (202, "ok"),
+    )
+
+    assert chronik_outbox.append_event(blocked_event(), tmp_path) == path
+
+    entries = chronik_outbox.status(tmp_path)
+    assert len(entries) == 1
+    assert entries[0].events == 2
+    assert entries[0].flushed is False
+    assert chronik_outbox.compact(tmp_path) == []
+    assert path.exists()
+
+
+def test_flush_all_sends_only_suffix_after_bound_receipt(tmp_path):
+    path = chronik_outbox.append_event(load_event(), tmp_path)
+    chronik_outbox.flush_file(
+        path,
+        base_url="http://chronik.test",
+        token="secret",
+        sender=lambda url, payload, token, timeout: (202, "ok"),
+    )
+    chronik_outbox.append_event(blocked_event(), tmp_path)
+    calls = []
+
+    def fake_sender(url, payload, token, timeout):
+        calls.append(payload)
+        return 202, "ok"
+
+    receipts = chronik_outbox.flush_all(
+        state_root=tmp_path,
+        base_url="http://chronik.test",
+        token="secret",
+        sender=fake_sender,
+    )
+
+    assert receipts == [chronik_outbox.receipt_path(path)]
+    assert len(calls) == 1
+    assert [event["kind"] for event in calls[0]] == ["agent.run.blocked"]
+    receipt = json.loads(chronik_outbox.receipt_path(path).read_text(encoding="utf-8"))
+    assert receipt["event_count"] == 2
+    assert receipt["source_bytes"] == path.stat().st_size
+    assert chronik_outbox.status(tmp_path)[0].flushed is True
+    assert chronik_outbox.compact(tmp_path) == [path]
+
+
+def test_append_during_send_records_only_sent_prefix(tmp_path):
+    path = chronik_outbox.append_event(load_event(), tmp_path)
+    appended = blocked_event()
+
+    def appending_sender(url, payload, token, timeout):
+        with path.open("ab") as handle:
+            handle.write(encoded_event(appended))
+            handle.flush()
+        return 202, "ok"
+
+    receipt_path = chronik_outbox.flush_file(
+        path,
+        base_url="http://chronik.test",
+        token="secret",
+        sender=appending_sender,
+    )
+
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["event_count"] == 1
+    assert receipt["source_bytes"] < path.stat().st_size
+    entry = chronik_outbox.status(tmp_path)[0]
+    assert entry.events == 2
+    assert entry.flushed is False
+    assert chronik_outbox.compact(tmp_path) == []
+
+    calls = []
+    chronik_outbox.flush_all(
+        state_root=tmp_path,
+        base_url="http://chronik.test",
+        token="secret",
+        sender=lambda url, payload, token, timeout: (calls.append(payload) or (202, "ok")),
+    )
+    assert [[event["kind"] for event in payload] for payload in calls] == [["agent.run.blocked"]]
+    assert chronik_outbox.status(tmp_path)[0].flushed is True
+
+
+def test_non_append_change_after_send_writes_no_receipt(tmp_path):
+    path = chronik_outbox.append_event(load_event(), tmp_path)
+
+    def replacing_sender(url, payload, token, timeout):
+        path.write_bytes(encoded_event(blocked_event()))
+        return 202, "ok"
+
+    with pytest.raises(chronik_outbox.OutboxError, match="non-append-only"):
+        chronik_outbox.flush_file(
+            path,
+            base_url="http://chronik.test",
+            token="secret",
+            sender=replacing_sender,
+        )
+
+    assert path.exists()
+    assert not chronik_outbox.receipt_path(path).exists()
+    entry = chronik_outbox.status(tmp_path)[0]
+    assert entry.events == 1
+    assert entry.flushed is False
+
+
+def test_malformed_receipt_never_authorizes_flush_or_compaction(tmp_path):
+    path = chronik_outbox.append_event(load_event(), tmp_path)
+    receipt = chronik_outbox.receipt_path(path)
+    receipt.parent.mkdir(parents=True, exist_ok=True)
+    receipt.write_text("{}\n", encoding="utf-8")
+    calls = []
+
+    assert chronik_outbox.status(tmp_path)[0].flushed is False
+    assert chronik_outbox.compact(tmp_path) == []
+    with pytest.raises(chronik_outbox.OutboxError, match="not snapshot-bound"):
+        chronik_outbox.flush_all(
+            state_root=tmp_path,
+            base_url="http://chronik.test",
+            token="secret",
+            sender=lambda url, payload, token, timeout: (calls.append(payload) or (202, "ok")),
+        )
+    assert calls == []
+    assert path.exists()
 
 
 def test_flush_failure_keeps_pending_file_and_no_receipt(tmp_path):
@@ -107,12 +257,8 @@ def test_flush_failure_keeps_pending_file_and_no_receipt(tmp_path):
 
 def test_preview_renders_views_without_receipts(tmp_path):
     completed = load_event()
-    blocked = load_event()
-    blocked["kind"] = "agent.run.blocked"
-    blocked["event_id"] = "sha256:" + "b" * 64
+    blocked = blocked_event()
     blocked["source"]["run_id"] = "run-blocked"
-    blocked["ts"] = "2026-07-02T12:10:00Z"
-    blocked["data"] = {"result": "blocked", "blocker_code": "task-failed"}
     completed_path = chronik_outbox.append_event(completed, tmp_path)
     blocked_path = chronik_outbox.append_event(blocked, tmp_path)
     result = chronik_outbox.preview(tmp_path)

--- a/tools/chronik_outbox.py
+++ b/tools/chronik_outbox.py
@@ -8,24 +8,30 @@ files that already have successful flush receipts.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
 import sys
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Iterator
 from urllib.parse import urlencode
 
 import httpx
 import jsonschema
+from filelock import FileLock, Timeout
 from jsonschema import Draft7Validator
 
 DOMAIN = "agent.ledger"
 DEFAULT_STATE_ROOT = Path(".local/state")
 SCHEMA_PATH = Path(__file__).resolve().parents[1] / "docs" / "chronik" / "agent-run-event-v0.schema.json"
 SAFE_PART = re.compile(r"[^A-Za-z0-9_.-]+")
+SHA256_HEX = re.compile(r"[0-9a-f]{64}")
+OUTBOX_LOCK_TIMEOUT = 10.0
+RECEIPT_VERSION = 1
 
 
 class OutboxError(RuntimeError):
@@ -38,6 +44,20 @@ class OutboxFileStatus:
     events: int
     bytes: int
     flushed: bool
+
+
+@dataclass(frozen=True)
+class OutboxSnapshot:
+    raw: bytes
+    events: tuple[dict[str, Any], ...]
+    sha256: str
+
+
+@dataclass(frozen=True)
+class ReceiptProgress:
+    source_bytes: int
+    event_count: int
+    source_sha256: str
 
 
 def load_json(path: Path) -> Any:
@@ -81,13 +101,173 @@ def receipt_path(path: Path) -> Path:
     return path.parent / ".flushed" / f"{path.name}.receipt.json"
 
 
+def lock_path(path: Path) -> Path:
+    return path.parent / ".locks" / f"{path.name}.lock"
+
+
+def canonical_source_path(path: Path) -> str:
+    return str(path.resolve())
+
+
+@contextmanager
+def outbox_lock(path: Path) -> Iterator[None]:
+    lock = lock_path(path)
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with FileLock(str(lock), timeout=OUTBOX_LOCK_TIMEOUT):
+            yield
+    except Timeout as exc:
+        raise OutboxError(f"timed out waiting for outbox lock: {path}") from exc
+
+
+def _parse_events(path: Path, raw: bytes) -> tuple[dict[str, Any], ...]:
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise OutboxError(f"{path}: invalid utf-8") from exc
+
+    events: list[dict[str, Any]] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise OutboxError(f"{path}:{line_number}: invalid jsonl") from exc
+        validate_event(event)
+        events.append(event)
+    return tuple(events)
+
+
+def _snapshot_unlocked(path: Path) -> OutboxSnapshot:
+    raw = path.read_bytes()
+    return OutboxSnapshot(
+        raw=raw,
+        events=_parse_events(path, raw),
+        sha256=hashlib.sha256(raw).hexdigest(),
+    )
+
+
+def _load_receipt(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    receipt = receipt_path(path)
+    try:
+        value = load_json(receipt)
+    except FileNotFoundError:
+        return False, None
+    except (OSError, TypeError, ValueError):
+        return True, None
+    return True, value if isinstance(value, dict) else None
+
+
+def _receipt_progress(path: Path, snapshot: OutboxSnapshot) -> ReceiptProgress | None:
+    exists, receipt = _load_receipt(path)
+    if not exists:
+        return None
+    if receipt is None or receipt.get("receipt_version") != RECEIPT_VERSION:
+        raise OutboxError(f"{path}: existing receipt is not snapshot-bound")
+
+    source_bytes = receipt.get("source_bytes")
+    event_count = receipt.get("event_count")
+    source_sha256 = receipt.get("source_sha256")
+    valid_scalars = (
+        isinstance(source_bytes, int)
+        and not isinstance(source_bytes, bool)
+        and isinstance(event_count, int)
+        and not isinstance(event_count, bool)
+        and isinstance(source_sha256, str)
+        and SHA256_HEX.fullmatch(source_sha256) is not None
+    )
+    if not valid_scalars:
+        raise OutboxError(f"{path}: existing receipt has invalid snapshot fields")
+    if (
+        receipt.get("domain") != DOMAIN
+        or receipt.get("source_path") != canonical_source_path(path)
+        or source_bytes < 0
+        or source_bytes > len(snapshot.raw)
+        or event_count < 0
+    ):
+        raise OutboxError(f"{path}: existing receipt does not match the outbox identity")
+
+    prefix = snapshot.raw[:source_bytes]
+    if source_bytes > 0 and not prefix.endswith(b"\n"):
+        raise OutboxError(f"{path}: receipt ends inside a JSONL record")
+    if hashlib.sha256(prefix).hexdigest() != source_sha256:
+        raise OutboxError(f"{path}: receipt prefix hash does not match the outbox")
+    if len(_parse_events(path, prefix)) != event_count:
+        raise OutboxError(f"{path}: receipt event count does not match its prefix")
+    return ReceiptProgress(
+        source_bytes=source_bytes,
+        event_count=event_count,
+        source_sha256=source_sha256,
+    )
+
+
+def _receipt_covers_snapshot(progress: ReceiptProgress | None, snapshot: OutboxSnapshot) -> bool:
+    return (
+        progress is not None
+        and progress.source_bytes == len(snapshot.raw)
+        and progress.event_count == len(snapshot.events)
+        and progress.source_sha256 == snapshot.sha256
+    )
+
+
+def _fsync_directory(path: Path) -> None:
+    directory_fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def _write_receipt(path: Path, snapshot: OutboxSnapshot, status_code: int) -> Path:
+    receipt = receipt_path(path)
+    receipt.parent.mkdir(parents=True, exist_ok=True)
+    payload = (
+        json.dumps(
+            {
+                "receipt_version": RECEIPT_VERSION,
+                "domain": DOMAIN,
+                "source_path": canonical_source_path(path),
+                "source_bytes": len(snapshot.raw),
+                "source_sha256": snapshot.sha256,
+                "event_count": len(snapshot.events),
+                "flushed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "status_code": status_code,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+    temporary = receipt.with_name(f".{receipt.name}.tmp")
+    try:
+        with temporary.open("wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, receipt)
+        _fsync_directory(receipt.parent)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+    return receipt
+
+
 def append_event(event: dict[str, Any], state_root: Path = DEFAULT_STATE_ROOT) -> Path:
     validate_event(event)
     path = outbox_path(event, state_root)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(event, sort_keys=True, separators=(",", ":")))
-        handle.write("\n")
+    encoded = (
+        json.dumps(event, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        + b"\n"
+    )
+    with outbox_lock(path):
+        with path.open("ab") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
     return path
 
 
@@ -96,30 +276,28 @@ def iter_outbox_files(state_root: Path = DEFAULT_STATE_ROOT) -> Iterable[Path]:
 
 
 def read_events(path: Path) -> list[dict[str, Any]]:
-    events: list[dict[str, Any]] = []
-    with path.open("r", encoding="utf-8") as handle:
-        for line_number, line in enumerate(handle, start=1):
-            if not line.strip():
-                continue
-            try:
-                event = json.loads(line)
-            except json.JSONDecodeError as exc:
-                raise OutboxError(f"{path}:{line_number}: invalid jsonl") from exc
-            validate_event(event)
-            events.append(event)
-    return events
+    with outbox_lock(path):
+        return list(_snapshot_unlocked(path).events)
 
 
 def status(state_root: Path = DEFAULT_STATE_ROOT) -> list[OutboxFileStatus]:
     entries: list[OutboxFileStatus] = []
     for path in iter_outbox_files(state_root):
-        event_count = sum(1 for line in path.read_text(encoding="utf-8").splitlines() if line.strip())
+        try:
+            with outbox_lock(path):
+                snapshot = _snapshot_unlocked(path)
+                try:
+                    progress = _receipt_progress(path, snapshot)
+                except OutboxError:
+                    progress = None
+        except FileNotFoundError:
+            continue
         entries.append(
             OutboxFileStatus(
                 path=path,
-                events=event_count,
-                bytes=path.stat().st_size,
-                flushed=receipt_path(path).exists(),
+                events=len(snapshot.events),
+                bytes=len(snapshot.raw),
+                flushed=_receipt_covers_snapshot(progress, snapshot),
             )
         )
     return entries
@@ -148,33 +326,34 @@ def flush_file(
     timeout: float = 5.0,
     sender: Callable[[str, list[dict[str, Any]], str, float], tuple[int, str]] | None = None,
 ) -> Path:
-    events = read_events(path)
-    if not events:
-        raise OutboxError(f"{path} contains no events")
+    with outbox_lock(path):
+        snapshot = _snapshot_unlocked(path)
+        progress = _receipt_progress(path, snapshot)
+        if _receipt_covers_snapshot(progress, snapshot):
+            return receipt_path(path)
+        source_bytes = progress.source_bytes if progress is not None else 0
+        pending_events = list(_parse_events(path, snapshot.raw[source_bytes:]))
+    if not pending_events:
+        raise OutboxError(f"{path} contains no pending events")
+
     resolved_token = token or token_from_env()
     url = f"{base_url.rstrip('/')}/v1/ingest?{urlencode({'domain': DOMAIN})}"
-    status_code, text = (sender or post_json)(url, events, resolved_token, timeout)
+    status_code, text = (sender or post_json)(url, pending_events, resolved_token, timeout)
     if not 200 <= status_code < 300:
         raise OutboxError(f"flush failed for {path}: HTTP {status_code}: {text}")
 
-    receipt = receipt_path(path)
-    receipt.parent.mkdir(parents=True, exist_ok=True)
-    receipt.write_text(
-        json.dumps(
-            {
-                "domain": DOMAIN,
-                "source_path": str(path),
-                "event_count": len(events),
-                "flushed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-                "status_code": status_code,
-            },
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    return receipt
+    with outbox_lock(path):
+        try:
+            current_raw = path.read_bytes()
+        except OSError as exc:
+            raise OutboxError(
+                f"flush succeeded for {path}, but the source cannot be verified; no receipt written"
+            ) from exc
+        if not current_raw.startswith(snapshot.raw):
+            raise OutboxError(
+                f"flush succeeded for {path}, but the source changed non-append-only; no receipt written"
+            )
+        return _write_receipt(path, snapshot, status_code)
 
 
 def flush_all(
@@ -187,7 +366,13 @@ def flush_all(
 ) -> list[Path]:
     receipts: list[Path] = []
     for path in iter_outbox_files(state_root):
-        if receipt_path(path).exists():
+        try:
+            with outbox_lock(path):
+                snapshot = _snapshot_unlocked(path)
+                progress = _receipt_progress(path, snapshot)
+                if _receipt_covers_snapshot(progress, snapshot):
+                    continue
+        except FileNotFoundError:
             continue
         receipts.append(flush_file(path, base_url=base_url, token=token, timeout=timeout, sender=sender))
     return receipts
@@ -196,9 +381,20 @@ def flush_all(
 def compact(state_root: Path = DEFAULT_STATE_ROOT) -> list[Path]:
     removed: list[Path] = []
     for path in iter_outbox_files(state_root):
-        if receipt_path(path).exists():
-            path.unlink()
-            removed.append(path)
+        try:
+            with outbox_lock(path):
+                snapshot = _snapshot_unlocked(path)
+                try:
+                    progress = _receipt_progress(path, snapshot)
+                except OutboxError:
+                    continue
+                if not _receipt_covers_snapshot(progress, snapshot):
+                    continue
+                path.unlink()
+                _fsync_directory(path.parent)
+        except FileNotFoundError:
+            continue
+        removed.append(path)
     return removed
 
 


### PR DESCRIPTION
## Problem

`tools.chronik_outbox` treated receipt existence as proof that the current outbox bytes were flushed. Appending another event to the same run file could therefore make `flush` skip the new event and let `compact` delete it.

The HTTP ingest path is append-only rather than event-ID-idempotent, so retrying the complete file would also duplicate already accepted events.

## Change

- serialize cooperating append, status, flush and compaction operations with a per-file lock
- bind versioned receipts to canonical source path, flushed byte prefix, event count and SHA-256
- send only the unacknowledged JSONL suffix
- preserve appends that occur during the network request as pending suffix data
- write receipts atomically and compact only an exact fully acknowledged snapshot
- fail closed for legacy, malformed or identity-mismatched receipts
- document the receipt and migration boundary

## Validation

- focused outbox regressions: 12 passed
- full repository validation: 418 passed
- Chronik role contract: passed
- local health/version/ingest/events smoke: passed
- `git diff --check` and compileall: passed

Self-review is bound to `e359519531bb18be301a1df4bbf177c2a5a788f0`.