### PR TITLE
fix: make agent ledger delivery idempotent

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,6 +39,7 @@ from storage import (
     list_domains,
     sanitize_domain,
     write_payload,
+    write_payload_unique,
 )
 from provenance import ProvenanceError, validate_provenance, has_provenance
 from validation import (
@@ -482,18 +483,45 @@ def _raise_storage_http_exception(exc: StorageError) -> NoReturn:
     # Fallback for other storage errors (e.g. symlinks, invalid paths)
     # We assume most are client errors (bad domain/path), but some might be internal
     msg = str(exc).lower()
+    if msg.startswith("conflicting event_id:"):
+        raise HTTPException(status_code=409, detail="conflicting event_id") from exc
+    if msg == "missing event_id":
+        raise HTTPException(status_code=400, detail="missing event_id") from exc
     if "invalid target" in msg:
         raise HTTPException(status_code=400, detail="invalid target") from exc
     raise HTTPException(status_code=500, detail="storage error") from exc
 
 
-def _process_and_write_combined(dom: str, items: list[Any]) -> None:
-    """Helper to run both processing and writing in a single threadpool task.
+def _agent_ledger_result(*, requested: int, written: int, skipped: int) -> dict[str, Any]:
+    if written == requested:
+        result = "accepted"
+    elif skipped == requested:
+        result = "replayed"
+    else:
+        result = "mixed"
+    return {
+        "domain": "agent.ledger",
+        "result": result,
+        "requested": requested,
+        "written": written,
+        "skipped_existing": skipped,
+    }
 
-    This reduces context switching overhead compared to running them separately.
-    """
+
+def _process_and_write_combined(dom: str, items: list[Any]) -> dict[str, Any] | None:
+    """Process one request and preserve existing semantics outside agent.ledger."""
     lines_to_write = _process_items(items, dom)
+    if not lines_to_write:
+        return None
+    if dom == "agent.ledger":
+        written, skipped = write_payload_unique(dom, lines_to_write, identity_key="event_id")
+        return _agent_ledger_result(
+            requested=len(lines_to_write),
+            written=written,
+            skipped=skipped,
+        )
     write_payload(dom, lines_to_write)
+    return None
 
 
 @app.post(
@@ -558,10 +586,12 @@ async def ingest_v1(
         dom = _sanitize_domain(first_item_domain)
 
     try:
-        await run_in_threadpool(_process_and_write_combined, dom, items)
+        result = await run_in_threadpool(_process_and_write_combined, dom, items)
     except StorageError as exc:
         _raise_storage_http_exception(exc)
 
+    if result is not None:
+        return JSONResponse(result, status_code=202)
     return PlainTextResponse("ok", status_code=202)
 
 
@@ -592,10 +622,12 @@ async def ingest(
     # Objekt oder Array → JSONL: eine kompakte Zeile pro Eintrag
     items = obj if isinstance(obj, list) else [obj]
     try:
-        await run_in_threadpool(_process_and_write_combined, dom, items)
+        result = await run_in_threadpool(_process_and_write_combined, dom, items)
     except StorageError as exc:
         _raise_storage_http_exception(exc)
 
+    if result is not None:
+        return JSONResponse(result, status_code=202)
     return PlainTextResponse("ok", status_code=202)
 
 

--- a/docs/chronik/agent-run-event-v0.md
+++ b/docs/chronik/agent-run-event-v0.md
@@ -23,6 +23,29 @@ POST /v1/ingest?domain=agent.ledger
 
 Die Domain ist bewusst **nicht** Teil des Event-Payloads. Chronik setzt die Storage-Domain im Envelope.
 
+## Zustellungs-Idempotenz
+
+Für `agent.ledger` ist `event_id` die stabile Zustellidentität. Chronik prüft diese Identität unter derselben exklusiven Ledger-Sperre wie den Append:
+
+- eine neue `event_id` wird genau einmal an das Ledger angehängt;
+- dieselbe `event_id` mit kanonisch identischem Eventinhalt ist ein erfolgreicher Replay und erzeugt keine zweite Ledgerzeile;
+- dieselbe `event_id` mit abweichendem kanonischem Eventinhalt wird als HTTP `409` abgewiesen;
+- ein Batch mit einem Identitätskonflikt wird vollständig vor dem Append abgewiesen.
+
+Erfolgreiche Requests liefern HTTP `202` mit einem JSON-Ergebnis:
+
+```json
+{
+  "domain": "agent.ledger",
+  "result": "accepted",
+  "requested": 1,
+  "written": 1,
+  "skipped_existing": 0
+}
+```
+
+`result` ist `accepted`, `replayed` oder `mixed`. Damit kann ein Producer nach einem Timeout oder verlorenen Response sicher erneut zustellen. Der Vertrag behauptet keine Exactly-once-Netzwerkübertragung; er stellt ausschließlich sicher, dass wiederholte Zustellung zum gleichen Ledgerzustand konvergiert. Andere Domains behalten ihre bisherige Append-Semantik und ihre bisherige Plaintext-Antwort.
+
 ## Erlaubte Kinds
 
 - `agent.run.started`

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,7 @@ import secrets
 import string
 import errno
 import fcntl
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import MagicMock
 from fastapi.testclient import TestClient
@@ -39,6 +40,27 @@ def create_event_file(mock_storage, domain, lines):
 
 def _test_secret() -> str:
     return "test-token"
+
+
+AGENT_EVENT_FIXTURE = (
+    Path(__file__).resolve().parent
+    / "fixtures"
+    / "agent-ledger"
+    / "agent-run-completed.v0.json"
+)
+
+
+def _agent_event() -> dict:
+    return json.loads(AGENT_EVENT_FIXTURE.read_text(encoding="utf-8"))
+
+
+def _agent_ledger_post(client, payload):
+    return client.post(
+        "/v1/ingest?domain=agent.ledger",
+        headers={"X-Auth": _test_secret(), "Content-Type": "application/json"},
+        json=payload,
+    )
+
 
 # --- Pagination Tests (New Logic) ---
 
@@ -676,6 +698,137 @@ def test_ingest_v1_ndjson(monkeypatch, tmp_path: Path, client):
         assert "received_at" in data2
         assert data2["domain"] == domain
         assert data2["payload"] == payload[1]
+
+
+def test_agent_ledger_empty_batch_preserves_noop_response(
+    monkeypatch, tmp_path: Path, client
+):
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+
+    response = client.post(
+        "/ingest/agent.ledger",
+        headers={"X-Auth": _test_secret(), "Content-Type": "application/json"},
+        json=[],
+    )
+
+    assert response.status_code == 202
+    assert response.text == "ok"
+    assert not list(tmp_path.glob("*.jsonl"))
+
+
+def test_agent_ledger_identical_replay_is_idempotent(monkeypatch, tmp_path: Path, client):
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+    event = _agent_event()
+
+    accepted = _agent_ledger_post(client, event)
+    replayed = _agent_ledger_post(client, event)
+
+    assert accepted.status_code == 202
+    assert accepted.json() == {
+        "domain": "agent.ledger",
+        "result": "accepted",
+        "requested": 1,
+        "written": 1,
+        "skipped_existing": 0,
+    }
+    assert replayed.status_code == 202
+    assert replayed.json() == {
+        "domain": "agent.ledger",
+        "result": "replayed",
+        "requested": 1,
+        "written": 0,
+        "skipped_existing": 1,
+    }
+    target = storage.safe_target_path("agent.ledger")
+    assert len(target.read_text(encoding="utf-8").splitlines()) == 1
+
+
+def test_agent_ledger_conflicting_replay_fails_closed(monkeypatch, tmp_path: Path, client):
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+    event = _agent_event()
+    conflict = _agent_event()
+    conflict["data"]["summary"] = "Different content for the same event identity."
+
+    assert _agent_ledger_post(client, event).status_code == 202
+    response = _agent_ledger_post(client, conflict)
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "conflicting event_id"}
+    target = storage.safe_target_path("agent.ledger")
+    stored = [json.loads(line) for line in target.read_text(encoding="utf-8").splitlines()]
+    assert len(stored) == 1
+    assert stored[0]["payload"] == event
+
+
+def test_agent_ledger_mixed_batch_reports_new_and_replayed(monkeypatch, tmp_path: Path, client):
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+    existing = _agent_event()
+    new_event = _agent_event()
+    new_event["event_id"] = "01JZ0000000000000000000002"
+    new_event["source"]["run_id"] = "run-20260702-120001"
+
+    assert _agent_ledger_post(client, existing).status_code == 202
+    response = _agent_ledger_post(client, [existing, new_event])
+
+    assert response.status_code == 202
+    assert response.json() == {
+        "domain": "agent.ledger",
+        "result": "mixed",
+        "requested": 2,
+        "written": 1,
+        "skipped_existing": 1,
+    }
+    target = storage.safe_target_path("agent.ledger")
+    stored = [json.loads(line)["payload"]["event_id"] for line in target.read_text().splitlines()]
+    assert stored == [existing["event_id"], new_event["event_id"]]
+
+
+def test_agent_ledger_conflicting_batch_appends_nothing(monkeypatch, tmp_path: Path, client):
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+    existing = _agent_event()
+    conflict = _agent_event()
+    conflict["data"]["result"] = "blocked"
+    new_event = _agent_event()
+    new_event["event_id"] = "01JZ0000000000000000000003"
+    new_event["source"]["run_id"] = "run-20260702-120002"
+
+    assert _agent_ledger_post(client, existing).status_code == 202
+    response = _agent_ledger_post(client, [new_event, conflict])
+
+    assert response.status_code == 409
+    target = storage.safe_target_path("agent.ledger")
+    stored = [json.loads(line)["payload"]["event_id"] for line in target.read_text().splitlines()]
+    assert stored == [existing["event_id"]]
+
+
+def test_agent_ledger_requires_event_id(monkeypatch, tmp_path: Path, client):
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+    event = _agent_event()
+    del event["event_id"]
+
+    response = _agent_ledger_post(client, event)
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "missing event_id"}
+    assert not list(tmp_path.glob("*.jsonl"))
+
+
+def test_agent_ledger_concurrent_identical_delivery_writes_once(
+    monkeypatch, tmp_path: Path, client
+):
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+    event = _agent_event()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        responses = list(executor.map(lambda _: _agent_ledger_post(client, event), range(2)))
+
+    assert [response.status_code for response in responses] == [202, 202]
+    assert sorted(response.json()["result"] for response in responses) == [
+        "accepted",
+        "replayed",
+    ]
+    target = storage.safe_target_path("agent.ledger")
+    assert len(target.read_text(encoding="utf-8").splitlines()) == 1
 
 
 def test_symlink_attack_rejected_after_resolve(monkeypatch, tmp_path):


### PR DESCRIPTION
## Problem

After Chronik accepts an `agent.ledger` batch, a producer can time out or lose the response before its local prefix receipt is durable. Retrying the unacknowledged events previously appended duplicate ledger rows.

## Change

- route only `agent.ledger` through Chronik's existing ledger-authoritative `event_id` identity index
- accept canonically identical replays without appending another row
- reject the same `event_id` with different event content as HTTP 409
- validate a complete batch before any append and preserve existing storage rollback/locking semantics
- return typed HTTP 202 results: `accepted`, `replayed` or `mixed`
- keep all other domains and empty-batch behavior unchanged
- document convergence semantics without claiming exactly-once transport

## Validation

- focused agent-ledger regressions: 7 passed
- complete API tests: 50 passed before the final empty-batch addition; the final complete suite includes it
- final Chronik validation: 425 passed
- Chronik role contract: passed
- local health/version/agent-ledger ingest/readback smoke: passed
- compileall and `git diff --check`: passed

## Scope

- `app.py`
- `tests/test_app.py`
- `docs/chronik/agent-run-event-v0.md`

Bureau task: `CHRONIK-CODING-MEMORY-V1-T001`
Bureau run: `BUR-RUN-20260730T132223Z-0a40837bba`
Self-review bound to `917a07626026a7c1d1db5418268843c38523c2d4`.