### PR TITLE
fix: separate Chronik delivery and persistence metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -248,8 +248,23 @@ from prometheus_client import Counter, Histogram
 # Event ingestion metrics
 events_ingested_total = Counter(
     "chronik_events_ingested_total",
-    "Total number of events ingested",
+    "Validated events presented for ingestion; not proof of durable persistence",
     ["domain", "event_type"],
+)
+
+events_persisted_total = Counter(
+    "chronik_events_persisted_total",
+    "Events durably appended to authoritative Chronik storage",
+    ["domain"],
+)
+
+agent_ledger_delivery_total = Counter(
+    "chronik_agent_ledger_delivery_total",
+    "Agent ledger ingest requests by bounded delivery outcome",
+    ["result"],
+)
+AGENT_LEDGER_DELIVERY_RESULTS: Final[frozenset[str]] = frozenset(
+    {"accepted", "replayed", "mixed", "conflict", "invalid_identity"}
 )
 
 events_rejected_total = Counter(
@@ -260,7 +275,7 @@ events_rejected_total = Counter(
 
 events_signal_strength = Counter(
     "chronik_events_signal_strength_total",
-    "Events by signal strength level",
+    "Validated delivery attempts by signal strength level; not durable writes",
     ["domain", "signal_strength"],
 )
 
@@ -473,19 +488,45 @@ def _process_items(items: list[Any], dom: str) -> list[str]:
     return lines
 
 
-def _raise_storage_http_exception(exc: StorageError) -> NoReturn:
-    """Map storage errors to HTTP exceptions."""
+def _record_persisted_events(dom: str, count: int) -> None:
+    """Record confirmed durable events without changing the ingest outcome."""
+    if count <= 0:
+        return
+    try:
+        events_persisted_total.labels(domain=_sanitize_metric_label(dom)).inc(count)
+    except Exception:
+        logger.exception("failed to record durable event metric", extra={"domain": dom})
+
+
+def _record_agent_ledger_outcome(result: str) -> None:
+    """Record one fixed agent.ledger result without affecting ledger semantics."""
+    if result not in AGENT_LEDGER_DELIVERY_RESULTS:
+        logger.error("unsupported agent.ledger delivery result")
+        return
+    try:
+        agent_ledger_delivery_total.labels(result=result).inc()
+    except Exception:
+        logger.exception("failed to record agent.ledger delivery metric")
+
+
+def _raise_storage_http_exception(
+    exc: StorageError, *, domain: str | None = None
+) -> NoReturn:
+    """Map storage errors to HTTP exceptions without claiming persistence."""
     if isinstance(exc, StorageFullError):
         raise HTTPException(status_code=507, detail="insufficient storage") from exc
     if isinstance(exc, StorageBusyError):
         raise HTTPException(status_code=429, detail="busy, try again") from exc
 
-    # Fallback for other storage errors (e.g. symlinks, invalid paths)
-    # We assume most are client errors (bad domain/path), but some might be internal
+    # Fallback for other storage errors (e.g. symlinks, invalid paths).
     msg = str(exc).lower()
     if msg.startswith("conflicting event_id:"):
+        if domain == "agent.ledger":
+            _record_agent_ledger_outcome("conflict")
         raise HTTPException(status_code=409, detail="conflicting event_id") from exc
     if msg == "missing event_id":
+        if domain == "agent.ledger":
+            _record_agent_ledger_outcome("invalid_identity")
         raise HTTPException(status_code=400, detail="missing event_id") from exc
     if "invalid target" in msg:
         raise HTTPException(status_code=400, detail="invalid target") from exc
@@ -515,12 +556,16 @@ def _process_and_write_combined(dom: str, items: list[Any]) -> dict[str, Any] | 
         return None
     if dom == "agent.ledger":
         written, skipped = write_payload_unique(dom, lines_to_write, identity_key="event_id")
-        return _agent_ledger_result(
+        result = _agent_ledger_result(
             requested=len(lines_to_write),
             written=written,
             skipped=skipped,
         )
+        _record_persisted_events(dom, written)
+        _record_agent_ledger_outcome(str(result["result"]))
+        return result
     write_payload(dom, lines_to_write)
+    _record_persisted_events(dom, len(lines_to_write))
     return None
 
 
@@ -588,7 +633,7 @@ async def ingest_v1(
     try:
         result = await run_in_threadpool(_process_and_write_combined, dom, items)
     except StorageError as exc:
-        _raise_storage_http_exception(exc)
+        _raise_storage_http_exception(exc, domain=dom)
 
     if result is not None:
         return JSONResponse(result, status_code=202)
@@ -624,7 +669,7 @@ async def ingest(
     try:
         result = await run_in_threadpool(_process_and_write_combined, dom, items)
     except StorageError as exc:
-        _raise_storage_http_exception(exc)
+        _raise_storage_http_exception(exc, domain=dom)
 
     if result is not None:
         return JSONResponse(result, status_code=202)

--- a/docs/chronik/agent-run-event-v0.md
+++ b/docs/chronik/agent-run-event-v0.md
@@ -46,6 +46,17 @@ Erfolgreiche Requests liefern HTTP `202` mit einem JSON-Ergebnis:
 
 `result` ist `accepted`, `replayed` oder `mixed`. Damit kann ein Producer nach einem Timeout oder verlorenen Response sicher erneut zustellen. Der Vertrag behauptet keine Exactly-once-Netzwerkübertragung; er stellt ausschließlich sicher, dass wiederholte Zustellung zum gleichen Ledgerzustand konvergiert. Andere Domains behalten ihre bisherige Append-Semantik und ihre bisherige Plaintext-Antwort.
 
+## Metriksemantik
+
+Chronik trennt Zustellversuche von dauerhaft geschriebenen Ereignissen:
+
+- `chronik_events_ingested_total{domain,event_type}` ist aus Kompatibilitätsgründen weiterhin vorhanden. Der Counter zählt validierte Ereignisse, die dem Ingest-Pfad übergeben wurden. Er ist **kein** Beleg für einen dauerhaften Ledger-Append.
+- `chronik_events_signal_strength_total{domain,signal_strength}` beschreibt ebenfalls validierte Zustellversuche und keine dauerhaften Writes.
+- `chronik_events_persisted_total{domain}` steigt erst, nachdem die zuständige Storage-Operation erfolgreich zurückgekehrt ist. Bei `agent.ledger` entspricht die Erhöhung exakt dem Feld `written` des Idempotenz-Ergebnisses.
+- `chronik_agent_ledger_delivery_total{result}` zählt Requests mit der festen Ergebnisvokabel `accepted`, `replayed`, `mixed`, `conflict` oder `invalid_identity`. Der Counter verwendet keine `event_id`, Payloadwerte, Repositorynamen oder andere unbeschränkte Labels.
+
+Daraus folgt: Ein identischer Replay erhöht die Zustellversuchs- und Ergebniszähler, aber nicht `chronik_events_persisted_total`. Ein Identitätskonflikt oder eine fehlende Identität erhöht ebenfalls keinen Durable-Write-Counter.
+
 ## Erlaubte Kinds
 
 - `agent.run.started`

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -30,6 +30,17 @@ def mock_storage(monkeypatch, tmp_path):
     monkeypatch.setenv("CHRONIK_TOKEN", "test-token")
     return tmp_path
 
+
+@pytest.fixture
+def isolated_rate_limiter():
+    """Keep request-heavy metric regressions from leaking into later tests."""
+    app.limiter.reset()
+    try:
+        yield
+    finally:
+        app.limiter.reset()
+
+
 def create_event_file(mock_storage, domain, lines):
     """Helper to create a domain file with specific lines."""
     p = mock_storage / f"{domain}.jsonl"
@@ -60,6 +71,10 @@ def _agent_ledger_post(client, payload):
         headers={"X-Auth": _test_secret(), "Content-Type": "application/json"},
         json=payload,
     )
+
+
+def _counter_value(counter, **labels) -> float:
+    return float(counter.labels(**labels)._value.get())
 
 
 # --- Pagination Tests (New Logic) ---
@@ -572,6 +587,19 @@ def test_metrics_endpoint_exposed(client):
     response = client.get("/metrics")
     assert response.status_code == 200
     assert "http_requests" in response.text
+    assert (
+        "# HELP chronik_events_ingested_total Validated events presented for "
+        "ingestion; not proof of durable persistence"
+    ) in response.text
+    assert (
+        "# HELP chronik_events_persisted_total Events durably appended to "
+        "authoritative Chronik storage"
+    ) in response.text
+    assert (
+        "# HELP chronik_events_signal_strength_total Validated delivery attempts "
+        "by signal strength level; not durable writes"
+    ) in response.text
+    assert "chronik_agent_ledger_delivery_total" in response.text
 
 
 def test_lock_timeout_returns_429(monkeypatch, client):
@@ -698,6 +726,100 @@ def test_ingest_v1_ndjson(monkeypatch, tmp_path: Path, client):
         assert "received_at" in data2
         assert data2["domain"] == domain
         assert data2["payload"] == payload[1]
+
+
+def test_agent_ledger_metrics_separate_attempts_writes_and_outcomes(
+    monkeypatch, tmp_path: Path, client, isolated_rate_limiter
+):
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+    event = _agent_event()
+    second = _agent_event()
+    second["event_id"] = "01JZ0000000000000000000099"
+    second["source"]["run_id"] = "run-20260702-129999"
+    conflict = _agent_event()
+    conflict["data"]["summary"] = "Conflicting content."
+    invalid = _agent_event()
+    del invalid["event_id"]
+
+    persisted_before = _counter_value(
+        app.events_persisted_total, domain="agent.ledger"
+    )
+    attempts_before = _counter_value(
+        app.events_ingested_total,
+        domain="agent.ledger",
+        event_type="agent.run.completed",
+    )
+    outcomes_before = {
+        result: _counter_value(app.agent_ledger_delivery_total, result=result)
+        for result in ("accepted", "replayed", "mixed", "conflict", "invalid_identity")
+    }
+
+    assert _agent_ledger_post(client, event).json()["result"] == "accepted"
+    assert _agent_ledger_post(client, event).json()["result"] == "replayed"
+    assert _agent_ledger_post(client, [event, second]).json()["result"] == "mixed"
+    assert _agent_ledger_post(client, conflict).status_code == 409
+    assert _agent_ledger_post(client, invalid).status_code == 400
+
+    assert _counter_value(
+        app.events_persisted_total, domain="agent.ledger"
+    ) == persisted_before + 2
+    assert _counter_value(
+        app.events_ingested_total,
+        domain="agent.ledger",
+        event_type="agent.run.completed",
+    ) == attempts_before + 6
+    for result in outcomes_before:
+        assert _counter_value(
+            app.agent_ledger_delivery_total, result=result
+        ) == outcomes_before[result] + 1
+
+
+def test_persisted_metric_changes_only_after_generic_storage_success(
+    monkeypatch, tmp_path: Path, client, isolated_rate_limiter
+):
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+    domain = "metrics.example"
+    before = _counter_value(app.events_persisted_total, domain=domain)
+
+    success = client.post(
+        f"/v1/ingest?domain={domain}",
+        headers={"X-Auth": _test_secret(), "Content-Type": "application/json"},
+        json=[{"data": "one"}, {"data": "two"}],
+    )
+    assert success.status_code == 202
+    assert _counter_value(app.events_persisted_total, domain=domain) == before + 2
+
+    def fail_write(_domain, _lines):
+        raise storage.StorageError("synthetic write failure")
+
+    monkeypatch.setattr(app, "write_payload", fail_write)
+    failed = client.post(
+        f"/v1/ingest?domain={domain}",
+        headers={"X-Auth": _test_secret(), "Content-Type": "application/json"},
+        json={"data": "three"},
+    )
+    assert failed.status_code == 500
+    assert _counter_value(app.events_persisted_total, domain=domain) == before + 2
+
+
+def test_metric_backend_failure_does_not_change_durable_ingest(
+    monkeypatch, tmp_path: Path, client, isolated_rate_limiter
+):
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+
+    class BrokenCounter:
+        def labels(self, **_labels):
+            raise RuntimeError("synthetic metrics failure")
+
+    monkeypatch.setattr(app, "events_persisted_total", BrokenCounter())
+    monkeypatch.setattr(app, "agent_ledger_delivery_total", BrokenCounter())
+
+    response = _agent_ledger_post(client, _agent_event())
+
+    assert response.status_code == 202
+    assert response.json()["result"] == "accepted"
+    target = storage.safe_target_path("agent.ledger")
+    assert len(target.read_text(encoding="utf-8").splitlines()) == 1
 
 
 def test_agent_ledger_empty_batch_preserves_noop_response(


### PR DESCRIPTION
## Problem

Chronik's existing `chronik_events_ingested_total` and signal-strength counters are incremented after payload validation but before the storage result. After agent-ledger idempotency, identical replays and conflicts could therefore be misread as newly durable events.

## Change

- retain `chronik_events_ingested_total` for compatibility and define it explicitly as validated delivery attempts
- define signal-strength metrics as attempt-level
- add `chronik_events_persisted_total{domain}` after confirmed storage success only
- count `agent.ledger` durable events by the idempotent storage result's exact `written` value
- add bounded `chronik_agent_ledger_delivery_total{result}` outcomes: `accepted`, `replayed`, `mixed`, `conflict`, `invalid_identity`
- make metric recording best-effort so a metrics-backend failure cannot change an already durable ingest result
- preserve all HTTP bodies, status semantics, ledger bytes, index state and non-agent ingestion behavior

## Validation

- focused metric and idempotency regressions: 11 passed
- complete Chronik test suite: 428 passed
- role contract: passed
- local health/version/agent-ledger ingest/readback smoke: passed
- `git diff --check` and compileall: passed
- rate-limit test isolation added after the full suite exposed cross-test bucket leakage

## Scope

- `app.py`
- `tests/test_app.py`
- `docs/chronik/agent-run-event-v0.md`

Planned Bureau task: `CHRONIK-CODING-MEMORY-V1-T002`
Reviewed proposal: `f51f833badcc73733176faab348632acc46d8bdc1013ecf662bd8f830415d987`
Self-review bound to `9327a40ec51ca0dbb8725c243cb9cbb7e35ce96d`.