### PR TITLE
fix: apply outcome-export redaction to array elements

### DIFF
--- a/operator_outcome_export.py
+++ b/operator_outcome_export.py
@@ -66,29 +66,38 @@ def _parse_utc_second(value: str, *, label: str) -> datetime:
 
 
 def _walk(value: Any, *, path: str = "$"):
+    """Yield ``(path, key, item)`` for every dict entry and every list element.
+
+    List elements carry no field name, so ``key`` is ``None`` for them. They are
+    still yielded: free-form arrays such as ``payload.does_not_establish`` hold
+    bare strings that must pass the same redaction boundary as object values.
+    """
     if isinstance(value, dict):
         for key, item in value.items():
             yield path, key, item
             yield from _walk(item, path=f"{path}.{key}")
     elif isinstance(value, list):
         for index, item in enumerate(value):
-            yield from _walk(item, path=f"{path}[{index}]")
+            item_path = f"{path}[{index}]"
+            yield item_path, None, item
+            yield from _walk(item, path=item_path)
 
 
 def _validate_redaction_boundary(export: dict[str, Any]) -> None:
     for path, key, value in _walk(export):
-        if key.lower() in _RAW_KEYS:
+        if key is not None and key.lower() in _RAW_KEYS:
             raise ValueError(f"raw output field is forbidden at {path}.{key}")
         if not isinstance(value, str):
             continue
+        location = f"{path}.{key}" if key is not None else path
         if _PRIVATE_PATH_RE.search(value):
-            raise ValueError(f"private absolute path is forbidden at {path}.{key}")
+            raise ValueError(f"private absolute path is forbidden at {location}")
         if (
             _PRIVATE_KEY_MARKER in value
             or any(prefix in value for prefix in _SECRET_PREFIXES)
             or _SECRET_ASSIGNMENT_RE.search(value)
         ):
-            raise ValueError(f"secret-shaped material is forbidden at {path}.{key}")
+            raise ValueError(f"secret-shaped material is forbidden at {location}")
 
 
 def validate_operator_outcome_export(export: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_operator_outcome_export_contract.py
+++ b/tests/test_operator_outcome_export_contract.py
@@ -78,6 +78,34 @@ def test_secret_shaped_text_and_private_paths_are_rejected():
             contract.validate_operator_outcome_export(export)
 
 
+def test_secret_shaped_text_in_free_form_arrays_is_rejected():
+    for leaked in ("Authorization: Bearer secret-value", "/home/alex/private/receipt.json"):
+        export = load_fixture()
+        export["payload"]["does_not_establish"] = ["causal_route_superiority", leaked]
+        export["payload_sha256"] = contract.sha256_json(export["payload"])
+        export["event_id"] = contract.event_id_for(export)
+        with pytest.raises(ValueError, match="forbidden"):
+            contract.validate_operator_outcome_export(export)
+
+
+def test_redaction_walk_reaches_bare_strings_inside_arrays():
+    located = {path: value for path, key, value in contract._walk({"a": ["first", "second"]})}
+    assert located["$.a[0]"] == "first"
+    assert located["$.a[1]"] == "second"
+
+
+def test_redaction_walk_still_flags_raw_keys_nested_in_arrays():
+    export = load_fixture()
+    export["payload"]["friction"] = [{
+        "kind": "unknown",
+        "surface": "runtime",
+        "resolved": False,
+        "stdout": "build output",
+    }]
+    with pytest.raises(ValueError, match="raw output field is forbidden"):
+        contract._validate_redaction_boundary(export)
+
+
 def test_future_inverted_freshness_is_rejected_and_status_is_not_persisted():
     export = load_fixture()
     assert "status" not in export["freshness"]


### PR DESCRIPTION
## Problem

`_validate_redaction_boundary` in `operator_outcome_export.py` never inspected bare strings inside arrays.

`_walk` yielded a triple only for **dict** entries. For a list it recursed into each element, but a scalar element is neither a dict nor a list, so it yielded nothing and fell out of the walk silently.

The pinned Heimlern payload schema defines `does_not_establish` as a free-form `array` of `string` (`minLength: 1`, no pattern). Secret-shaped material placed there passed **both** schema validation and the redaction boundary:

```
LEAKED (accepted): 'Authorization: Bearer secret-value'
LEAKED (accepted): '/home/alex/private/receipt.json'
```

Strings inside dicts nested in arrays (e.g. `friction[].fallback`) were already covered, which is why existing tests did not catch this.

## Fix

`_walk` now also yields each list element, with `key = None` since list elements carry no field name. The raw-key lookup is guarded with `key is not None`, and the error location renders as `$.payload.does_not_establish[1]` instead of a bogus `...None` suffix.

The change is monotonic: it can only add rejections, never remove them. Dicts nested in lists are still yielded exactly once, so there is no duplicate reporting.

## Tests

- `test_secret_shaped_text_in_free_form_arrays_is_rejected` — Bearer token and private absolute path in `does_not_establish` are now rejected.
- `test_redaction_walk_reaches_bare_strings_inside_arrays` — the walk reaches `$.a[0]` / `$.a[1]`.
- `test_redaction_walk_still_flags_raw_keys_nested_in_arrays` — regression guard for the `key is not None` change.

The two redaction tests were verified to **fail against the pre-fix source** and pass after it.

## Validation

- `./scripts/validate-local.sh` — `431 passed`, role contract OK, `local validation smoke ok` (baseline on `main` was 428).
- `python scripts/check_role.py .ai-context.yml` — `role-contract: OK chronik`
- `ruff check` — `All checks passed!`

## Scope

Touches only `operator_outcome_export.py` and its contract test. Disjoint from every unmerged Chronik branch (`storage.py`, `coding_memory.py`, `scripts/check_role.py`, `docs/chronik/*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)