### PR TITLE
Harden Chronik agent test environment contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,15 +17,18 @@ Chronik is the append-only event ledger and historical evidence axis for the ope
 Before proposing repository changes, run the narrowest relevant checks. For operator-role or service-bootstrap changes, use:
 
 ```bash
-python3 scripts/check_role.py .ai-context.yml
-python3 -m pytest -q tests/test_service_artifacts.py tests/test_chronik_outbox.py tests/test_agent_ledger_view.py
+./scripts/setup-venv.sh
+./.venv/bin/python scripts/check_role.py .ai-context.yml
+./.venv/bin/python -m pytest -q tests/test_service_artifacts.py tests/test_chronik_outbox.py tests/test_agent_ledger_view.py
 ```
 
 For broader application changes, prefer:
 
 ```bash
-python3 -m pytest -q
+make test
 ```
+
+Use `make validate-local` for the complete role and API smoke validation. Direct test runs with the system Python are not the repository contract because runtime dependencies intentionally live in `.venv`.
 
 ## Key documents
 

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,17 @@ AUTH_TOKEN := $(if $(CHRONIK_TOKEN),$(CHRONIK_TOKEN))
 # Prefer the project venv (has pyyaml etc.); fall back to system python.
 PYTHON := $(if $(wildcard .venv/bin/python),./.venv/bin/python,python)
 
-.PHONY: dev ingest-test ensure-token validate-local check-role
+.PHONY: dev ingest-test ensure-token test validate-local check-role
 
 dev:
 	uvicorn app:app --reload --port $(PORT)
 
 check-role:
 	$(PYTHON) scripts/check_role.py
+
+test:
+	./scripts/setup-venv.sh
+	./.venv/bin/python -m pytest -q
 
 validate-local:
 	./scripts/validate-local.sh

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -34,8 +34,9 @@ Default service paths:
 Repository-only validation:
 
 ```bash
-python3 scripts/check_role.py .ai-context.yml
-python3 -m pytest -q tests/test_service_artifacts.py tests/test_chronik_outbox.py tests/test_agent_ledger_view.py
+./scripts/setup-venv.sh
+./.venv/bin/python scripts/check_role.py .ai-context.yml
+./.venv/bin/python -m pytest -q tests/test_service_artifacts.py tests/test_chronik_outbox.py tests/test_agent_ledger_view.py
 ```
 
 These checks do not start or enable a user service.

--- a/tests/test_service_artifacts.py
+++ b/tests/test_service_artifacts.py
@@ -89,6 +89,19 @@ def test_operator_docs_close_ai_context_loop(runbook_content: str):
     assert "CHRONIK_TOKEN=dev" in runbook_content
 
 
+def test_agent_test_commands_use_project_virtualenv():
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+
+    assert "python3 -m pytest" not in agents
+    assert "./scripts/setup-venv.sh" in agents
+    assert "./.venv/bin/python -m pytest -q tests/" in agents
+    assert "make test" in agents
+    assert "test:" in makefile
+    assert "./scripts/setup-venv.sh" in makefile
+    assert "./.venv/bin/python -m pytest -q" in makefile
+
+
 def test_runtime_activation_gate_has_ordered_phases(runbook_content: str):
     headings = (
         "### Effects requiring separate approval",

--- a/tests/test_service_artifacts.py
+++ b/tests/test_service_artifacts.py
@@ -89,13 +89,16 @@ def test_operator_docs_close_ai_context_loop(runbook_content: str):
     assert "CHRONIK_TOKEN=dev" in runbook_content
 
 
-def test_agent_test_commands_use_project_virtualenv():
+def test_agent_test_commands_use_project_virtualenv(runbook_content: str):
     agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
 
     assert "python3 -m pytest" not in agents
+    assert "python3 -m pytest" not in runbook_content
     assert "./scripts/setup-venv.sh" in agents
+    assert "./scripts/setup-venv.sh" in runbook_content
     assert "./.venv/bin/python -m pytest -q tests/" in agents
+    assert "./.venv/bin/python -m pytest -q tests/" in runbook_content
     assert "make test" in agents
     assert "test:" in makefile
     assert "./scripts/setup-venv.sh" in makefile


### PR DESCRIPTION
## Problem

`AGENTS.md` instructed automated contributors to run `python3 -m pytest`, while Chronik intentionally installs runtime and test dependencies into `.venv`. On a clean host Python this produced 21 collection errors (`filelock` and `limits` missing), although the canonical project environment passed the suite.

## Change

- add a canonical `make test` target that prepares `.venv` and runs the complete suite
- route narrow agent and operator-runbook checks through `scripts/setup-venv.sh` and `.venv/bin/python`
- add a repository contract test preventing both instruction surfaces from returning to naked system-Python pytest commands

## Review follow-up

Codex identified the duplicate system-Python command in `docs/runbook.md`. The runbook now uses the same project-venv contract as `AGENTS.md`; the regression test covers both files. The review thread is resolved on head `b9c2a2c0c0f08911e910183db3962e02cc6b70a3`.

## Evidence

- focused contract suite before review follow-up: 19 passed
- complete suite before review follow-up: 432 passed
- role contract: PASS
- `git diff --check`: PASS
- `make -n test` resolves to setup plus `.venv` pytest
- current-head GitHub workflows: 5/5 PASS (`wgx-guard`, `validate-chronik-fixtures`, `ai-context guard`, `validate (aussen fixtures)`, `Validate fixtures against contracts`)
- pull request mergeable; no unresolved review thread

## Self-review

PASS on current head. The change affects only contributor test entrypoints, the operator runbook and their regression contract. It does not alter Chronik ledger behavior, runtime activation, service state, dependencies, generated JSONL data, queue authority or deployment.