### PR TITLE
fix(outbox): bound importer journal output

### DIFF
--- a/deploy/systemd/user/chronik-outbox-import.service
+++ b/deploy/systemd/user/chronik-outbox-import.service
@@ -5,8 +5,10 @@ ConditionPathIsDirectory=%h/.local/state/grabowski/chronik-outbox
 
 [Service]
 Type=oneshot
+LogRateLimitIntervalSec=30s
+LogRateLimitBurst=200
 WorkingDirectory=%h/.local/lib/chronik/current
-ExecStart=%h/repos/chronik/.venv/bin/python %h/.local/lib/chronik/current/tools/coding_memory.py --data-dir %h/.local/state/chronik/data import-outbox --outbox-root %h/.local/state --receipt-dir %h/.local/state/chronik/import-receipts
+ExecStart=%h/repos/chronik/.venv/bin/python %h/.local/lib/chronik/current/tools/coding_memory.py --data-dir %h/.local/state/chronik/data import-outbox --outbox-root %h/.local/state --receipt-dir %h/.local/state/chronik/import-receipts --output-mode summary
 UMask=0077
 NoNewPrivileges=true
 PrivateTmp=true

--- a/docs/chronik/direct-operator-memory-v1.md
+++ b/docs/chronik/direct-operator-memory-v1.md
@@ -159,7 +159,12 @@ Die Unit `chronik-outbox-import.service` ist ein gehärteter One-shot-Importer.
 Der Timer startet sie alle zwei Minuten. Dieselbe One-shot-Unit wird von systemd
 nicht parallel ein zweites Mal gestartet; ein noch aktiver Lauf verhindert damit
 überlappende Importer. Die Unit darf die Grabowski-Outbox nur lesen und
-ausschließlich unter `~/.local/state/chronik` schreiben.
+ausschließlich unter `~/.local/state/chronik` schreiben. Für systemd nutzt die
+Unit `import-outbox --output-mode summary`: Pro Lauf entsteht genau ein kompakter
+JSON-Einzeiler mit Zählern. Dateiinventare werden nicht ausgegeben; höchstens drei
+gekürzte Fehlerstichproben bleiben sichtbar. Zusätzlich begrenzt die Unit die
+Journalrate auf 200 Meldungen je 30 Sekunden. Der CLI-Standard bleibt `full`,
+damit bestehende interaktive und maschinelle Aufrufer kompatibel bleiben.
 
 Der HTTP-Dienst `chronik.service` ist für diesen Pfad nicht erforderlich. Er
 soll nur aktiviert werden, wenn ein konkreter externer Konsument den HTTP-Ingest

--- a/tests/test_grabowski_outbox_import.py
+++ b/tests/test_grabowski_outbox_import.py
@@ -329,6 +329,113 @@ def test_import_outbox_cli_returns_nonzero_on_any_invalid_source(tmp_path):
     assert json.loads(result.stdout)["errors"]
 
 
+def test_import_outbox_cli_summary_is_single_line_and_bounded(tmp_path):
+    import subprocess
+    import sys
+
+    data = tmp_path / "data"
+    receipts = tmp_path / "receipts"
+    outbox = tmp_path / "state"
+    write_outbox(outbox, [event("agent.run.completed", "a")])
+    root = Path(__file__).parents[1]
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(root / "tools" / "coding_memory.py"),
+            "--data-dir",
+            str(data),
+            "import-outbox",
+            "--outbox-root",
+            str(outbox),
+            "--receipt-dir",
+            str(receipts),
+            "--output-mode",
+            "summary",
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0
+    assert len(result.stdout.splitlines()) == 1
+    assert len(result.stdout.encode("utf-8")) < 4096
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "chronik-grabowski-outbox-summary.v1"
+    assert payload["events_imported"] == 1
+    assert payload["error_count"] == 0
+    assert payload["error_samples"] == []
+    assert "bundle_inventory" not in payload
+
+
+def test_import_outbox_cli_summary_preserves_bounded_error_signal(tmp_path):
+    import subprocess
+    import sys
+
+    data = tmp_path / "data"
+    receipts = tmp_path / "receipts"
+    outbox = tmp_path / "state"
+    write_outbox(
+        outbox,
+        [event("agent.run.completed", "e", source_repo="heimgewebe/other")],
+    )
+    root = Path(__file__).parents[1]
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(root / "tools" / "coding_memory.py"),
+            "--data-dir",
+            str(data),
+            "import-outbox",
+            "--outbox-root",
+            str(outbox),
+            "--receipt-dir",
+            str(receipts),
+            "--output-mode",
+            "summary",
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 2
+    assert len(result.stdout.splitlines()) == 1
+    assert len(result.stdout.encode("utf-8")) < 4096
+    payload = json.loads(result.stdout)
+    assert payload["error_count"] == 1
+    assert len(payload["error_samples"]) == 1
+    assert "not produced by canonical Grabowski" in payload["error_samples"][0]["error"]
+    assert payload["errors_truncated"] is False
+
+
+def test_outbox_summary_has_a_hard_worst_case_size_bound():
+    from tools import coding_memory as coding_memory_cli
+
+    result = {
+        "schema_version": "chronik-grabowski-outbox-batch.v2",
+        **{key: 0 for key in coding_memory_cli.OUTBOX_SUMMARY_KEYS},
+        "identity_index_mode": "unused",
+        "identity_index_full_rebuild": False,
+        "errors": [
+            {
+                "source_path": "/very/long/" + "source" * 200,
+                "error": "failure " * 500,
+            }
+            for _ in range(20)
+        ],
+        "historical_only": True,
+    }
+
+    summary = coding_memory_cli.outbox_summary(result)
+    encoded = json.dumps(summary, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    assert len(encoded) < 4096
+    assert summary["error_count"] == 20
+    assert len(summary["error_samples"]) == 3
+    assert summary["errors_truncated"] is True
+
+
 def test_import_preserves_repository_target_identity(tmp_path, monkeypatch):
     data, receipts, outbox = configure(tmp_path, monkeypatch)
     value = event("agent.run.completed", "d")

--- a/tests/test_service_artifacts.py
+++ b/tests/test_service_artifacts.py
@@ -64,6 +64,9 @@ def test_outbox_import_units_are_direct_bounded_and_hardened():
     timer = (ROOT / "deploy" / "systemd" / "user" / "chronik-outbox-import.timer").read_text(encoding="utf-8")
 
     assert "import-outbox" in service
+    assert "--output-mode summary" in service
+    assert "LogRateLimitIntervalSec=30s" in service
+    assert "LogRateLimitBurst=200" in service
     assert "plexer" not in service.lower()
     assert "ReadOnlyPaths=%h/.local/state/grabowski/chronik-outbox" in service
     assert "ReadWritePaths=%h/.local/state/chronik" in service

--- a/tools/coding_memory.py
+++ b/tools/coding_memory.py
@@ -17,6 +17,66 @@ sys.path.insert(0, root_path)
 import coding_memory  # noqa: E402
 
 
+OUTBOX_SUMMARY_KEYS = (
+    "files_seen",
+    "loose_files_seen",
+    "bundle_manifests_seen",
+    "bundles_valid",
+    "bundled_sources_seen",
+    "sources_seen_total",
+    "sources_after_deduplication",
+    "orphan_bundles",
+    "files_imported_or_confirmed",
+    "files_unchanged",
+    "receipts_written",
+    "receipts_reused",
+    "loose_sources_imported_or_confirmed",
+    "bundled_sources_imported_or_confirmed",
+    "events_imported",
+    "events_skipped_existing",
+    "target_scans",
+    "target_records_scanned",
+    "identity_index_mode",
+    "identity_index_full_rebuild",
+    "identity_index_entries_after",
+)
+OUTBOX_SUMMARY_ERROR_LIMIT = 3
+OUTBOX_SUMMARY_SOURCE_LIMIT = 160
+OUTBOX_SUMMARY_ERROR_TEXT_LIMIT = 320
+
+
+def _bounded_text(value: object, limit: int) -> str:
+    text = str(value)
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def outbox_summary(result: dict) -> dict:
+    errors = result.get("errors") if isinstance(result.get("errors"), list) else []
+    summary = {
+        "schema_version": "chronik-grabowski-outbox-summary.v1",
+        "result_schema_version": result.get("schema_version"),
+        **{key: result.get(key) for key in OUTBOX_SUMMARY_KEYS},
+        "error_count": len(errors),
+        "error_samples": [
+            {
+                "source_path": _bounded_text(
+                    item.get("source_path", "<unknown>"),
+                    OUTBOX_SUMMARY_SOURCE_LIMIT,
+                ),
+                "error": _bounded_text(
+                    item.get("error", "unknown error"),
+                    OUTBOX_SUMMARY_ERROR_TEXT_LIMIT,
+                ),
+            }
+            for item in errors[:OUTBOX_SUMMARY_ERROR_LIMIT]
+            if isinstance(item, dict)
+        ],
+        "errors_truncated": len(errors) > OUTBOX_SUMMARY_ERROR_LIMIT,
+        "historical_only": result.get("historical_only") is True,
+    }
+    return summary
+
+
 def load(path: Path):
     text = path.read_text(encoding="utf-8").strip()
     if not text:
@@ -106,6 +166,12 @@ def main(argv=None):
     outbox = sub.add_parser("import-outbox")
     outbox.add_argument("--outbox-root", type=Path, default=Path.home() / ".local/state")
     outbox.add_argument("--receipt-dir", type=Path)
+    outbox.add_argument(
+        "--output-mode",
+        choices=("full", "summary"),
+        default="full",
+        help="Emit the full result or one bounded single-line summary.",
+    )
 
     compact = sub.add_parser("compact-outbox")
     compact.add_argument("--outbox-root", type=Path, default=Path.home() / ".local/state")
@@ -176,7 +242,10 @@ def main(argv=None):
         print(f"chronik-coding-memory: {exc}", file=sys.stderr)
         return 2
 
-    print(json.dumps(result, indent=2, sort_keys=True))
+    if args.command == "import-outbox" and args.output_mode == "summary":
+        print(json.dumps(outbox_summary(result), sort_keys=True, separators=(",", ":")))
+    else:
+        print(json.dumps(result, indent=2, sort_keys=True))
     if args.command in {"import-outbox", "compact-outbox"} and result["errors"]:
         return 2
     return 0


### PR DESCRIPTION
## Summary

- add `import-outbox --output-mode summary` while keeping `full` as the compatibility default
- emit one compact result line with scalar counters and at most three bounded error samples
- exclude `bundle_inventory` and per-source result payloads from systemd journal output
- add a unit-local journal rate limit

## Root cause

A boot-window journal readback attributed 9,998 of 10,000 stored user-journal messages in 30 seconds to `chronik-outbox-import.service`. The pretty-printed full batch result then caused roughly 42,000 messages to be suppressed on each two-minute importer run.

## Bureau binding

- Task: `CHRONIK-ECOSYSTEM-CLOSEOUT-V1-T012`
- Candidate: `candidate-f994db92fe605952e45d4e42`
- Live-register event: `1825`
- Reviewed proposal: `26a2077fb53cbee1598d61ecd933d5d7079ece30f39af6bfa765b57f8a1d16b7`

## Validation

- focused importer/unit tests: 43 passed
- complete Chronik suite: 435 passed
- role contract: passed
- local health/version/agent.ledger ingest and readback smoke: passed
- `git diff --check`: passed

## Runtime gate

Merge alone does not claim the incident closed. After exact-head review and green CI, deploy an immutable release, install the unit from the same commit, run at least one timer cycle, and verify no new global journald suppression. Rollback restores the previous release and unit without changing ledger, receipt, or outbox bytes.
