### PR TITLE
fix(outbox): bound the importer summary line in bytes

### DIFF
--- a/docs/chronik/direct-operator-memory-v1.md
+++ b/docs/chronik/direct-operator-memory-v1.md
@@ -162,9 +162,15 @@ nicht parallel ein zweites Mal gestartet; ein noch aktiver Lauf verhindert damit
 ausschließlich unter `~/.local/state/chronik` schreiben. Für systemd nutzt die
 Unit `import-outbox --output-mode summary`: Pro Lauf entsteht genau ein kompakter
 JSON-Einzeiler mit Zählern. Dateiinventare werden nicht ausgegeben; höchstens drei
-gekürzte Fehlerstichproben bleiben sichtbar. Zusätzlich begrenzt die Unit die
-Journalrate auf 200 Meldungen je 30 Sekunden. Der CLI-Standard bleibt `full`,
-damit bestehende interaktive und maschinelle Aufrufer kompatibel bleiben.
+gekürzte Fehlerstichproben bleiben sichtbar. Die Zeile bleibt garantiert unter
+4096 Bytes: Gekürzt wird nach der JSON-kodierten Bytelänge, nicht nach
+Zeichenzahl, weil Escaping ein Zeichen auf bis zu zwölf Bytes ausdehnen kann.
+Reicht das nicht, entfallen zusätzlich Fehlerstichproben; `errors_truncated`
+bleibt dann `true`. Die aggregierte `error_count` und der Exitcode `2` bei
+Fehlern bleiben in jedem Fall erhalten. Zusätzlich begrenzt die Unit die
+Journalrate unabhängig vom User-Manager auf 200 Meldungen je 30 Sekunden. Der
+CLI-Standard bleibt `full`, damit bestehende interaktive und maschinelle Aufrufer
+kompatibel bleiben.
 
 Der HTTP-Dienst `chronik.service` ist für diesen Pfad nicht erforderlich. Er
 soll nur aktiviert werden, wenn ein konkreter externer Konsument den HTTP-Ingest

--- a/tests/test_grabowski_outbox_import.py
+++ b/tests/test_grabowski_outbox_import.py
@@ -436,6 +436,124 @@ def test_outbox_summary_has_a_hard_worst_case_size_bound():
     assert summary["errors_truncated"] is True
 
 
+@pytest.mark.parametrize(
+    "filler",
+    [
+        "s",
+        "ä",  # two UTF-8 bytes, six once JSON-escaped
+        "\x01",  # control character, six bytes once escaped
+        "\U0001f600",  # astral plane, twelve bytes as an escaped surrogate pair
+        "\n",
+        '"\\',
+    ],
+    ids=["ascii", "latin1", "control", "astral", "newline", "quote-backslash"],
+)
+def test_outbox_summary_line_stays_bounded_for_any_error_text(filler):
+    from tools import coding_memory as coding_memory_cli
+
+    result = {
+        "schema_version": "chronik-grabowski-outbox-batch.v2" + filler * 500,
+        **{key: 0 for key in coding_memory_cli.OUTBOX_SUMMARY_KEYS},
+        "identity_index_mode": filler * 500,
+        "identity_index_full_rebuild": False,
+        "errors": [
+            {"source_path": filler * 2000, "error": filler * 5000} for _ in range(20)
+        ],
+        "historical_only": True,
+    }
+
+    line = coding_memory_cli.outbox_summary_line(result)
+
+    # +1 for the newline print() appends, so the whole journal write is bounded.
+    assert len(line.encode("utf-8")) + 1 < coding_memory_cli.OUTBOX_SUMMARY_MAX_BYTES
+    assert coding_memory_cli.OUTBOX_SUMMARY_MAX_BYTES == 4096
+    assert "\n" not in line
+    payload = json.loads(line)
+    assert payload["error_count"] == 20
+    assert len(payload["error_samples"]) <= 3
+    assert payload["errors_truncated"] is True
+
+
+def test_outbox_summary_line_falls_back_when_a_counter_itself_is_oversized():
+    from tools import coding_memory as coding_memory_cli
+
+    result = {
+        "schema_version": "chronik-grabowski-outbox-batch.v2",
+        **{key: 0 for key in coding_memory_cli.OUTBOX_SUMMARY_KEYS},
+        "files_seen": list(range(50000)),
+        "identity_index_mode": "unused",
+        "identity_index_full_rebuild": False,
+        "errors": [{"source_path": "/a.jsonl", "error": "boom"}],
+        "historical_only": True,
+    }
+
+    line = coding_memory_cli.outbox_summary_line(result)
+    payload = json.loads(line)
+
+    assert len(line.encode("utf-8")) + 1 < coding_memory_cli.OUTBOX_SUMMARY_MAX_BYTES
+    assert payload["error_count"] == 1
+    assert payload["errors_truncated"] is True
+    assert payload["schema_version"] == "chronik-grabowski-outbox-summary.v1"
+    # Dropping error samples cannot help here, so the minimal payload is used.
+    assert "files_seen" not in payload
+
+
+def test_outbox_summary_keeps_short_error_text_intact():
+    from tools import coding_memory as coding_memory_cli
+
+    result = {
+        "schema_version": "chronik-grabowski-outbox-batch.v2",
+        **{key: 0 for key in coding_memory_cli.OUTBOX_SUMMARY_KEYS},
+        "identity_index_mode": "unused",
+        "identity_index_full_rebuild": False,
+        "errors": [{"source_path": "/a/b.jsonl", "error": "unreadable: Ümläut"}],
+        "historical_only": True,
+    }
+
+    payload = json.loads(coding_memory_cli.outbox_summary_line(result))
+
+    assert payload["error_samples"] == [
+        {"source_path": "/a/b.jsonl", "error": "unreadable: Ümläut"}
+    ]
+    assert payload["errors_truncated"] is False
+    assert payload["identity_index_mode"] == "unused"
+    assert payload["result_schema_version"] == "chronik-grabowski-outbox-batch.v2"
+
+
+def test_import_outbox_cli_default_output_mode_keeps_the_full_schema(tmp_path):
+    import subprocess
+    import sys
+
+    data = tmp_path / "data"
+    receipts = tmp_path / "receipts"
+    outbox = tmp_path / "state"
+    write_outbox(outbox, [event("agent.run.completed", "a")])
+    root = Path(__file__).parents[1]
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(root / "tools" / "coding_memory.py"),
+            "--data-dir",
+            str(data),
+            "import-outbox",
+            "--outbox-root",
+            str(outbox),
+            "--receipt-dir",
+            str(receipts),
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "chronik-grabowski-outbox-batch.v2"
+    assert payload["errors"] == []
+    assert "bundle_inventory" in payload
+    assert "error_samples" not in payload
+
+
 def test_import_preserves_repository_target_identity(tmp_path, monkeypatch):
     data, receipts, outbox = configure(tmp_path, monkeypatch)
     value = event("agent.run.completed", "d")

--- a/tools/coding_memory.py
+++ b/tools/coding_memory.py
@@ -43,19 +43,45 @@ OUTBOX_SUMMARY_KEYS = (
 OUTBOX_SUMMARY_ERROR_LIMIT = 3
 OUTBOX_SUMMARY_SOURCE_LIMIT = 160
 OUTBOX_SUMMARY_ERROR_TEXT_LIMIT = 320
+OUTBOX_SUMMARY_LABEL_LIMIT = 96
+OUTBOX_SUMMARY_MAX_BYTES = 4096
+
+
+def _encoded_length(text: str) -> int:
+    """Bytes this string costs inside the emitted summary line, quotes included."""
+    return len(json.dumps(text).encode("utf-8"))
 
 
 def _bounded_text(value: object, limit: int) -> str:
+    """Truncate so the JSON-encoded form stays within ``limit`` bytes.
+
+    Escaping expands non-ASCII and control characters (one code point can cost
+    twelve bytes as an escaped surrogate pair), so a character count is not a
+    size bound for the journal line.
+    """
     text = str(value)
-    return text if len(text) <= limit else text[: limit - 1] + "…"
+    if _encoded_length(text) <= limit:
+        return text
+    low, high = 0, len(text)
+    while low < high:
+        middle = (low + high + 1) // 2
+        if _encoded_length(text[:middle] + "…") <= limit:
+            low = middle
+        else:
+            high = middle - 1
+    return text[:low] + "…"
+
+
+def _bounded_label(value: object) -> object:
+    return _bounded_text(value, OUTBOX_SUMMARY_LABEL_LIMIT) if isinstance(value, str) else value
 
 
 def outbox_summary(result: dict) -> dict:
     errors = result.get("errors") if isinstance(result.get("errors"), list) else []
     summary = {
         "schema_version": "chronik-grabowski-outbox-summary.v1",
-        "result_schema_version": result.get("schema_version"),
-        **{key: result.get(key) for key in OUTBOX_SUMMARY_KEYS},
+        "result_schema_version": _bounded_label(result.get("schema_version")),
+        **{key: _bounded_label(result.get(key)) for key in OUTBOX_SUMMARY_KEYS},
         "error_count": len(errors),
         "error_samples": [
             {
@@ -75,6 +101,36 @@ def outbox_summary(result: dict) -> dict:
         "historical_only": result.get("historical_only") is True,
     }
     return summary
+
+
+def _encode_summary(summary: dict) -> str:
+    return json.dumps(summary, sort_keys=True, separators=(",", ":"))
+
+
+def _emitted_bytes(line: str) -> int:
+    """Journal cost of the line, including the terminator ``print`` appends."""
+    return len(line.encode("utf-8")) + 1
+
+
+def outbox_summary_line(result: dict) -> str:
+    """Render one summary line that stays below the hard journal size bound."""
+    summary = outbox_summary(result)
+    line = _encode_summary(summary)
+    while _emitted_bytes(line) >= OUTBOX_SUMMARY_MAX_BYTES and summary["error_samples"]:
+        summary["error_samples"] = summary["error_samples"][:-1]
+        summary["errors_truncated"] = True
+        line = _encode_summary(summary)
+    if _emitted_bytes(line) >= OUTBOX_SUMMARY_MAX_BYTES:
+        line = _encode_summary(
+            {
+                "schema_version": summary["schema_version"],
+                "error_count": summary["error_count"],
+                "error_samples": [],
+                "errors_truncated": True,
+                "historical_only": summary["historical_only"],
+            }
+        )
+    return line
 
 
 def load(path: Path):
@@ -243,7 +299,7 @@ def main(argv=None):
         return 2
 
     if args.command == "import-outbox" and args.output_mode == "summary":
-        print(json.dumps(outbox_summary(result), sort_keys=True, separators=(",", ":")))
+        print(outbox_summary_line(result))
     else:
         print(json.dumps(result, indent=2, sort_keys=True))
     if args.command in {"import-outbox", "compact-outbox"} and result["errors"]:


### PR DESCRIPTION
## Problem

The compact `import-outbox --output-mode summary` mode truncates the error
samples by **character** count (`OUTBOX_SUMMARY_SOURCE_LIMIT=160`,
`OUTBOX_SUMMARY_ERROR_TEXT_LIMIT=320`). JSON escaping expands one code point to
up to twelve bytes (escaped surrogate pair), so the emitted journal line was not
actually bounded. Measured on `main` (`e01d3eb`) with the existing helper:

| error/source filler | emitted line |
| --- | --- |
| ASCII | 2304 B |
| Latin-1 (`ä`) / control char | 9474 B |
| astral (`😀`) | **18078 B** |

A single non-ASCII outbox path or error text was enough to exceed the intended
4096-byte bound every two minutes.

## Change

- `_bounded_text` truncates on the **JSON-encoded UTF-8 byte length** instead of
  the character count (binary search on the safe prefix, `…` marker preserved).
- String-valued summary scalars (`result_schema_version`, `identity_index_mode`)
  are bounded the same way.
- New `outbox_summary_line` renders the final line and drops further error
  samples until the write — line **plus the newline `print` appends** — is below
  the hard `OUTBOX_SUMMARY_MAX_BYTES = 4096` bound, with a minimal fallback
  payload if even that is not enough.

Unchanged: aggregated `error_count`, the `errors_truncated` signal, the non-zero
exit on import errors, the `full` CLI default, and the full result schema.

## Verification

- Full-mode output is byte-identical between `e01d3eb` and this head for the
  same fixture (diffed, only tmp paths normalised).
- Adversarial fuzz, 4000 random code-point inputs across the whole Unicode
  range: worst emitted line 2257 B, always `< 4096`, never multi-line.
- End-to-end CLI run against eight emoji-named outbox files that all fail the
  canonical-producer check: exit `2`, one line, 1431 B, `error_count=8`,
  3 samples, `errors_truncated=true`, no bundle inventory.
- `scripts/validate-local.sh`: role contract OK, 444 tests passed, API smoke OK.

The `chronik-outbox-import.service` unit already carries the independent
`LogRateLimitIntervalSec=30s` / `LogRateLimitBurst=200`; the two-minute timer and
the sandbox are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)