### PR TITLE
fix(outbox): bound remote flush error details

### DIFF
--- a/tests/test_chronik_outbox.py
+++ b/tests/test_chronik_outbox.py
@@ -243,7 +243,7 @@ def test_flush_failure_keeps_pending_file_and_no_receipt(tmp_path):
     event = load_event()
     path = chronik_outbox.append_event(event, tmp_path)
 
-    with pytest.raises(chronik_outbox.OutboxError):
+    with pytest.raises(chronik_outbox.OutboxError, match="HTTP 503: down"):
         chronik_outbox.flush_file(
             path,
             base_url="http://chronik.test",
@@ -253,6 +253,45 @@ def test_flush_failure_keeps_pending_file_and_no_receipt(tmp_path):
 
     assert path.exists()
     assert not chronik_outbox.receipt_path(path).exists()
+
+
+@pytest.mark.parametrize("filler", ["X", "🧪", '"', "\\"])
+def test_flush_failure_bounds_and_escapes_untrusted_http_body(tmp_path, filler):
+    path = chronik_outbox.append_event(load_event(), tmp_path)
+    body = "upstream failure\r\nSECOND-LINE\t" + filler * 5000
+
+    with pytest.raises(chronik_outbox.OutboxError) as raised:
+        chronik_outbox.flush_file(
+            path,
+            base_url="http://chronik.test",
+            token="secret",
+            sender=lambda url, payload, token, timeout: (503, body),
+        )
+
+    prefix = f"flush failed for {path}: HTTP 503: "
+    message = str(raised.value)
+    assert message.startswith(prefix)
+    detail = message[len(prefix) :]
+    assert len(detail.encode("utf-8")) <= chronik_outbox.HTTP_ERROR_DETAIL_MAX_BYTES
+    assert r"\r\nSECOND-LINE\t" in detail
+    assert "\r" not in message
+    assert "\n" not in message
+    assert "\t" not in message
+    assert detail.endswith("…")
+    assert path.exists()
+    assert not chronik_outbox.receipt_path(path).exists()
+
+
+def test_http_error_detail_escapes_unicode_separators_and_lone_surrogates():
+    detail = chronik_outbox._bounded_http_error_detail(
+        "first\u0085second\u2028third\u2029fourth\ud800"
+    )
+
+    assert r"\u0085" in detail
+    assert r"\u2028" in detail
+    assert r"\u2029" in detail
+    assert r"\\ud800" in detail
+    assert all(char not in detail for char in ("\u0085", "\u2028", "\u2029"))
 
 
 def test_preview_renders_views_without_receipts(tmp_path):

--- a/tools/chronik_outbox.py
+++ b/tools/chronik_outbox.py
@@ -32,6 +32,7 @@ SAFE_PART = re.compile(r"[^A-Za-z0-9_.-]+")
 SHA256_HEX = re.compile(r"[0-9a-f]{64}")
 OUTBOX_LOCK_TIMEOUT = 10.0
 RECEIPT_VERSION = 1
+HTTP_ERROR_DETAIL_MAX_BYTES = 1024
 
 
 class OutboxError(RuntimeError):
@@ -80,6 +81,39 @@ def safe_part(value: str, label: str) -> str:
     if not cleaned:
         raise OutboxError(f"{label} is empty after sanitization")
     return cleaned[:160]
+
+
+def _json_single_line(value: object) -> str:
+    """Render untrusted text without literal line or separator controls."""
+    text = str(value).encode("utf-8", errors="backslashreplace").decode("utf-8")
+    rendered = json.dumps(text, ensure_ascii=False)[1:-1]
+    safe: list[str] = []
+    for char in rendered:
+        codepoint = ord(char)
+        if 0x7F <= codepoint <= 0x9F or codepoint in {0x2028, 0x2029}:
+            safe.append(f"\\u{codepoint:04x}")
+        else:
+            safe.append(char)
+    return "".join(safe)
+
+
+def _bounded_http_error_detail(value: object) -> str:
+    """Return one escaped diagnostic within the HTTP error byte budget."""
+    limit = HTTP_ERROR_DETAIL_MAX_BYTES
+    text = str(value)
+    rendered = _json_single_line(text)
+    if len(rendered.encode("utf-8")) <= limit:
+        return rendered
+
+    low, high = 0, len(text)
+    while low < high:
+        middle = (low + high + 1) // 2
+        candidate = _json_single_line(text[:middle] + "…")
+        if len(candidate.encode("utf-8")) <= limit:
+            low = middle
+        else:
+            high = middle - 1
+    return _json_single_line(text[:low] + "…")
 
 
 def producer_and_run_id(event: dict[str, Any]) -> tuple[str, str]:
@@ -340,7 +374,8 @@ def flush_file(
     url = f"{base_url.rstrip('/')}/v1/ingest?{urlencode({'domain': DOMAIN})}"
     status_code, text = (sender or post_json)(url, pending_events, resolved_token, timeout)
     if not 200 <= status_code < 300:
-        raise OutboxError(f"flush failed for {path}: HTTP {status_code}: {text}")
+        detail = _bounded_http_error_detail(text)
+        raise OutboxError(f"flush failed for {path}: HTTP {status_code}: {detail}")
 
     with outbox_lock(path):
         try:


### PR DESCRIPTION
## Problem

A non-2xx Chronik outbox flush copied the complete untrusted HTTP response body into `OutboxError`. A reproduced 200,000-byte body plus a newline produced a 200,115-byte diagnostic with an injected second log line.

## Change

- cap the rendered HTTP error detail at 1,024 UTF-8 bytes
- escape CR, LF, tabs, C0/C1 controls, Unicode line separators, quotes and backslashes into one diagnostic line
- retain short readable messages and the HTTP status
- leave source, receipt, retry and compaction semantics unchanged

## Verification

- focused: `17 passed`
- full: `449 passed`
- `make validate-local`: role contract, 449 tests and local ingest/readback smoke passed
- Ruff and `git diff --check` passed
- attack replay: total error reduced from 200,115 to 1,130 bytes; zero literal newlines; detail bounded to 1,024 bytes

## Boundary

The HTTP client still reads the response body before rendering it; transport-level response-size limiting is separate follow-up work.