### PR TITLE
test(auth): prove constant-work token comparisons

### DIFF
--- a/tests/test_security_auth.py
+++ b/tests/test_security_auth.py
@@ -1,4 +1,6 @@
+import app as app_module
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from app import app
 
@@ -6,6 +8,71 @@ from app import app
 def client():
     with TestClient(app) as c:
         yield c
+
+
+@pytest.mark.parametrize(
+    ("configured", "provided", "expected_tokens", "expected_status"),
+    [
+        ("only", "only", ("only",), None),
+        ("first,second", "first", ("first", "second"), None),
+        (
+            "first,second,third",
+            "third",
+            ("first", "second", "third"),
+            None,
+        ),
+        (
+            "alpha,, beta\nalpha,\r\n gamma,beta",
+            "invalid",
+            ("alpha", "beta", "gamma"),
+            401,
+        ),
+    ],
+    ids=[
+        "single-match",
+        "first-match",
+        "last-match",
+        "no-match-with-empty-and-duplicate-entries",
+    ],
+)
+def test_auth_compares_every_deduplicated_token(
+    monkeypatch, configured, provided, expected_tokens, expected_status
+):
+    monkeypatch.setenv("CHRONIK_TOKEN", configured)
+    comparisons = []
+
+    def recording_compare_digest(candidate, configured_token):
+        comparisons.append((candidate, configured_token))
+        return candidate == configured_token
+
+    monkeypatch.setattr(
+        app_module.secrets, "compare_digest", recording_compare_digest
+    )
+
+    if expected_status is None:
+        app_module._require_auth(provided)
+    else:
+        with pytest.raises(HTTPException) as exc_info:
+            app_module._require_auth(provided)
+        assert exc_info.value.status_code == expected_status
+
+    assert comparisons == [(provided, token) for token in expected_tokens]
+
+
+def test_auth_all_empty_config_fails_closed_without_comparison(monkeypatch):
+    monkeypatch.setenv("CHRONIK_TOKEN", ", ,\n\r")
+
+    def unexpected_compare_digest(candidate, configured_token):
+        pytest.fail("compare_digest called without a configured token")
+
+    monkeypatch.setattr(
+        app_module.secrets, "compare_digest", unexpected_compare_digest
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        app_module._require_auth("candidate")
+
+    assert exc_info.value.status_code == 500
 
 def test_auth_single_token(client, monkeypatch):
     monkeypatch.setenv("CHRONIK_TOKEN", "secret123")


### PR DESCRIPTION
## Summary

- Add direct deterministic regression coverage for one comparison per deduplicated configured token.
- Cover one, two, and three candidates; first, last, and no match; empty and duplicate entries; invalid input; and all-empty fail-closed configuration.
- Preserve production code and existing API behavior.

## Candidate provenance

This closes the remaining evidence gap for candidate `candidate-bcb10938ccfeafc052a59f1c`, event `1998`.

The production fix pre-existed this branch at base `7ae5d38d53c51a957d3713da4a0d878272b6330b`: `app.py` already performs a non-short-circuiting full loop over deduplicated configured tokens and fails closed when no usable token exists. This PR does not redesign or hash tokens.

## Timing diagnosis

The previously reported runtime above 90 seconds did not reproduce. The original 11-test module passed in 0.60 seconds (0.93 seconds wall time), and the expanded 16-test module passed in 0.55 seconds (0.75 seconds wall time) under a 60-second timeout. The slowest recorded setup was 0.03 seconds, so no lifespan or fixture change was made.

## Validation

- `timeout 60s ./.venv/bin/python -m pytest -q tests/test_security_auth.py --durations=0` — 16 passed in 0.55s
- `timeout 900s make validate-local` — role contract OK, 454 passed in 8.97s, API smoke OK