### PR TITLE
Route repository verification through Metarepo

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -13,6 +13,9 @@ permissions:
 
 jobs:
   guard:
-    # Fleet-Repos, die von metarepo aus via wgx up Templates beziehen,
-    # werden auf den kanonischen Guard-Workflow aus heimgewebe/wgx gesetzt.
-    uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@main
+    # Compatibility filename only: verification policy is owned by Metarepo.
+    uses: heimgewebe/metarepo/.github/workflows/reusable-repo-verify.yml@6107899aaec1866087e4f99bacca2488282ba0b8
+    with:
+      mode: guard
+    permissions:
+      contents: read

--- a/.github/workflows/wgx-smoke.yml
+++ b/.github/workflows/wgx-smoke.yml
@@ -15,8 +15,14 @@ name: wgx-smoke
       - "requirements.txt"
       - "requirements-dev.txt"
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
-    # auch hier: statt eigener CI-Logik nur noch Forwarder auf das
-    # kanonische wgx-Workflow-Repo.
-    uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@main
+    # Compatibility filename only: verification policy is owned by Metarepo.
+    uses: heimgewebe/metarepo/.github/workflows/reusable-repo-verify.yml@6107899aaec1866087e4f99bacca2488282ba0b8
+    with:
+      mode: smoke
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary
- keep the existing `wgx-guard.yml` / `wgx-smoke.yml` compatibility filenames and trigger paths
- route both callers directly to Metarepo `reusable-repo-verify.yml` pinned at merge commit `6107899aaec1866087e4f99bacca2488282ba0b8`
- bind explicit `guard` / `smoke` modes and read-only contents permissions

## Validation
- RepoGround freshness: exact on Chronik `fd6a09b14c5f4843b702786213f847f6abd48c34`
- Reposkop work-admission evidence: verified
- actionlint: both changed workflows pass
- `git diff --check`: pass

PR CI is the runtime proof because the Metarepo reusable workflow checks out its own revisions-bound WGX compatibility runner.