### PR TITLE
perf(outbox): add steady no-change fast path

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -40,6 +40,8 @@ GRABOWSKI_ARCHIVE_INDEX_SCHEMA = "chronik-grabowski-outbox-archive-index.v1"
 GRABOWSKI_WRITER_COMPACTION_LOCK_FILENAME = ".writer-compaction.lock"
 GRABOWSKI_SOURCE_INDEX_FILENAME = "source-index.v1.json"
 GRABOWSKI_SOURCE_INDEX_SCHEMA = "chronik-grabowski-source-index.v1"
+GRABOWSKI_STEADY_CHECKPOINT_FILENAME = "steady-import-checkpoint.v1.json"
+GRABOWSKI_STEADY_CHECKPOINT_SCHEMA = "chronik-grabowski-steady-import-checkpoint.v1"
 DEFAULT_COMPACTION_MAX_SOURCES = 256
 DEFAULT_COMPACTION_MAX_BYTES = 64 * 1024 * 1024
 
@@ -393,6 +395,358 @@ def _receipt_matches_prepared_source(
     unsigned = dict(receipt)
     unsigned.pop("receipt_sha256", None)
     return claimed_digest == sha256_bytes(canonical_bytes(unsigned))
+
+
+def _steady_checkpoint_path(receipt_dir: Path) -> Path:
+    return receipt_dir / GRABOWSKI_STEADY_CHECKPOINT_FILENAME
+
+
+def _inventory_fingerprint(
+    paths: Iterable[Path], *, private: bool
+) -> dict[str, Any] | None:
+    digest = hashlib.sha256()
+    count = 0
+    for path in sorted(paths, key=lambda item: str(item)):
+        try:
+            info = path.lstat()
+        except OSError:
+            return None
+        if not stat.S_ISREG(info.st_mode):
+            return None
+        if private and (
+            info.st_uid != os.geteuid() or info.st_mode & 0o077 or info.st_nlink != 1
+        ):
+            return None
+        material = canonical_bytes(
+            {
+                "path": str(path.absolute()),
+                "identity": list(_file_identity(info)),
+            }
+        )
+        digest.update(len(material).to_bytes(8, "big", signed=False))
+        digest.update(material)
+        count += 1
+    return {"count": count, "sha256": digest.hexdigest()}
+
+
+def _directory_identity(path: Path) -> dict[str, int] | None:
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return {
+            "device": -1,
+            "inode": -1,
+            "mode": 0,
+            "links": 0,
+            "uid": os.geteuid(),
+            "size": 0,
+            "mtime_ns": 0,
+            "ctime_ns": 0,
+        }
+    except OSError:
+        return None
+    if not stat.S_ISDIR(info.st_mode) or info.st_uid != os.geteuid() or info.st_mode & 0o022:
+        return None
+    return {
+        "device": int(info.st_dev),
+        "inode": int(info.st_ino),
+        "mode": int(info.st_mode),
+        "links": int(info.st_nlink),
+        "uid": int(info.st_uid),
+        "size": int(info.st_size),
+        "mtime_ns": int(info.st_mtime_ns),
+        "ctime_ns": int(info.st_ctime_ns),
+    }
+
+
+def _stable_source_inventory_identity(
+    *,
+    source_dir: Path,
+    bundle_dir: Path,
+    sources: list[Path],
+    manifests: list[Path],
+    bundle_files: list[Path],
+) -> dict[str, Any] | None:
+    source_dir_before = _directory_identity(source_dir)
+    bundle_dir_before = _directory_identity(bundle_dir)
+    if source_dir_before is None or bundle_dir_before is None:
+        return None
+    fingerprint = _inventory_fingerprint(
+        [*sources, *manifests, *bundle_files], private=False
+    )
+    source_dir_after = _directory_identity(source_dir)
+    bundle_dir_after = _directory_identity(bundle_dir)
+    if (
+        fingerprint is None
+        or source_dir_after is None
+        or bundle_dir_after is None
+        or source_dir_before != source_dir_after
+        or bundle_dir_before != bundle_dir_after
+    ):
+        return None
+    return {
+        "artifacts": fingerprint,
+        "source_dir": source_dir_after,
+        "bundle_dir": bundle_dir_after,
+    }
+
+
+def _private_file_identity(path: Path) -> dict[str, Any] | None:
+    try:
+        info = path.lstat()
+    except OSError:
+        return None
+    if (
+        not stat.S_ISREG(info.st_mode)
+        or info.st_uid != os.geteuid()
+        or info.st_mode & 0o077
+        or info.st_nlink != 1
+    ):
+        return None
+    return dict(zip(_FILE_IDENTITY_FIELDS, _file_identity(info)))
+
+
+def _steady_fast_identity(
+    *,
+    source_dir: Path,
+    bundle_dir: Path,
+    sources: list[Path],
+    manifests: list[Path],
+    bundle_files: list[Path],
+    receipt_dir: Path,
+    source_index_path: Path,
+) -> dict[str, Any] | None:
+    source_inventory = _stable_source_inventory_identity(
+        source_dir=source_dir,
+        bundle_dir=bundle_dir,
+        sources=sources,
+        manifests=manifests,
+        bundle_files=bundle_files,
+    )
+    if source_inventory is None:
+        return None
+    receipt_paths = (
+        list(receipt_dir.glob("*.receipt.json")) if receipt_dir.is_dir() else []
+    )
+    receipt_inventory = _inventory_fingerprint(receipt_paths, private=True)
+    source_index_identity = _private_file_identity(source_index_path)
+    try:
+        target_identity = storage.read_unique_storage_checkpoint_identity(DOMAIN)
+    except storage.StorageError:
+        return None
+    if (
+        receipt_inventory is None
+        or source_index_identity is None
+        or target_identity is None
+    ):
+        return None
+
+    # Close the metadata race window opened while receipts and target state were
+    # observed. Any source or receipt drift since the first fingerprint must
+    # enter the existing full reconciliation path.
+    final_source_inventory = _stable_source_inventory_identity(
+        source_dir=source_dir,
+        bundle_dir=bundle_dir,
+        sources=sources,
+        manifests=manifests,
+        bundle_files=bundle_files,
+    )
+    final_receipt_paths = (
+        list(receipt_dir.glob("*.receipt.json")) if receipt_dir.is_dir() else []
+    )
+    final_receipt_inventory = _inventory_fingerprint(
+        final_receipt_paths, private=True
+    )
+    if (
+        final_source_inventory != source_inventory
+        or final_receipt_inventory != receipt_inventory
+    ):
+        return None
+    final_source_index_identity = _private_file_identity(source_index_path)
+    try:
+        final_target_identity = storage.read_unique_storage_checkpoint_identity(DOMAIN)
+    except storage.StorageError:
+        return None
+    if (
+        final_source_index_identity != source_index_identity
+        or final_target_identity != target_identity
+    ):
+        return None
+    return {
+        "source_inventory": final_source_inventory,
+        "receipt_inventory": final_receipt_inventory,
+        "source_index_identity": final_source_index_identity,
+        "target_identity": final_target_identity,
+    }
+
+
+def _load_steady_checkpoint(
+    path: Path, *, source_dir: Path
+) -> dict[str, Any] | None:
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+    if (
+        not stat.S_ISREG(info.st_mode)
+        or info.st_uid != os.geteuid()
+        or info.st_mode & 0o077
+        or info.st_nlink != 1
+    ):
+        return None
+    try:
+        raw, _ = _read_immutable_artifact_snapshot(path, label="steady import checkpoint")
+        if not raw.endswith(b"\n"):
+            return None
+        document = json.loads(raw)
+        if not isinstance(document, dict):
+            return None
+        expected = {
+            "schema_version",
+            "source_dir",
+            "selection_contract",
+            "identity",
+            "summary",
+            "recorded_at",
+            "historical_only",
+            "does_not_establish",
+            "checkpoint_sha256",
+        }
+        if set(document) != expected:
+            return None
+        claimed = document.get("checkpoint_sha256")
+        unsigned = dict(document)
+        unsigned.pop("checkpoint_sha256")
+        if (
+            document.get("schema_version") != GRABOWSKI_STEADY_CHECKPOINT_SCHEMA
+            or document.get("source_dir") != str(source_dir.resolve())
+            or document.get("selection_contract") != sorted(HIGH_VALUE_KINDS)
+            or document.get("historical_only") is not True
+            or document.get("does_not_establish") != DOES_NOT_ESTABLISH
+            or not isinstance(claimed, str)
+            or claimed != sha256_bytes(canonical_bytes(unsigned))
+            or not isinstance(document.get("identity"), dict)
+            or not isinstance(document.get("summary"), dict)
+        ):
+            return None
+        recorded_at = document.get("recorded_at")
+        if not isinstance(recorded_at, str):
+            return None
+        _parse_timestamp(recorded_at, field="steady_checkpoint.recorded_at")
+        return document
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def _steady_summary_from_result(result: dict[str, Any]) -> dict[str, Any]:
+    source_count = int(result["sources_after_deduplication"])
+    event_count = int(result["events_imported"]) + int(result["events_skipped_existing"])
+    return {
+        "files_seen": int(result["files_seen"]),
+        "loose_files_seen": int(result["loose_files_seen"]),
+        "bundle_manifests_seen": int(result["bundle_manifests_seen"]),
+        "bundles_valid": int(result["bundles_valid"]),
+        "bundled_sources_seen": int(result["bundled_sources_seen"]),
+        "sources_seen_total": int(result["sources_seen_total"]),
+        "sources_after_deduplication": source_count,
+        "orphan_bundles": int(result["orphan_bundles"]),
+        "files_imported_or_confirmed": source_count,
+        "files_unchanged": source_count,
+        "receipts_written": 0,
+        "receipts_reused": source_count,
+        "loose_sources_imported_or_confirmed": int(result["loose_files_seen"]),
+        "bundled_sources_imported_or_confirmed": int(result["bundled_sources_seen"]),
+        "events_imported": 0,
+        "events_skipped_existing": event_count,
+        "target_scans": 0,
+        "target_records_scanned": 0,
+        "identity_index_mode": "steady",
+        "identity_index_full_rebuild": False,
+        "identity_index_entries_after": int(result["identity_index_entries_after"]),
+        "source_index_mode": "steady",
+        "source_index_file_bytes": int(result["source_index_file_bytes"]),
+        "sources_reused": source_count,
+        "sources_revalidated": 0,
+        "sources_changed": 0,
+        "sources_added": 0,
+        "sources_removed": 0,
+        "source_bytes_read": 0,
+        "source_bytes_hashed": 0,
+        "source_events_validated": 0,
+    }
+
+
+def _publish_steady_checkpoint(
+    path: Path,
+    *,
+    source_dir: Path,
+    identity: dict[str, Any],
+    summary: dict[str, Any],
+    previous: dict[str, Any] | None,
+) -> bool:
+    semantic = {
+        "schema_version": GRABOWSKI_STEADY_CHECKPOINT_SCHEMA,
+        "source_dir": str(source_dir.resolve()),
+        "selection_contract": sorted(HIGH_VALUE_KINDS),
+        "identity": identity,
+        "summary": summary,
+        "historical_only": True,
+        "does_not_establish": DOES_NOT_ESTABLISH,
+    }
+    if previous is not None and all(
+        previous.get(key) == value for key, value in semantic.items()
+    ):
+        return False
+    document = {**semantic, "recorded_at": utc_now()}
+    document["checkpoint_sha256"] = sha256_bytes(canonical_bytes(document))
+    raw = json.dumps(document, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+    _atomic_write(path, raw)
+    _fsync_directory(path.parent)
+    return True
+
+
+def _steady_fast_result(
+    checkpoint: dict[str, Any],
+    *,
+    source_dir: Path,
+    receipt_dir: Path,
+    source_index_path: Path,
+    import_started_ns: int,
+    phase_ns: Counter[str],
+    counters: Counter[str],
+) -> dict[str, Any]:
+    summary = dict(checkpoint["summary"])
+    counters["steady_fast_path_hits"] += 1
+    counters["sources_reused"] = int(summary["sources_reused"])
+    elapsed_ns = time.perf_counter_ns() - import_started_ns
+    telemetry = {
+        "schema_version": "chronik-grabowski-import-telemetry.v1",
+        "elapsed_seconds": round(elapsed_ns / 1_000_000_000, 6),
+        "phases_seconds": {
+            name: round(value / 1_000_000_000, 6)
+            for name, value in sorted(phase_ns.items())
+        },
+        "counters": dict(sorted(counters.items())),
+    }
+    return {
+        "schema_version": "chronik-grabowski-outbox-batch.v2",
+        "source_dir": str(source_dir),
+        "receipt_dir": str(receipt_dir),
+        **summary,
+        "source_index_path": str(source_index_path),
+        "source_index_written": False,
+        "elapsed_seconds": telemetry["elapsed_seconds"],
+        "import_telemetry": telemetry,
+        "bundle_inventory": [],
+        "bundle_inventory_omitted": True,
+        "steady_fast_path": True,
+        "steady_checkpoint_sha256": checkpoint["checkpoint_sha256"],
+        "errors": [],
+        "historical_only": True,
+        "does_not_establish": DOES_NOT_ESTABLISH,
+    }
 
 
 def _source_index_path(receipt_dir: Path) -> Path:
@@ -763,7 +1117,6 @@ def _publish_grabowski_source_index(
     _atomic_write(path, raw)
     _fsync_directory(path.parent)
     return True, len(raw)
-
 
 
 def _ledger_payloads_by_event_id() -> tuple[dict[str, bytes], int]:
@@ -1570,7 +1923,12 @@ def import_grabowski_outbox_file(source: Path, *, receipt_dir: Path) -> dict[str
     return results[0]
 
 
-def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str, Any]:
+def import_grabowski_outbox(
+    *,
+    outbox_root: Path,
+    receipt_dir: Path,
+    allow_steady_fast_path: bool = False,
+) -> dict[str, Any]:
     import_started_ns = time.perf_counter_ns()
     phase_ns: Counter[str] = Counter()
     counters: Counter[str] = Counter()
@@ -1601,6 +1959,36 @@ def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str
     counters["loose_sources_discovered"] = len(sources)
     counters["bundle_manifests_discovered"] = len(manifests)
     counters["bundle_files_discovered"] = len(bundle_files)
+
+    steady_checkpoint_path = _steady_checkpoint_path(receipt_dir)
+    prior_steady_checkpoint = _load_steady_checkpoint(
+        steady_checkpoint_path, source_dir=source_dir
+    )
+    if allow_steady_fast_path and prior_steady_checkpoint is not None:
+        with measured_phase("steady_fast_path"):
+            current_fast_identity = _steady_fast_identity(
+                source_dir=source_dir,
+                bundle_dir=bundle_dir,
+                sources=sources,
+                manifests=manifests,
+                bundle_files=bundle_files,
+                receipt_dir=receipt_dir,
+                source_index_path=source_index_path,
+            )
+            if (
+                current_fast_identity is not None
+                and current_fast_identity == prior_steady_checkpoint.get("identity")
+            ):
+                return _steady_fast_result(
+                    prior_steady_checkpoint,
+                    source_dir=source_dir,
+                    receipt_dir=receipt_dir,
+                    source_index_path=source_index_path,
+                    import_started_ns=import_started_ns,
+                    phase_ns=phase_ns,
+                    counters=counters,
+                )
+            counters["steady_fast_path_fallbacks"] += 1
 
     target_path = storage.safe_target_path(DOMAIN)
     target_missing_or_empty = not target_path.exists() or target_path.stat().st_size == 0
@@ -1868,17 +2256,7 @@ def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str
         counters["source_index_reuses"] = 1
 
     bundled_sources_seen = sum(int(item["source_count"]) for item in bundle_metadata)
-    elapsed_ns = time.perf_counter_ns() - import_started_ns
-    telemetry = {
-        "schema_version": "chronik-grabowski-import-telemetry.v1",
-        "elapsed_seconds": round(elapsed_ns / 1_000_000_000, 6),
-        "phases_seconds": {
-            name: round(value / 1_000_000_000, 6)
-            for name, value in sorted(phase_ns.items())
-        },
-        "counters": dict(sorted(counters.items())),
-    }
-    return {
+    base_result = {
         "schema_version": "chronik-grabowski-outbox-batch.v2",
         "source_dir": str(source_dir),
         "receipt_dir": str(receipt_dir),
@@ -1919,12 +2297,74 @@ def import_grabowski_outbox(*, outbox_root: Path, receipt_dir: Path) -> dict[str
         "source_bytes_read": counters["source_bytes_read"],
         "source_bytes_hashed": counters["source_bytes_hashed"],
         "source_events_validated": counters["source_events_validated"],
-        "elapsed_seconds": telemetry["elapsed_seconds"],
-        "import_telemetry": telemetry,
         "bundle_inventory": bundle_metadata,
         "errors": errors,
         "historical_only": True,
         "does_not_establish": DOES_NOT_ESTABLISH,
+    }
+    if (
+        not errors
+        and ledger_reconciled
+        and receipt_writes_succeeded
+        and identity_index_entries_after is not None
+    ):
+        with measured_phase("steady_checkpoint_publish"):
+            source_inventory = _stable_source_inventory_identity(
+                source_dir=source_dir,
+                bundle_dir=bundle_dir,
+                sources=sources,
+                manifests=manifests,
+                bundle_files=bundle_files,
+            )
+            receipt_paths = (
+                list(receipt_dir.glob("*.receipt.json"))
+                if receipt_dir.is_dir()
+                else []
+            )
+            receipt_inventory = _inventory_fingerprint(receipt_paths, private=True)
+            source_index_identity = _private_file_identity(source_index_path)
+            try:
+                target_identity = storage.read_unique_storage_checkpoint_identity(DOMAIN)
+            except storage.StorageError:
+                target_identity = None
+            if (
+                source_inventory is not None
+                and receipt_inventory is not None
+                and source_index_identity is not None
+                and target_identity is not None
+            ):
+                checkpoint_identity = {
+                    "source_inventory": source_inventory,
+                    "receipt_inventory": receipt_inventory,
+                    "source_index_identity": source_index_identity,
+                    "target_identity": target_identity,
+                }
+                checkpoint_summary = _steady_summary_from_result(base_result)
+                if _publish_steady_checkpoint(
+                    steady_checkpoint_path,
+                    source_dir=source_dir,
+                    identity=checkpoint_identity,
+                    summary=checkpoint_summary,
+                    previous=prior_steady_checkpoint,
+                ):
+                    counters["steady_checkpoint_writes"] += 1
+                else:
+                    counters["steady_checkpoint_reuses"] += 1
+    elapsed_ns = time.perf_counter_ns() - import_started_ns
+    telemetry = {
+        "schema_version": "chronik-grabowski-import-telemetry.v1",
+        "elapsed_seconds": round(elapsed_ns / 1_000_000_000, 6),
+        "phases_seconds": {
+            name: round(value / 1_000_000_000, 6)
+            for name, value in sorted(phase_ns.items())
+        },
+        "counters": dict(sorted(counters.items())),
+    }
+    return {
+        **base_result,
+        "elapsed_seconds": telemetry["elapsed_seconds"],
+        "import_telemetry": telemetry,
+        "steady_fast_path": False,
     }
 
 

--- a/docs/chronik/direct-operator-memory-v1.md
+++ b/docs/chronik/direct-operator-memory-v1.md
@@ -171,9 +171,28 @@ geschriebene und übersprungene Ereignisse aus. Reproduzierbare Zielgrenzen sind
 - null vollständige Ledger-Datensätze im steady state und weiterhin höchstens
   ein Scan in Rebuild-/Catch-up-Sonderpfaden.
 
-Ein Importbeleg bleibt dabei reine Evidenz: Auch der Wiederholungsimport gleicht
-jeden Payload-Fingerprint gegen den tatsächlichen Ledger ab und vertraut weder
-nur dem Receipt noch nur dem Source-Index.
+Ein Importbeleg bleibt dabei reine Evidenz. Im normalen Vollpfad gleicht auch
+der Wiederholungsimport jeden Payload-Fingerprint gegen den tatsächlichen Ledger
+ab und vertraut weder nur dem Receipt noch nur dem Source-Index.
+
+Für den vom Timer verwendeten `summary`-Pfad darf ein exakt unveränderter Lauf
+diesen Vollabgleich überspringen, aber nur auf Basis eines kleinen privaten
+`steady-import-checkpoint.v1.json`, der **nach** einem erfolgreichen Vollabgleich
+geschrieben wurde. Der Checkpoint bindet die Metadatenidentität aller losen
+Quellen, Bundle-Manifeste und Bundle-Dateien, aller Import-Receipts, des
+Source-Index sowie des Ledger- und Identity-Index-Paares. Vor einem Fast-Return
+werden Source- und Receipt-Inventar nach dem Ledger-/Index-Read ein zweites Mal
+abgeglichen, um Änderungen im Prüfzeitfenster zu erkennen. Nur wenn sämtliche
+Identitäten exakt dem vorherigen Vollabgleich entsprechen, werden Source-Index-
+Laden, logische Quellmaterialisierung, Merge und erneuter Ledger-Abgleich
+ausgelassen. Jede Abweichung, fehlende Datei, unsichere Dateiform, beschädigte
+Checkpoint-Struktur oder Digest-Abweichung fällt deterministisch auf den
+bestehenden Vollpfad zurück. `--output-mode full` verwendet diesen Fast-Path
+nicht.
+
+Der Checkpoint ist eine rekonstruierbare Beschleunigungsprojektion. Er ist weder
+Replay- noch Historienautorität und begründet insbesondere keine aktuelle Git-,
+CI-, Runtime-, Task- oder Retry-Wahrheit.
 
 Ein Receipt wird erst nach dem erfolgreichen Ledger-Abgleich geschrieben. Falls
 dieser Evidenzschritt scheitert, bleiben die bereits bestätigten Ledger-Zahlen
@@ -193,9 +212,11 @@ nicht parallel ein zweites Mal gestartet; ein noch aktiver Lauf verhindert damit
 überlappende Importer. Die Unit darf die Grabowski-Outbox nur lesen und
 ausschließlich unter `~/.local/state/chronik` schreiben. Für systemd nutzt die
 Unit `import-outbox --output-mode summary`: Pro Lauf entsteht genau ein kompakter
-JSON-Einzeiler mit Zählern. Dateiinventare werden nicht ausgegeben; höchstens drei
-gekürzte Fehlerstichproben bleiben sichtbar. Die Zeile bleibt garantiert unter
-4096 Bytes: Gekürzt wird nach der JSON-kodierten Bytelänge, nicht nach
+JSON-Einzeiler mit Zählern. Nur dieser Summary-Pfad aktiviert den oben
+beschriebenen no-change Fast-Path; jeder Drift führt im selben Lauf zurück in den
+normalen vollständigen Abgleich. Dateiinventare werden nicht ausgegeben; höchstens
+drei gekürzte Fehlerstichproben bleiben sichtbar. Die Zeile bleibt garantiert
+unter 4096 Bytes: Gekürzt wird nach der JSON-kodierten Bytelänge, nicht nach
 Zeichenzahl, weil Escaping ein Zeichen auf bis zu zwölf Bytes ausdehnen kann.
 Reicht das nicht, entfallen zusätzlich Fehlerstichproben; `errors_truncated`
 bleibt dann `true`. Die aggregierte `error_count` und der Exitcode `2` bei
@@ -217,7 +238,7 @@ Git-, CI-, Runtime- oder Recovery-Prüfungen.
 
 ## Receipt-Wiederverwendung und Replay-Autorität
 
-Jeder Outbox-Import gleicht die Event-IDs weiterhin mit dem maßgeblichen Chronik-Ledger ab. Sind die Quellbytes unverändert, alle angeforderten Events im Ledger vorhanden und der vorhandene quellgebundene Receipt durch seinen SHA-256-Digest intakt, wird die Receipt-Datei nicht ersetzt. Die Batch-Telemetrie trennt `receipts_written` und `receipts_reused`.
+Im normalen Vollpfad gleicht jeder Outbox-Import die Event-IDs mit dem maßgeblichen Chronik-Ledger ab. Der exakt-unveränderte `summary`-Fast-Path darf diesen erneuten Einzelabgleich nur überspringen, solange sein nach einem erfolgreichen Vollabgleich geschriebener Checkpoint unveränderte Source-, Receipt-, Source-Index-, Ledger- und Identity-Index-Identitäten belegt; jede Drift fällt auf den Vollpfad zurück. Sind dort die Quellbytes unverändert, alle angeforderten Events im Ledger vorhanden und der vorhandene quellgebundene Receipt durch seinen SHA-256-Digest intakt, wird die Receipt-Datei nicht ersetzt. Die Batch-Telemetrie trennt `receipts_written` und `receipts_reused`.
 
 `receipt_sha256` im Laufergebnis bindet ausdrücklich die unveränderte Receipt-Datei (`receipt_digest_scope=persisted_receipt`), nicht die aktuellen Laufzähler. `imported`, `skipped_existing` und die Scan-Zähler beschreiben den aktuellen Lauf.
 

--- a/storage.py
+++ b/storage.py
@@ -19,6 +19,7 @@ from identity_index import (
     IdentityIndexCommitUncertain,
     IdentityIndexDriftError,
     IdentityIndexError,
+    index_path_for_target,
     open_identity_index,
     reset_identity_index_for_authoritative_replay,
 )
@@ -42,6 +43,7 @@ __all__ = [
     "read_tail",
     "read_last_line",
     "read_domain_snapshot",
+    "read_unique_storage_checkpoint_identity",
     "scan_domain",
     "list_domains",
     "get_lock_path",
@@ -374,6 +376,73 @@ def _raise_append_error(exc: BaseException, target_path: Path) -> None:
             raise StorageFullError("insufficient storage") from exc
         raise StorageError("append failed") from exc
     raise exc
+
+
+def _checkpoint_file_identity(info: os.stat_result) -> dict[str, int]:
+    return {
+        "device": int(info.st_dev),
+        "inode": int(info.st_ino),
+        "mode": int(info.st_mode),
+        "links": int(info.st_nlink),
+        "uid": int(info.st_uid),
+        "size": int(info.st_size),
+        "mtime_ns": int(info.st_mtime_ns),
+        "ctime_ns": int(info.st_ctime_ns),
+    }
+
+
+def read_unique_storage_checkpoint_identity(
+    domain: str, *, identity_key: str = "event_id"
+) -> dict[str, object] | None:
+    """Return a cheap identity for a previously reconciled unique ledger/index pair.
+
+    This deliberately does not synchronize, rebuild, create, or query identity rows.
+    It is useful only as a compare-against-prior-success accelerator: callers must
+    already possess a checkpoint written after the normal full reconciliation.
+    Any metadata drift forces the caller back through that full path.
+    """
+    try:
+        target_path = safe_target_path(domain)
+    except DomainError as exc:
+        raise StorageError("invalid target path") from exc
+    try:
+        target_info = target_path.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise StorageRecoveryError("target identity unavailable") from exc
+    if not stat.S_ISREG(target_info.st_mode):
+        raise StorageRecoveryError("target is not a regular file")
+
+    index_path = index_path_for_target(target_path)
+    try:
+        index_info = index_path.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise StorageRecoveryError("identity index identity unavailable") from exc
+    if (
+        not stat.S_ISREG(index_info.st_mode)
+        or index_info.st_uid != os.geteuid()
+        or index_info.st_mode & 0o077
+        or index_info.st_nlink != 1
+    ):
+        raise StorageRecoveryError("identity index identity is not private and regular")
+
+    with _locked_open(target_path, "rb") as fh:
+        opened = _target_stat_for_fd(target_path, fh.fileno())
+        try:
+            current_index = index_path.lstat()
+        except OSError as exc:
+            raise StorageRecoveryError("identity index changed during checkpoint read") from exc
+        if _checkpoint_file_identity(current_index) != _checkpoint_file_identity(index_info):
+            raise StorageRecoveryError("identity index changed during checkpoint read")
+        return {
+            "schema_version": 1,
+            "identity_key": identity_key,
+            "ledger": _checkpoint_file_identity(opened),
+            "identity_index": _checkpoint_file_identity(current_index),
+        }
 
 
 def _append_jsonl_transaction(fh, target_path: Path, lines: Iterable[str]) -> None:
@@ -968,7 +1037,6 @@ def write_payload_unique_groups(
             raise
         except IdentityIndexError as exc:
             _raise_identity_index_error(exc)
-
 
 
 def write_payload_unique(

--- a/tests/test_benchmark_outbox_import.py
+++ b/tests/test_benchmark_outbox_import.py
@@ -32,6 +32,11 @@ def test_benchmark_reports_persistent_index_reuse(tmp_path):
     assert report["schema_version"] == "chronik-outbox-import-benchmark.v3"
     assert report["thresholds"]["representative_no_change_max_seconds"] == 1.0
     assert report["thresholds"]["small_delta_max_seconds"] == 2.0
+    assert tier["first"]["steady_fast_path"] is False
+    assert tier["repeat"]["steady_fast_path"] is True
+    assert tier["small_delta"]["steady_fast_path"] is False
+    assert tier["bundled_rebuild"]["steady_fast_path"] is False
+    assert tier["bundled_repeat"]["steady_fast_path"] is True
     assert tier["first"]["target_scans"] == 0
     assert tier["first"]["target_records_scanned"] == 0
     assert tier["repeat"]["target_scans"] == 0

--- a/tests/test_grabowski_outbox_import.py
+++ b/tests/test_grabowski_outbox_import.py
@@ -130,6 +130,287 @@ def test_no_change_import_reuses_source_index_without_source_reads(
     assert index_path.stat().st_mtime_ns == original_stat.st_mtime_ns
 
 
+def test_summary_steady_fast_path_skips_full_source_and_ledger_reconciliation(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    write_named_outbox(
+        outbox,
+        "grabowski_task-first-a1.jsonl",
+        [event("agent.run.completed", "a")],
+    )
+    write_named_outbox(
+        outbox,
+        "grabowski_task-second-a1.jsonl",
+        [event("agent.run.completed", "b")],
+    )
+    first = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    checkpoint = receipts / coding_memory.GRABOWSKI_STEADY_CHECKPOINT_FILENAME
+    assert first["steady_fast_path"] is False
+    assert checkpoint.is_file()
+
+    def unexpected_full_path(*args, **kwargs):
+        raise AssertionError("steady fast path entered full reconciliation")
+
+    monkeypatch.setattr(coding_memory, "_load_grabowski_source_index", unexpected_full_path)
+    monkeypatch.setattr(coding_memory, "_import_prepared_grabowski_sources", unexpected_full_path)
+    second = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    assert second["steady_fast_path"] is True
+    assert second["events_imported"] == 0
+    assert second["events_skipped_existing"] == 2
+    assert second["files_unchanged"] == 2
+    assert second["receipts_reused"] == 2
+    assert second["source_index_mode"] == "steady"
+    assert second["source_bytes_read"] == 0
+    assert second["source_bytes_hashed"] == 0
+    assert second["source_events_validated"] == 0
+    assert second["target_scans"] == 0
+    assert second["target_records_scanned"] == 0
+    assert second["bundle_inventory"] == []
+    assert second["bundle_inventory_omitted"] is True
+    assert second["import_telemetry"]["counters"]["steady_fast_path_hits"] == 1
+
+
+def test_summary_steady_fast_path_falls_back_when_source_directory_changes_mid_check(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    write_outbox(outbox, [event("agent.run.completed", "a")])
+    coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    original = coding_memory._inventory_fingerprint
+    mutated = False
+
+    def mutate_after_snapshot(paths, *, private):
+        nonlocal mutated
+        result = original(paths, private=private)
+        if not private and not mutated:
+            mutated = True
+            write_named_outbox(
+                outbox,
+                "grabowski_task-raced-a1.jsonl",
+                [event("agent.run.completed", "b")],
+            )
+        return result
+
+    monkeypatch.setattr(coding_memory, "_inventory_fingerprint", mutate_after_snapshot)
+    recovered = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    assert recovered["steady_fast_path"] is False
+    assert recovered["import_telemetry"]["counters"]["steady_fast_path_fallbacks"] == 1
+    # The raced source was created after this run's initial glob; it is picked up on
+    # the next normal run rather than being incorrectly certified unchanged.
+    next_result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    assert next_result["events_imported"] == 1
+    assert next_result["steady_fast_path"] is False
+
+
+def test_summary_steady_fast_path_rechecks_source_after_target_identity(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    write_outbox(outbox, [event("agent.run.completed", "a")])
+    coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    original = coding_memory.storage.read_unique_storage_checkpoint_identity
+    mutated = False
+
+    def mutate_before_return(*args, **kwargs):
+        nonlocal mutated
+        result = original(*args, **kwargs)
+        if not mutated:
+            mutated = True
+            write_named_outbox(
+                outbox,
+                "grabowski_task-late-race-a1.jsonl",
+                [event("agent.run.completed", "b")],
+            )
+        return result
+
+    monkeypatch.setattr(
+        coding_memory.storage,
+        "read_unique_storage_checkpoint_identity",
+        mutate_before_return,
+    )
+    recovered = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    assert recovered["steady_fast_path"] is False
+    assert recovered["import_telemetry"]["counters"]["steady_fast_path_fallbacks"] == 1
+    next_result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    assert next_result["events_imported"] == 1
+    assert next_result["steady_fast_path"] is False
+
+
+def test_summary_steady_fast_path_rechecks_receipts_after_target_identity(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    write_outbox(outbox, [event("agent.run.completed", "a")])
+    coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    receipt = next(receipts.glob("*.receipt.json"))
+    original = coding_memory.storage.read_unique_storage_checkpoint_identity
+    mutated = False
+
+    def mutate_before_return(*args, **kwargs):
+        nonlocal mutated
+        result = original(*args, **kwargs)
+        if not mutated:
+            mutated = True
+            tampered = json.loads(receipt.read_text())
+            tampered["source_sha256"] = "0" * 64
+            receipt.write_text(json.dumps(tampered), encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(
+        coding_memory.storage,
+        "read_unique_storage_checkpoint_identity",
+        mutate_before_return,
+    )
+    recovered = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    assert recovered["steady_fast_path"] is False
+    assert recovered["import_telemetry"]["counters"]["steady_fast_path_fallbacks"] == 1
+    assert recovered["receipts_written"] == 1
+
+
+def test_summary_steady_fast_path_falls_back_after_receipt_drift(tmp_path, monkeypatch):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    write_outbox(outbox, [event("agent.run.completed", "a")])
+    coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    receipt = next(receipts.glob("*.receipt.json"))
+    tampered = json.loads(receipt.read_text())
+    tampered["source_sha256"] = "0" * 64
+    receipt.write_text(json.dumps(tampered), encoding="utf-8")
+
+    recovered = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    assert recovered["steady_fast_path"] is False
+    assert recovered["import_telemetry"]["counters"]["steady_fast_path_fallbacks"] == 1
+    assert recovered["receipts_written"] == 1
+    repaired = json.loads(receipt.read_text())
+    assert repaired["receipt_sha256"]
+
+
+def test_summary_steady_fast_path_falls_back_after_source_index_drift(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    write_outbox(outbox, [event("agent.run.completed", "a")])
+    coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    index_path = receipts / coding_memory.GRABOWSKI_SOURCE_INDEX_FILENAME
+    raw = index_path.read_bytes()
+    index_path.write_bytes(raw)
+    index_path.chmod(0o600)
+
+    recovered = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    assert recovered["steady_fast_path"] is False
+    assert recovered["import_telemetry"]["counters"]["steady_fast_path_fallbacks"] == 1
+    assert recovered["errors"] == []
+
+
+def test_summary_steady_fast_path_falls_back_after_ledger_drift(tmp_path, monkeypatch):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    write_outbox(outbox, [event("agent.run.completed", "a")])
+    coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    coding_memory.import_events([event("agent.run.completed", "b")])
+
+    recovered = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    assert recovered["steady_fast_path"] is False
+    assert recovered["import_telemetry"]["counters"]["steady_fast_path_fallbacks"] == 1
+    assert recovered["target_scans"] == 0
+    assert recovered["errors"] == []
+
+
+def test_corrupt_steady_checkpoint_falls_back_to_full_import(tmp_path, monkeypatch):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    write_outbox(outbox, [event("agent.run.completed", "a")])
+    coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    checkpoint = receipts / coding_memory.GRABOWSKI_STEADY_CHECKPOINT_FILENAME
+    checkpoint.write_text("{}\n", encoding="utf-8")
+    checkpoint.chmod(0o600)
+
+    recovered = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    assert recovered["steady_fast_path"] is False
+    assert recovered["errors"] == []
+    rebuilt = json.loads(checkpoint.read_text())
+    claimed = rebuilt.pop("checkpoint_sha256")
+    assert claimed == coding_memory.sha256_bytes(coding_memory.canonical_bytes(rebuilt))
+
+
 def test_metadata_drift_revalidates_source_even_when_size_and_mtime_match(
     tmp_path, monkeypatch
 ):
@@ -821,7 +1102,6 @@ def test_cross_file_divergent_event_id_fails_before_batch_append(tmp_path, monke
     target = data / "agent.ledger.jsonl"
     assert not target.exists() or target.read_text() == ""
     assert not receipts.exists()
-
 
 
 def test_single_file_receipt_failure_preserves_original_exception(

--- a/tools/benchmark_outbox_import.py
+++ b/tools/benchmark_outbox_import.py
@@ -73,12 +73,18 @@ def synthetic_event(label: str, kind: str = "agent.run.completed") -> dict:
     }
 
 
-def _measure(outbox_root: Path, receipt_dir: Path) -> dict:
+def _measure(
+    outbox_root: Path,
+    receipt_dir: Path,
+    *,
+    allow_steady_fast_path: bool = False,
+) -> dict:
     tracemalloc.start()
     started = time.perf_counter()
     result = coding_memory.import_grabowski_outbox(
         outbox_root=outbox_root,
         receipt_dir=receipt_dir,
+        allow_steady_fast_path=allow_steady_fast_path,
     )
     elapsed = time.perf_counter() - started
     _, peak = tracemalloc.get_traced_memory()
@@ -91,6 +97,7 @@ def _measure(outbox_root: Path, receipt_dir: Path) -> dict:
         "events_imported": result["events_imported"],
         "events_skipped_existing": result["events_skipped_existing"],
         "source_index_mode": result["source_index_mode"],
+        "steady_fast_path": result.get("steady_fast_path") is True,
         "sources_reused": result["sources_reused"],
         "sources_revalidated": result["sources_revalidated"],
         "sources_changed": result["sources_changed"],
@@ -171,7 +178,9 @@ def benchmark_tier(
             )
         receipt_dir = temp_root / "receipts"
         first = _measure(outbox_root, receipt_dir)
-        repeat = _measure(outbox_root, receipt_dir)
+        repeat = _measure(
+            outbox_root, receipt_dir, allow_steady_fast_path=True
+        )
         delta_index = source_files
         delta_values = (
             synthetic_event(f"{name}-{delta_index}-started", "agent.run.started"),
@@ -181,7 +190,9 @@ def benchmark_tier(
             "".join(json.dumps(value, sort_keys=True) + "\n" for value in delta_values),
             encoding="utf-8",
         )
-        small_delta = _measure(outbox_root, receipt_dir)
+        small_delta = _measure(
+            outbox_root, receipt_dir, allow_steady_fast_path=True
+        )
         loose_files_before = len(list(source_dir.glob("*.jsonl")))
         total_source_files = source_files + 1
         compaction = _measure_compaction(
@@ -190,8 +201,12 @@ def benchmark_tier(
             max_sources=total_source_files,
         )
         loose_files_after = len(list(source_dir.glob("*.jsonl")))
-        bundled_rebuild = _measure(outbox_root, receipt_dir)
-        bundled_repeat = _measure(outbox_root, receipt_dir)
+        bundled_rebuild = _measure(
+            outbox_root, receipt_dir, allow_steady_fast_path=True
+        )
+        bundled_repeat = _measure(
+            outbox_root, receipt_dir, allow_steady_fast_path=True
+        )
         worst_seconds = max(
             first["elapsed_seconds"],
             small_delta["elapsed_seconds"],
@@ -212,6 +227,11 @@ def benchmark_tier(
             and not compaction["errors"]
             and not bundled_rebuild["errors"]
             and not bundled_repeat["errors"]
+            and first["steady_fast_path"] is False
+            and repeat["steady_fast_path"] is True
+            and small_delta["steady_fast_path"] is False
+            and bundled_rebuild["steady_fast_path"] is False
+            and bundled_repeat["steady_fast_path"] is True
             and first["target_scans"] <= MAX_TARGET_SCANS
             and repeat["target_scans"] <= MAX_TARGET_SCANS
             and small_delta["target_scans"] <= MAX_TARGET_SCANS

--- a/tools/coding_memory.py
+++ b/tools/coding_memory.py
@@ -48,6 +48,7 @@ OUTBOX_SUMMARY_KEYS = (
     "source_bytes_read",
     "source_bytes_hashed",
     "source_events_validated",
+    "steady_fast_path",
     "elapsed_seconds",
 )
 OUTBOX_SUMMARY_ERROR_LIMIT = 3
@@ -299,6 +300,7 @@ def main(argv=None):
                 result = coding_memory.import_grabowski_outbox(
                     outbox_root=args.outbox_root,
                     receipt_dir=receipt_dir.expanduser(),
+                    allow_steady_fast_path=args.output_mode == "summary",
                 )
             elif args.command == "compact-outbox":
                 receipt_dir = args.receipt_dir or data_path / "import-receipts"


### PR DESCRIPTION
## Summary
- add a summary-only, fail-closed no-change checkpoint fast path after a successful full reconciliation
- bind source, receipt, source-index, ledger and identity-index identities with repeated race checks
- keep `--output-mode full` on the existing authoritative full path and fall back on any drift/corruption
- expose fast-path state in compact timer summaries and benchmark the real summary path

## Validation
- 480 tests passed
- role-contract: OK chronik
- git diff --check passed
- benchmark passed: 1000-source no-change 0.087s, small delta fallback 1.005s, bundled no-change 0.048s
- live pre-hardening fast-path proof on the Heim-PC corpus: ~0.24-0.26s with zero source reads/hashes/event validation and zero target scans

Runtime activation is intentionally not part of this PR.