### PR TITLE
refactor(ingest): modularize processing stages

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,15 +41,18 @@ from storage import (
     write_payload,
     write_payload_unique,
 )
-from provenance import ProvenanceError, validate_provenance, has_provenance
+from provenance import ProvenanceError
 from validation import (
-    normalize_heimgeist_item,
     parse_iso_ts,
     prewarm_validators,
-    validate_insights_daily_payload,
 )
 from integrity import IntegrityManager
-from canonical_ingest import build_envelope
+from canonical_ingest import (
+    apply_retention_policy,
+    build_quality_envelope,
+    payload_event_type,
+)
+from ingest_validation import validate_and_normalize_item
 
 # --- Runtime constants & logging ---
 MAX_PAYLOAD_SIZE: Final[int] = int(
@@ -411,71 +414,40 @@ def _process_items(items: list[Any], dom: str) -> list[str]:
     # Pre-compute label to prevent label pollution/entropy
     domain_label = _sanitize_metric_label(dom)
 
-    # Normalisieren & validieren
     for entry in items:
-        if not isinstance(entry, dict):
-            raise HTTPException(status_code=400, detail="invalid payload")
+        try:
+            normalized = validate_and_normalize_item(
+                entry,
+                dom,
+                provenance_enforced=is_provenance_enforced,
+            )
+        except ProvenanceError as exc:
+            provenance_validation_failures.labels(domain=domain_label).inc()
+            events_rejected_total.labels(domain=domain_label, reason="provenance").inc()
+            logger.warning(
+                f"Provenance validation failed: {exc}", extra={"domain": dom}
+            )
+            raise HTTPException(
+                status_code=400,
+                detail=f"provenance validation failed: {str(exc)}",
+            ) from exc
 
-        normalized = dict(entry)
-
-        # 1. Validation & Normalization logic per domain
-        if dom == "insights.daily":
-            validate_insights_daily_payload(normalized)
-        elif dom == "heimgeist":
-            normalized = normalize_heimgeist_item(normalized)
-        else:
-            # Generic domain checks
-            summary_val = normalized.get("summary")
-            if isinstance(summary_val, str) and len(summary_val) > 500:
-                raise HTTPException(status_code=422, detail="summary too long (max 500)")
-
-            if "domain" in normalized:
-                entry_domain = normalized["domain"]
-                if not isinstance(entry_domain, str):
-                    raise HTTPException(status_code=400, detail="invalid payload")
-
-                try:
-                    sanitized_entry_domain = sanitize_domain(entry_domain)
-                except DomainError as exc:
-                    raise HTTPException(status_code=400, detail="invalid payload") from exc
-                if sanitized_entry_domain != dom:
-                    raise HTTPException(status_code=400, detail="domain mismatch")
-        
-        # 1b. Provenance validation (if enabled)
-        if is_provenance_enforced:
-            try:
-                validate_provenance(normalized, strict=True)
-            except ProvenanceError as exc:
-                provenance_validation_failures.labels(domain=domain_label).inc()
-                events_rejected_total.labels(domain=domain_label, reason="provenance").inc()
-                logger.warning(
-                    f"Provenance validation failed: {exc}",
-                    extra={"domain": dom}
-                )
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"provenance validation failed: {str(exc)}"
-                ) from exc
-        else:
-            # Non-strict validation: just log warnings
-            validate_provenance(normalized, strict=False)
-        
-        # 1c. Identify the event type for bounded metrics. Canonical quality and
-        # retention metadata are computed once by the shared envelope constructor.
-        event_type = normalized.get("kind") or normalized.get("type") or normalized.get("event")
+        event_type = payload_event_type(normalized)
         metrics_event_type = event_type if event_type else f"domain.{dom}"
         event_type_for_metrics = _sanitize_metric_label(metrics_event_type)
         received_dt = datetime.now(timezone.utc)
 
-        # 2. Canonical Wrapping (All domains). API and local importers share
-        # this constructor so receipt hashes and retention metadata do not drift.
-        wrapper = build_envelope(
+        quality_envelope = build_quality_envelope(
             dom,
             normalized,
             received_at=received_dt,
             quality_enabled=is_quality_enabled,
         )
-        
+        wrapper = apply_retention_policy(
+            quality_envelope,
+            received_at=received_dt,
+        )
+
         if is_quality_enabled:
             events_signal_strength.labels(
                 domain=domain_label,
@@ -483,7 +455,7 @@ def _process_items(items: list[Any], dom: str) -> list[str]:
             ).inc()
         # Track metrics with sanitized labels (both domain and event_type)
         events_ingested_total.labels(domain=domain_label, event_type=event_type_for_metrics).inc()
-        
+
         lines.append(json.dumps(wrapper, ensure_ascii=False, separators=(",", ":")))
     return lines
 

--- a/canonical_ingest.py
+++ b/canonical_ingest.py
@@ -1,4 +1,5 @@
-"""Canonical Chronik envelope construction shared by API and local importers."""
+"""Functional envelope stages shared by the API and local importers."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -8,25 +9,81 @@ from quality import compute_completeness, compute_signal_strength
 from retention import compute_expiry_date, get_ttl_for_event
 
 
-def build_envelope(domain: str, payload: dict[str, Any], *, received_at: datetime | None = None, quality_enabled: bool = True) -> dict[str, Any]:
-    observed = received_at or datetime.now(timezone.utc)
+def _as_utc(observed: datetime) -> datetime:
     if observed.tzinfo is None:
         raise ValueError("received_at must be timezone-aware")
-    observed = observed.astimezone(timezone.utc)
-    event_type = payload.get("kind") or payload.get("type") or payload.get("event") or "unknown"
-    expiry = compute_expiry_date(str(event_type), observed)
-    wrapper: dict[str, Any] = {
+    return observed.astimezone(timezone.utc)
+
+
+def payload_event_type(payload: dict[str, Any]) -> Any:
+    """Return the event type using Chronik's established field priority."""
+    return payload.get("kind") or payload.get("type") or payload.get("event")
+
+
+def build_quality_envelope(
+    domain: str,
+    payload: dict[str, Any],
+    *,
+    received_at: datetime | None = None,
+    quality_enabled: bool = True,
+) -> dict[str, Any]:
+    """Build the copied base envelope and optional structural quality markers."""
+    observed = _as_utc(received_at or datetime.now(timezone.utc))
+
+    envelope: dict[str, Any] = {
         "domain": domain,
         "received_at": observed.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "payload": dict(payload),
+    }
+    if quality_enabled:
+        envelope["quality"] = {
+            "signal_strength": compute_signal_strength(payload).value,
+            "completeness": compute_completeness(payload),
+        }
+    return envelope
+
+
+def apply_retention_policy(
+    quality_envelope: dict[str, Any], *, received_at: datetime | None = None
+) -> dict[str, Any]:
+    """Return an independently owned envelope ready for persistence."""
+    payload = quality_envelope["payload"]
+    if received_at is None:
+        observed = datetime.strptime(
+            quality_envelope["received_at"], "%Y-%m-%dT%H:%M:%SZ"
+        ).replace(tzinfo=timezone.utc)
+    else:
+        observed = _as_utc(received_at)
+    event_type = payload_event_type(payload) or "unknown"
+    expiry = compute_expiry_date(str(event_type), observed)
+
+    envelope: dict[str, Any] = {
+        "domain": quality_envelope["domain"],
+        "received_at": quality_envelope["received_at"],
         "payload": dict(payload),
         "retention": {
             "ttl_days": get_ttl_for_event(str(event_type)),
             "expires_at": expiry.strftime("%Y-%m-%dT%H:%M:%SZ") if expiry else None,
         },
     }
-    if quality_enabled:
-        wrapper["quality"] = {
-            "signal_strength": compute_signal_strength(payload).value,
-            "completeness": compute_completeness(payload),
-        }
-    return wrapper
+    if "quality" in quality_envelope:
+        envelope["quality"] = dict(quality_envelope["quality"])
+    return envelope
+
+
+def build_envelope(
+    domain: str,
+    payload: dict[str, Any],
+    *,
+    received_at: datetime | None = None,
+    quality_enabled: bool = True,
+) -> dict[str, Any]:
+    """Compose the quality and retention stages for compatibility callers."""
+    observed = received_at or datetime.now(timezone.utc)
+    quality_envelope = build_quality_envelope(
+        domain,
+        payload,
+        received_at=observed,
+        quality_enabled=quality_enabled,
+    )
+    return apply_retention_policy(quality_envelope, received_at=observed)

--- a/ingest_validation.py
+++ b/ingest_validation.py
@@ -1,0 +1,47 @@
+"""Validation, normalization, and provenance stage for HTTP ingest items."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+
+from provenance import validate_provenance
+from storage import DomainError, sanitize_domain
+from validation import normalize_heimgeist_item, validate_insights_daily_payload
+
+
+def validate_and_normalize_item(
+    entry: Any, domain: str, *, provenance_enforced: bool
+) -> dict[str, Any]:
+    """Return a validated outer copy without mutating the caller's item."""
+    if not isinstance(entry, dict):
+        raise HTTPException(status_code=400, detail="invalid payload")
+
+    normalized = dict(entry)
+
+    if domain == "insights.daily":
+        validate_insights_daily_payload(normalized)
+    elif domain == "heimgeist":
+        normalized = normalize_heimgeist_item(normalized)
+    else:
+        summary = normalized.get("summary")
+        if isinstance(summary, str) and len(summary) > 500:
+            raise HTTPException(
+                status_code=422, detail="summary too long (max 500)"
+            )
+
+        if "domain" in normalized:
+            entry_domain = normalized["domain"]
+            if not isinstance(entry_domain, str):
+                raise HTTPException(status_code=400, detail="invalid payload")
+
+            try:
+                sanitized_entry_domain = sanitize_domain(entry_domain)
+            except DomainError as exc:
+                raise HTTPException(status_code=400, detail="invalid payload") from exc
+            if sanitized_entry_domain != domain:
+                raise HTTPException(status_code=400, detail="domain mismatch")
+
+    validate_provenance(normalized, strict=provenance_enforced)
+    return normalized

--- a/tests/test_ingest_pipeline_parity.py
+++ b/tests/test_ingest_pipeline_parity.py
@@ -1,0 +1,303 @@
+import copy
+import json
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
+
+import app
+from canonical_ingest import apply_retention_policy, build_quality_envelope
+from ingest_validation import validate_and_normalize_item
+
+
+RECEIVED_AT = datetime(2026, 1, 1, 12, 34, 56, 789000, tzinfo=timezone.utc)
+
+
+class _FixedDateTime:
+    @classmethod
+    def now(cls, tz=None):
+        assert tz is timezone.utc
+        return RECEIVED_AT
+
+
+class _MetricRecorder:
+    def __init__(self):
+        self.increments = []
+
+    def labels(self, **labels):
+        recorder = self
+
+        class _BoundMetric:
+            def inc(self, amount=1):
+                recorder.increments.append((labels, amount))
+
+        return _BoundMetric()
+
+
+@pytest.fixture
+def process_context(monkeypatch):
+    ingested = _MetricRecorder()
+    signal = _MetricRecorder()
+    rejected = _MetricRecorder()
+    provenance_failures = _MetricRecorder()
+    monkeypatch.setattr(app, "datetime", _FixedDateTime)
+    monkeypatch.setattr(app, "events_ingested_total", ingested)
+    monkeypatch.setattr(app, "events_signal_strength", signal)
+    monkeypatch.setattr(app, "events_rejected_total", rejected)
+    monkeypatch.setattr(app, "provenance_validation_failures", provenance_failures)
+    return {
+        "ingested": ingested,
+        "signal": signal,
+        "rejected": rejected,
+        "provenance_failures": provenance_failures,
+    }
+
+
+@pytest.mark.parametrize(
+    ("domain", "payload", "expected_payload", "retention", "quality", "event_type"),
+    [
+        pytest.param(
+            "example.com",
+            {
+                "domain": "Example.COM",
+                "event_id": "evt-ä",
+                "kind": "app.debug.trace",
+                "ts": "2026-01-01T10:00:00Z",
+                "source": {"repo": "heimgewebe/example", "component": "api"},
+                "data": {"message": "grüß"},
+            },
+            {
+                "domain": "Example.COM",
+                "event_id": "evt-ä",
+                "kind": "app.debug.trace",
+                "ts": "2026-01-01T10:00:00Z",
+                "source": {"repo": "heimgewebe/example", "component": "api"},
+                "data": {"message": "grüß"},
+            },
+            {"ttl_days": 7, "expires_at": "2026-01-08T12:34:56Z"},
+            {"signal_strength": "high", "completeness": True},
+            "app.debug.trace",
+            id="generic-domain",
+        ),
+        pytest.param(
+            "insights.daily",
+            {
+                "ts": "2026-01-01",
+                "topics": [["chronik", 1.0]],
+                "questions": [],
+                "deltas": [],
+                "source": "semantAH",
+                "metadata": {"generated_at": "2026-01-01T10:00:00Z"},
+            },
+            {
+                "ts": "2026-01-01",
+                "topics": [["chronik", 1.0]],
+                "questions": [],
+                "deltas": [],
+                "source": "semantAH",
+                "metadata": {"generated_at": "2026-01-01T10:00:00Z"},
+            },
+            {"ttl_days": 30, "expires_at": "2026-01-31T12:34:56Z"},
+            {"signal_strength": "medium", "completeness": False},
+            "domain.insights.daily",
+            id="insights-daily",
+        ),
+        pytest.param(
+            "heimgeist",
+            {
+                "id": "legacy-1",
+                "source": "heimgeist-worker",
+                "timestamp": "2026-01-01T10:00:00Z",
+                "payload": {
+                    "kind": "heimgeist.insight",
+                    "version": 1,
+                    "data": {"note": "remember"},
+                },
+            },
+            {
+                "kind": "heimgeist.insight",
+                "version": 1,
+                "id": "legacy-1",
+                "meta": {
+                    "occurred_at": "2026-01-01T10:00:00Z",
+                    "producer": "heimgeist-worker",
+                },
+                "data": {"note": "remember"},
+            },
+            {"ttl_days": 30, "expires_at": "2026-01-31T12:34:56Z"},
+            {"signal_strength": "medium", "completeness": False},
+            "heimgeist.insight",
+            id="heimgeist-legacy-normalization",
+        ),
+    ],
+)
+def test_process_items_preserves_canonical_jsonl_and_metrics(
+    monkeypatch,
+    process_context,
+    domain,
+    payload,
+    expected_payload,
+    retention,
+    quality,
+    event_type,
+):
+    monkeypatch.setenv("CHRONIK_ENFORCE_PROVENANCE", "0")
+    monkeypatch.setenv("CHRONIK_ENABLE_QUALITY", "1")
+    original = copy.deepcopy(payload)
+    expected = {
+        "domain": domain,
+        "received_at": "2026-01-01T12:34:56Z",
+        "payload": expected_payload,
+        "retention": retention,
+        "quality": quality,
+    }
+
+    normalized = validate_and_normalize_item(
+        payload,
+        domain,
+        provenance_enforced=False,
+    )
+    quality_envelope = build_quality_envelope(
+        domain,
+        normalized,
+        received_at=RECEIVED_AT,
+        quality_enabled=True,
+    )
+    stage_line = json.dumps(
+        apply_retention_policy(quality_envelope, received_at=RECEIVED_AT),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    lines = app._process_items([payload], domain)
+
+    expected_line = json.dumps(expected, ensure_ascii=False, separators=(",", ":"))
+    assert lines == [stage_line] == [expected_line]
+    assert payload == original
+    assert process_context["signal"].increments == [
+        ({"domain": domain, "signal_strength": quality["signal_strength"]}, 1)
+    ]
+    assert process_context["ingested"].increments == [
+        ({"domain": domain, "event_type": event_type}, 1)
+    ]
+    assert process_context["rejected"].increments == []
+    assert process_context["provenance_failures"].increments == []
+
+
+def test_process_items_quality_disabled_preserves_envelope_and_metric_counts(
+    monkeypatch, process_context
+):
+    monkeypatch.setenv("CHRONIK_ENFORCE_PROVENANCE", "0")
+    monkeypatch.setenv("CHRONIK_ENABLE_QUALITY", "0")
+    payload = {"type": "temp.event", "summary": "accepted"}
+
+    lines = app._process_items([payload], "quality.disabled")
+
+    assert lines == [
+        '{"domain":"quality.disabled","received_at":"2026-01-01T12:34:56Z",'
+        '"payload":{"type":"temp.event","summary":"accepted"},'
+        '"retention":{"ttl_days":1,"expires_at":"2026-01-02T12:34:56Z"}}'
+    ]
+    assert process_context["signal"].increments == []
+    assert process_context["ingested"].increments == [
+        ({"domain": "quality.disabled", "event_type": "temp.event"}, 1)
+    ]
+
+
+def test_process_items_strict_provenance_failure_preserves_detail_and_metrics(
+    monkeypatch, process_context
+):
+    monkeypatch.setenv("CHRONIK_ENFORCE_PROVENANCE", "1")
+    monkeypatch.setenv("CHRONIK_ENABLE_QUALITY", "1")
+
+    with pytest.raises(HTTPException) as exc_info:
+        app._process_items([{"kind": "test.event"}], "strict.example")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == (
+        "provenance validation failed: Missing or invalid provenance fields: "
+        "source (must be an object), event_id (or id)"
+    )
+    assert process_context["provenance_failures"].increments == [
+        ({"domain": "strict.example"}, 1)
+    ]
+    assert process_context["rejected"].increments == [
+        ({"domain": "strict.example", "reason": "provenance"}, 1)
+    ]
+    assert process_context["signal"].increments == []
+    assert process_context["ingested"].increments == []
+
+
+def test_process_items_accepts_complete_provenance_in_strict_mode(
+    monkeypatch, process_context
+):
+    monkeypatch.setenv("CHRONIK_ENFORCE_PROVENANCE", "1")
+    monkeypatch.setenv("CHRONIK_ENABLE_QUALITY", "0")
+    payload = {
+        "event_id": "strict-accepted",
+        "kind": "test.strict",
+        "source": {"repo": "heimgewebe/chronik", "component": "tests"},
+    }
+
+    [line] = app._process_items([payload], "strict.example")
+
+    assert json.loads(line)["payload"] == payload
+    assert process_context["provenance_failures"].increments == []
+    assert process_context["rejected"].increments == []
+    assert process_context["ingested"].increments == [
+        ({"domain": "strict.example", "event_type": "test.strict"}, 1)
+    ]
+
+
+@pytest.mark.parametrize(
+    ("payload", "status_code", "detail"),
+    [
+        ({"domain": "other.example"}, 400, "domain mismatch"),
+        ({"domain": 42}, 400, "invalid payload"),
+        ({"summary": "x" * 501}, 422, "summary too long (max 500)"),
+    ],
+)
+def test_process_items_generic_validation_errors_are_stable(
+    monkeypatch, process_context, payload, status_code, detail
+):
+    monkeypatch.setenv("CHRONIK_ENFORCE_PROVENANCE", "0")
+
+    with pytest.raises(HTTPException) as exc_info:
+        app._process_items([payload], "example.com")
+
+    assert exc_info.value.status_code == status_code
+    assert exc_info.value.detail == detail
+    assert process_context["signal"].increments == []
+    assert process_context["ingested"].increments == []
+
+
+def test_process_items_accepts_summary_at_exact_limit(monkeypatch, process_context):
+    monkeypatch.setenv("CHRONIK_ENFORCE_PROVENANCE", "0")
+    monkeypatch.setenv("CHRONIK_ENABLE_QUALITY", "0")
+
+    [line] = app._process_items([{"summary": "x" * 500}], "example.com")
+
+    assert json.loads(line)["payload"]["summary"] == "x" * 500
+    assert process_context["ingested"].increments == [
+        ({"domain": "example.com", "event_type": "domain.example.com"}, 1)
+    ]
+
+
+def test_process_items_preserves_metrics_for_valid_prefix_of_failed_batch(
+    monkeypatch, process_context
+):
+    monkeypatch.setenv("CHRONIK_ENFORCE_PROVENANCE", "0")
+    monkeypatch.setenv("CHRONIK_ENABLE_QUALITY", "1")
+
+    with pytest.raises(HTTPException) as exc_info:
+        app._process_items(
+            [{"kind": "test.first"}, {"summary": "x" * 501}],
+            "batch.example",
+        )
+
+    assert exc_info.value.status_code == 422
+    assert process_context["signal"].increments == [
+        ({"domain": "batch.example", "signal_strength": "low"}, 1)
+    ]
+    assert process_context["ingested"].increments == [
+        ({"domain": "batch.example", "event_type": "test.first"}, 1)
+    ]


### PR DESCRIPTION
## Summary

- extract HTTP ingest validation, normalization, and provenance into a small functional stage
- split canonical envelope construction into quality and retention stages while preserving build_envelope compatibility
- keep _process_items as the metric-aware thin orchestrator
- freeze generic, insights.daily, heimgeist, provenance, quality, retention, error, mutation, and metric parity in focused tests

## Validation

- make test: 491 passed
- make validate-local: role contract OK, 491 passed, isolated API smoke OK
- focused ingest/app/validation/provenance/quality/retention/coding-memory suite: 161 passed
- git diff checks: clean
- Ruff: not configured in repository tooling