### PR TITLE
refactor(http): add Pydantic ingest adapter

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,6 +53,11 @@ from canonical_ingest import (
     payload_event_type,
 )
 from ingest_validation import validate_and_normalize_item
+from http_adapter import (
+    HttpPayloadShapeError,
+    adapt_ingest_http_items,
+    ingest_request_body_openapi,
+)
 
 # --- Runtime constants & logging ---
 MAX_PAYLOAD_SIZE: Final[int] = int(
@@ -398,6 +403,14 @@ async def _read_body_as_utf8(request: Request, limit: int) -> str:
     return data.decode("utf-8")
 
 
+def _adapt_http_items(value: Any) -> list[dict[str, Any]]:
+    """Apply only the permissive Pydantic HTTP-shape adapter."""
+    try:
+        return adapt_ingest_http_items(value)
+    except HttpPayloadShapeError as exc:
+        raise HTTPException(status_code=400, detail="invalid payload") from exc
+
+
 def _process_items(items: list[Any], dom: str) -> list[str]:
     lines: list[str] = []
     # Leeres Array: nichts zu tun
@@ -546,6 +559,7 @@ def _process_and_write_combined(dom: str, items: list[Any]) -> dict[str, Any] | 
     # Dependency order matters: auth FIRST, then size check.
     dependencies=[Depends(_require_auth_dep), Depends(_validate_body_size)],
     status_code=202,
+    openapi_extra=ingest_request_body_openapi(include_ndjson=True),
 )
 @limiter.limit(RATE_LIMIT)
 async def ingest_v1(
@@ -565,22 +579,23 @@ async def ingest_v1(
     except UnicodeError as exc:
         raise HTTPException(status_code=400, detail="invalid encoding") from exc
 
-    items = []
     if "application/json" in content_type:
         try:
             obj = json.loads(body)
-            items = obj if isinstance(obj, list) else [obj]
         except json.JSONDecodeError as exc:
             raise HTTPException(status_code=400, detail="invalid json") from exc
+        items = _adapt_http_items(obj)
     elif "application/x-ndjson" in content_type:
+        decoded_items: list[Any] = []
         lines = body.strip().split("\n")
         for line in lines:
             if not line:
                 continue
             try:
-                items.append(json.loads(line))
+                decoded_items.append(json.loads(line))
             except json.JSONDecodeError as exc:
                 raise HTTPException(status_code=400, detail="invalid ndjson") from exc
+        items = _adapt_http_items(decoded_items)
     else:
         raise HTTPException(status_code=415, detail="unsupported content-type")
 
@@ -617,6 +632,7 @@ async def ingest_v1(
     # Dependency order matters: auth FIRST, then size check.
     dependencies=[Depends(_require_auth_dep), Depends(_validate_body_size)],
     deprecated=True,
+    openapi_extra=ingest_request_body_openapi(include_ndjson=False),
 )
 @limiter.limit(RATE_LIMIT)
 async def ingest(
@@ -636,8 +652,8 @@ async def ingest(
     except json.JSONDecodeError as exc:
         raise HTTPException(status_code=400, detail="invalid json") from exc
 
-    # Objekt oder Array → JSONL: eine kompakte Zeile pro Eintrag
-    items = obj if isinstance(obj, list) else [obj]
+    # Pydantic adapts only the HTTP object shape; canonical validation follows.
+    items = _adapt_http_items(obj)
     try:
         result = await run_in_threadpool(_process_and_write_combined, dom, items)
     except StorageError as exc:

--- a/http_adapter.py
+++ b/http_adapter.py
@@ -1,0 +1,69 @@
+"""Permissive Pydantic adapter for Chronik's HTTP ingest boundary.
+
+The adapter validates only transport shape: an ingest item must be a JSON object.
+It deliberately defines no canonical event fields or semantic constraints. Those
+remain owned by the JSON-Schema/domain validation path in ``ingest_validation``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+
+class HttpPayloadShapeError(ValueError):
+    """Raised when a decoded HTTP payload is not an object or object batch."""
+
+
+class IngestHttpItem(BaseModel):
+    """Lossless, permissive HTTP object adapter.
+
+    No event fields are declared here on purpose. Pydantic provides the HTTP
+    object boundary and generated OpenAPI shape; canonical contracts validate
+    the contents later in the ingest pipeline.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+
+def adapt_ingest_http_items(value: Any) -> list[dict[str, Any]]:
+    """Adapt one decoded JSON object or a batch without semantic validation."""
+    raw_items = value if isinstance(value, list) else [value]
+    adapted: list[dict[str, Any]] = []
+
+    for raw in raw_items:
+        try:
+            item = IngestHttpItem.model_validate(raw)
+        except ValidationError as exc:
+            raise HttpPayloadShapeError("invalid payload") from exc
+        adapted.append(item.model_dump(mode="python"))
+
+    return adapted
+
+
+def ingest_request_body_openapi(*, include_ndjson: bool) -> dict[str, Any]:
+    """Return request-body metadata generated from the permissive Pydantic model."""
+    item_schema = IngestHttpItem.model_json_schema()
+    content: dict[str, Any] = {
+        "application/json": {
+            "schema": {
+                "oneOf": [
+                    item_schema,
+                    {"type": "array", "items": item_schema},
+                ]
+            }
+        }
+    }
+    if include_ndjson:
+        content["application/x-ndjson"] = {
+            "schema": {
+                "type": "string",
+                "description": (
+                    "One JSON object per line. Pydantic validates only the HTTP "
+                    "object shape; canonical Chronik contracts validate contents."
+                ),
+            }
+        }
+
+    return {"requestBody": {"required": True, "content": content}}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi>=0.110
+pydantic>=2.6,<3
 uvicorn[standard]>=0.27
 filelock>=3.13
 prometheus-fastapi-instrumentator>=6.1,<7

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+import app
+from http_adapter import HttpPayloadShapeError, adapt_ingest_http_items
+
+
+def test_adapter_preserves_arbitrary_json_object_fields() -> None:
+    payload = {
+        "custom": "value",
+        "nested": {"items": [1, True, None, {"x": 2.5}]},
+        "unmodeled": 17,
+    }
+
+    assert adapt_ingest_http_items(payload) == [payload]
+
+
+def test_adapter_accepts_empty_batch_and_rejects_scalar_items() -> None:
+    assert adapt_ingest_http_items([]) == []
+
+    with pytest.raises(HttpPayloadShapeError):
+        adapt_ingest_http_items([{"ok": True}, "not-an-object"])
+
+
+def test_canonical_validation_still_runs_after_http_adapter() -> None:
+    items = app._adapt_http_items({"summary": "x" * 501})
+
+    with pytest.raises(HTTPException) as exc_info:
+        app._process_items(items, "example.com")
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "summary too long (max 500)"
+
+
+def test_openapi_uses_permissive_pydantic_shape_for_ingest() -> None:
+    operation = app.app.openapi()["paths"]["/v1/ingest"]["post"]
+    content = operation["requestBody"]["content"]
+    schema = content["application/json"]["schema"]
+
+    assert "application/x-ndjson" in content
+    assert len(schema["oneOf"]) == 2
+    object_schema = schema["oneOf"][0]
+    assert object_schema["type"] == "object"
+    assert object_schema["additionalProperties"] is True
+    assert object_schema.get("required", []) == []
+    assert schema["oneOf"][1]["type"] == "array"


### PR DESCRIPTION
## Summary
- add a deliberately permissive Pydantic model at the HTTP ingest boundary
- keep JSON-Schema/domain validators in `ingest_validation.py` fully canonical and unchanged
- expose JSON object/batch plus NDJSON request shapes in generated FastAPI OpenAPI metadata
- declare Pydantic 2 as a direct runtime dependency

## Contract boundary
Pydantic validates only that decoded ingest items are JSON objects and preserves arbitrary fields (`extra="allow"`). It does not define event fields, replace JSON Schema validation, or weaken provenance/domain checks.

## Validation
- `./scripts/validate-local.sh` → role-contract OK, 495 passed, local API smoke OK
- targeted adapter + app suite → 58 passed
- existing Starlette/FastAPI TestClient deprecation warning remains unrelated to this patch

Implements optimization plan item 1.2.