### PR TITLE
refactor(config): centralize runtime settings

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import re
 import secrets
 import time
@@ -58,13 +57,13 @@ from http_adapter import (
     adapt_ingest_http_items,
     ingest_request_body_openapi,
 )
+from settings import Settings
 
 # --- Runtime constants & logging ---
-MAX_PAYLOAD_SIZE: Final[int] = int(
-    os.getenv("CHRONIK_MAX_BODY") or str(1024 * 1024)
-)
+_STARTUP_SETTINGS = Settings()
+MAX_PAYLOAD_SIZE: Final[int] = _STARTUP_SETTINGS.max_payload_size
 MAX_RID_LENGTH: Final[int] = 128
-RATE_LIMIT: Final[str] = os.getenv("CHRONIK_RATE_LIMIT") or "60/minute"
+RATE_LIMIT: Final[str] = _STARTUP_SETTINGS.rate_limit
 
 # Provenance enforcement: set to "1" to require provenance fields
 # Quality markers: set to "0" to disable quality marker computation
@@ -73,24 +72,15 @@ RATE_LIMIT: Final[str] = os.getenv("CHRONIK_RATE_LIMIT") or "60/minute"
 
 def _is_provenance_enforced() -> bool:
     """Check if provenance enforcement is enabled at runtime."""
-    return os.getenv("CHRONIK_ENFORCE_PROVENANCE", "0") == "1"
+    return Settings.provenance_enforced_now()
 
 
 def _is_quality_enabled() -> bool:
     """Check if quality markers are enabled at runtime."""
-    return os.getenv("CHRONIK_ENABLE_QUALITY", "1") == "1"
+    return Settings.quality_enabled_now()
 
-LOG_LEVEL = (
-    os.getenv("CHRONIK_LOG_LEVEL") or os.getenv("LOG_LEVEL", "INFO")
-).upper()
-
-_debug_val = (os.getenv("CHRONIK_DEBUG") or "").lower()
-DEBUG_MODE: Final[bool] = _debug_val in {
-    "1",
-    "true",
-    "yes",
-    "on",
-}
+LOG_LEVEL = _STARTUP_SETTINGS.log_level
+DEBUG_MODE: Final[bool] = _STARTUP_SETTINGS.debug_mode
 logging.basicConfig(level=LOG_LEVEL)
 logger = logging.getLogger("chronik")
 
@@ -135,8 +125,7 @@ async def lifespan(app: FastAPI):
     app.state.integrity_manager = IntegrityManager()
 
     # Start integrity sync loop if enabled
-    integrity_enabled = os.getenv("CHRONIK_INTEGRITY_ENABLED", "1") == "1"
-    if integrity_enabled:
+    if Settings.integrity_enabled_now():
         app.state.integrity_task = asyncio.create_task(app.state.integrity_manager.loop())
     else:
         app.state.integrity_task = None
@@ -161,7 +150,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="chronik-ingest", debug=DEBUG_MODE, lifespan=lifespan)
 
-VERSION: Final[str] = os.environ.get("CHRONIK_VERSION") or "1.0.0"
+VERSION: Final[str] = _STARTUP_SETTINGS.version
 
 _METRIC_LABEL_SANITIZER = re.compile(r'[^a-zA-Z0-9._-]')
 _TOKEN_SPLITTER = re.compile(r'[,\r\n]')
@@ -179,7 +168,7 @@ def _get_valid_tokens() -> tuple[str, ...]:
     Results are cached to minimize per-request overhead.
     """
     global _VALID_TOKENS_CACHE, _RAW_TOKEN_ENV_CACHE
-    raw = os.environ.get("CHRONIK_TOKEN", "")
+    raw = Settings.current_token()
 
     # Fast path: Return cached version if environment hasn't changed.
     if _VALID_TOKENS_CACHE is not None and raw == _RAW_TOKEN_ENV_CACHE:

--- a/integrity.py
+++ b/integrity.py
@@ -16,6 +16,7 @@ from storage import (
     sanitize_domain,
 )
 
+from settings import DEFAULT_INTEGRITY_SOURCES_URL, Settings
 from validation import parse_iso_ts
 
 logger = logging.getLogger(__name__)
@@ -39,14 +40,11 @@ def normalize_status(value: Any) -> str:
     v = value.strip().upper()
     return v if v in ALLOWED_STATUS else "UNCLEAR"
 
-DEFAULT_SOURCES_URL = "https://github.com/heimgewebe/metarepo/releases/download/integrity/sources.v1.json"
+DEFAULT_SOURCES_URL = DEFAULT_INTEGRITY_SOURCES_URL
 
 # Concurrency limit for integrity aggregation to prevent threadpool starvation.
 # Default is 20, which is safe for standard Starlette/AnyIO threadpools.
-try:
-    INTEGRITY_CONCURRENCY_LIMIT = int(os.getenv("CHRONIK_INTEGRITY_CONCURRENCY", "20"))
-except ValueError:
-    INTEGRITY_CONCURRENCY_LIMIT = 20
+INTEGRITY_CONCURRENCY_LIMIT = Settings().integrity_concurrency_limit
 
 def get_current_utc_str() -> str:
     """Return current UTC time in strict ISO8601 format (Z-suffix)."""
@@ -55,11 +53,12 @@ def get_current_utc_str() -> str:
 
 class IntegrityManager:
     def __init__(self):
-        self.sources_url = os.getenv("INTEGRITY_SOURCES_URL", DEFAULT_SOURCES_URL)
-        self.override = os.getenv("INTEGRITY_SOURCES_OVERRIDE")
-        self.fetch_interval = int(os.getenv("INTEGRITY_FETCH_INTERVAL_SEC", "300"))
+        settings = Settings()
+        self.sources_url = settings.integrity_sources_url
+        self.override = settings.integrity_sources_override
+        self.fetch_interval = settings.integrity_fetch_interval
         # Default 10 min tolerance for future timestamps
-        self.future_tolerance_min = int(os.getenv("INTEGRITY_FUTURE_TOLERANCE_MIN", "10"))
+        self.future_tolerance_min = settings.integrity_future_tolerance_min
         self._running = False
 
     async def loop(self):

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 python_version = 3.10
-files = http_adapter.py, ingest_validation.py, canonical_ingest.py
+files = settings.py, http_adapter.py, ingest_validation.py, canonical_ingest.py
 ignore_missing_imports = True
 show_error_codes = True
 error_summary = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 fastapi>=0.110
 pydantic>=2.6,<3
+pydantic-settings>=2.15,<3
 uvicorn[standard]>=0.27
 filelock>=3.13
 prometheus-fastapi-instrumentator>=6.1,<7

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,176 @@
+"""Typed environment settings for the Chronik runtime.
+
+Environment variable names and legacy default/empty-value semantics are kept
+stable here. Pydantic-backed instances model process-start and manager configuration.
+Settings that were historically re-read for every request use lightweight class
+methods so runtime toggles remain observable without model-construction overhead.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+DEFAULT_INTEGRITY_SOURCES_URL = (
+    "https://github.com/heimgewebe/metarepo/releases/download/integrity/"
+    "sources.v1.json"
+)
+
+
+class Settings(BaseSettings):
+    """Chronik environment configuration with legacy-compatible semantics."""
+
+    model_config = SettingsConfigDict(
+        case_sensitive=True,
+        extra="ignore",
+        env_file=None,
+        env_ignore_empty=False,
+        frozen=True,
+    )
+
+    max_body_raw: str | None = Field(default=None, validation_alias="CHRONIK_MAX_BODY")
+    rate_limit_raw: str | None = Field(
+        default=None, validation_alias="CHRONIK_RATE_LIMIT"
+    )
+    provenance_raw: str | None = Field(
+        default=None, validation_alias="CHRONIK_ENFORCE_PROVENANCE"
+    )
+    quality_raw: str | None = Field(
+        default=None, validation_alias="CHRONIK_ENABLE_QUALITY"
+    )
+    chronik_log_level_raw: str | None = Field(
+        default=None, validation_alias="CHRONIK_LOG_LEVEL"
+    )
+    fallback_log_level_raw: str | None = Field(
+        default=None, validation_alias="LOG_LEVEL"
+    )
+    debug_raw: str | None = Field(default=None, validation_alias="CHRONIK_DEBUG")
+    integrity_enabled_raw: str | None = Field(
+        default=None, validation_alias="CHRONIK_INTEGRITY_ENABLED"
+    )
+    version_raw: str | None = Field(default=None, validation_alias="CHRONIK_VERSION")
+    token_raw: str | None = Field(default=None, validation_alias="CHRONIK_TOKEN")
+    data_dir_raw: str | None = Field(default=None, validation_alias="CHRONIK_DATA_DIR")
+    lock_timeout_raw: str | None = Field(
+        default=None, validation_alias="CHRONIK_LOCK_TIMEOUT"
+    )
+    integrity_concurrency_raw: str | None = Field(
+        default=None, validation_alias="CHRONIK_INTEGRITY_CONCURRENCY"
+    )
+    integrity_sources_url_raw: str | None = Field(
+        default=None, validation_alias="INTEGRITY_SOURCES_URL"
+    )
+    integrity_sources_override_raw: str | None = Field(
+        default=None, validation_alias="INTEGRITY_SOURCES_OVERRIDE"
+    )
+    integrity_fetch_interval_raw: str | None = Field(
+        default=None, validation_alias="INTEGRITY_FETCH_INTERVAL_SEC"
+    )
+    integrity_future_tolerance_raw: str | None = Field(
+        default=None, validation_alias="INTEGRITY_FUTURE_TOLERANCE_MIN"
+    )
+
+    @staticmethod
+    def _exact_one(raw: str | None, *, default: str) -> bool:
+        return (default if raw is None else raw) == "1"
+
+    @classmethod
+    def current_token(cls) -> str:
+        """Read the dynamic auth token value without constructing a settings model."""
+        return os.environ.get("CHRONIK_TOKEN", "")
+
+    @classmethod
+    def provenance_enforced_now(cls) -> bool:
+        """Read the dynamic provenance switch using its exact legacy semantics."""
+        return cls._exact_one(os.environ.get("CHRONIK_ENFORCE_PROVENANCE"), default="0")
+
+    @classmethod
+    def quality_enabled_now(cls) -> bool:
+        """Read the dynamic quality switch using its exact legacy semantics."""
+        return cls._exact_one(os.environ.get("CHRONIK_ENABLE_QUALITY"), default="1")
+
+    @classmethod
+    def integrity_enabled_now(cls) -> bool:
+        """Read the integrity-loop switch at lifespan start without model overhead."""
+        return cls._exact_one(os.environ.get("CHRONIK_INTEGRITY_ENABLED"), default="1")
+
+    @property
+    def max_payload_size(self) -> int:
+        return int(self.max_body_raw or str(1024 * 1024))
+
+    @property
+    def rate_limit(self) -> str:
+        return self.rate_limit_raw or "60/minute"
+
+    @property
+    def provenance_enforced(self) -> bool:
+        return self._exact_one(self.provenance_raw, default="0")
+
+    @property
+    def quality_enabled(self) -> bool:
+        return self._exact_one(self.quality_raw, default="1")
+
+    @property
+    def log_level(self) -> str:
+        if self.chronik_log_level_raw:
+            return self.chronik_log_level_raw.upper()
+        if self.fallback_log_level_raw is None:
+            return "INFO"
+        return self.fallback_log_level_raw.upper()
+
+    @property
+    def debug_mode(self) -> bool:
+        return (self.debug_raw or "").lower() in {"1", "true", "yes", "on"}
+
+    @property
+    def integrity_enabled(self) -> bool:
+        return self._exact_one(self.integrity_enabled_raw, default="1")
+
+    @property
+    def version(self) -> str:
+        return self.version_raw or "1.0.0"
+
+    @property
+    def token(self) -> str:
+        return "" if self.token_raw is None else self.token_raw
+
+    @property
+    def data_dir(self) -> Path:
+        raw = "data" if self.data_dir_raw is None else self.data_dir_raw
+        return Path(raw).resolve()
+
+    @property
+    def lock_timeout(self) -> int:
+        return int(self.lock_timeout_raw or "30")
+
+    @property
+    def integrity_concurrency_limit(self) -> int:
+        raw = "20" if self.integrity_concurrency_raw is None else self.integrity_concurrency_raw
+        try:
+            return int(raw)
+        except ValueError:
+            return 20
+
+    @property
+    def integrity_sources_url(self) -> str:
+        if self.integrity_sources_url_raw is None:
+            return DEFAULT_INTEGRITY_SOURCES_URL
+        return self.integrity_sources_url_raw
+
+    @property
+    def integrity_sources_override(self) -> str | None:
+        return self.integrity_sources_override_raw
+
+    @property
+    def integrity_fetch_interval(self) -> int:
+        raw = "300" if self.integrity_fetch_interval_raw is None else self.integrity_fetch_interval_raw
+        return int(raw)
+
+    @property
+    def integrity_future_tolerance_min(self) -> int:
+        raw = "10" if self.integrity_future_tolerance_raw is None else self.integrity_future_tolerance_raw
+        return int(raw)

--- a/storage.py
+++ b/storage.py
@@ -15,6 +15,8 @@ from typing import Final, Iterable, Iterator, NoReturn, Tuple
 
 from filelock import FileLock, Timeout
 
+from settings import Settings
+
 from identity_index import (
     IdentityIndexCommitUncertain,
     IdentityIndexDriftError,
@@ -93,9 +95,8 @@ class StorageMissingIdentityError(StorageError):
         )
 
 
-DATA_DIR: Final[Path] = Path(
-    os.environ.get("CHRONIK_DATA_DIR", "data")
-).resolve()
+_STORAGE_SETTINGS = Settings()
+DATA_DIR: Final[Path] = _STORAGE_SETTINGS.data_dir
 DATA_DIR.mkdir(parents=True, exist_ok=True)
 
 # RFC-like FQDN validation: labels 1..63, a-z0-9 and '-' (no '_'), total ≤ 253
@@ -115,7 +116,7 @@ FILENAME_RE: Final[re.Pattern[str]] = re.compile(
 # Additional characters we remove for security (besides / and \0)
 _UNSAFE_FILENAME_CHARS: Final[re.Pattern[str]] = re.compile(r"[][<>:\"|?*]")
 
-LOCK_TIMEOUT: Final[int] = int(os.getenv("CHRONIK_LOCK_TIMEOUT") or "30")
+LOCK_TIMEOUT: Final[int] = _STORAGE_SETTINGS.lock_timeout
 
 
 def sanitize_domain(domain: str) -> str:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,151 @@
+from pathlib import Path
+
+import pytest
+
+from settings import DEFAULT_INTEGRITY_SOURCES_URL, Settings
+
+
+RUNTIME_ENV_KEYS = (
+    "CHRONIK_MAX_BODY",
+    "CHRONIK_RATE_LIMIT",
+    "CHRONIK_ENFORCE_PROVENANCE",
+    "CHRONIK_ENABLE_QUALITY",
+    "CHRONIK_LOG_LEVEL",
+    "LOG_LEVEL",
+    "CHRONIK_DEBUG",
+    "CHRONIK_INTEGRITY_ENABLED",
+    "CHRONIK_VERSION",
+    "CHRONIK_TOKEN",
+    "CHRONIK_DATA_DIR",
+    "CHRONIK_LOCK_TIMEOUT",
+    "CHRONIK_INTEGRITY_CONCURRENCY",
+    "INTEGRITY_SOURCES_URL",
+    "INTEGRITY_SOURCES_OVERRIDE",
+    "INTEGRITY_FETCH_INTERVAL_SEC",
+    "INTEGRITY_FUTURE_TOLERANCE_MIN",
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_settings_environment(monkeypatch):
+    for key in RUNTIME_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_defaults_match_legacy_runtime_contract():
+    settings = Settings()
+
+    assert settings.max_payload_size == 1024 * 1024
+    assert settings.rate_limit == "60/minute"
+    assert settings.provenance_enforced is False
+    assert settings.quality_enabled is True
+    assert settings.log_level == "INFO"
+    assert settings.debug_mode is False
+    assert settings.integrity_enabled is True
+    assert settings.version == "1.0.0"
+    assert settings.token == ""
+    assert settings.data_dir == Path("data").resolve()
+    assert settings.lock_timeout == 30
+    assert settings.integrity_concurrency_limit == 20
+    assert settings.integrity_sources_url == DEFAULT_INTEGRITY_SOURCES_URL
+    assert settings.integrity_sources_override is None
+    assert settings.integrity_fetch_interval == 300
+    assert settings.integrity_future_tolerance_min == 10
+
+
+def test_empty_values_preserve_legacy_fallback_semantics(monkeypatch):
+    monkeypatch.setenv("CHRONIK_MAX_BODY", "")
+    monkeypatch.setenv("CHRONIK_RATE_LIMIT", "")
+    monkeypatch.setenv("CHRONIK_LOG_LEVEL", "")
+    monkeypatch.setenv("LOG_LEVEL", "")
+    monkeypatch.setenv("CHRONIK_VERSION", "")
+    monkeypatch.setenv("CHRONIK_LOCK_TIMEOUT", "")
+    monkeypatch.setenv("CHRONIK_DATA_DIR", "")
+    monkeypatch.setenv("INTEGRITY_SOURCES_URL", "")
+    monkeypatch.setenv("INTEGRITY_SOURCES_OVERRIDE", "")
+
+    settings = Settings()
+
+    assert settings.max_payload_size == 1024 * 1024
+    assert settings.rate_limit == "60/minute"
+    assert settings.log_level == ""
+    assert settings.version == "1.0.0"
+    assert settings.lock_timeout == 30
+    assert settings.data_dir == Path("").resolve()
+    assert settings.integrity_sources_url == ""
+    assert settings.integrity_sources_override == ""
+
+
+def test_boolean_flags_keep_exact_existing_string_semantics(monkeypatch):
+    monkeypatch.setenv("CHRONIK_ENFORCE_PROVENANCE", "1")
+    monkeypatch.setenv("CHRONIK_ENABLE_QUALITY", "0")
+    monkeypatch.setenv("CHRONIK_INTEGRITY_ENABLED", "true")
+    monkeypatch.setenv("CHRONIK_DEBUG", "YES")
+
+    settings = Settings()
+
+    assert settings.provenance_enforced is True
+    assert settings.quality_enabled is False
+    assert settings.integrity_enabled is False
+    assert settings.debug_mode is True
+
+
+def test_log_level_prefers_chronik_specific_value(monkeypatch):
+    monkeypatch.setenv("LOG_LEVEL", "warning")
+    monkeypatch.setenv("CHRONIK_LOG_LEVEL", "debug")
+
+    assert Settings().log_level == "DEBUG"
+
+
+def test_integrity_concurrency_retains_invalid_value_fallback(monkeypatch):
+    monkeypatch.setenv("CHRONIK_INTEGRITY_CONCURRENCY", "not-an-int")
+
+    assert Settings().integrity_concurrency_limit == 20
+
+
+def test_other_integer_settings_remain_fail_closed(monkeypatch):
+    monkeypatch.setenv("CHRONIK_LOCK_TIMEOUT", "invalid")
+    with pytest.raises(ValueError):
+        _ = Settings().lock_timeout
+
+    monkeypatch.delenv("CHRONIK_LOCK_TIMEOUT")
+    monkeypatch.setenv("INTEGRITY_FETCH_INTERVAL_SEC", "")
+    with pytest.raises(ValueError):
+        _ = Settings().integrity_fetch_interval
+
+
+def test_settings_instances_observe_environment_at_construction(monkeypatch):
+    monkeypatch.setenv("CHRONIK_TOKEN", "first")
+    monkeypatch.setenv("CHRONIK_ENABLE_QUALITY", "1")
+    first = Settings()
+
+    monkeypatch.setenv("CHRONIK_TOKEN", "second")
+    monkeypatch.setenv("CHRONIK_ENABLE_QUALITY", "0")
+    second = Settings()
+
+    assert first.token == "first"
+    assert first.quality_enabled is True
+    assert second.token == "second"
+    assert second.quality_enabled is False
+
+
+def test_dynamic_accessors_observe_environment_without_model_rebuild(monkeypatch):
+    monkeypatch.setenv("CHRONIK_TOKEN", "first")
+    monkeypatch.setenv("CHRONIK_ENFORCE_PROVENANCE", "0")
+    monkeypatch.setenv("CHRONIK_ENABLE_QUALITY", "1")
+    monkeypatch.setenv("CHRONIK_INTEGRITY_ENABLED", "1")
+
+    assert Settings.current_token() == "first"
+    assert Settings.provenance_enforced_now() is False
+    assert Settings.quality_enabled_now() is True
+    assert Settings.integrity_enabled_now() is True
+
+    monkeypatch.setenv("CHRONIK_TOKEN", "second")
+    monkeypatch.setenv("CHRONIK_ENFORCE_PROVENANCE", "1")
+    monkeypatch.setenv("CHRONIK_ENABLE_QUALITY", "0")
+    monkeypatch.setenv("CHRONIK_INTEGRITY_ENABLED", "true")
+
+    assert Settings.current_token() == "second"
+    assert Settings.provenance_enforced_now() is True
+    assert Settings.quality_enabled_now() is False
+    assert Settings.integrity_enabled_now() is False


### PR DESCRIPTION
## Summary
- add one typed `Settings` boundary backed by pydantic-settings for Chronik runtime configuration
- preserve existing environment names, defaults, empty-value behavior and exact boolean semantics
- keep historically dynamic token/provenance/quality/integrity reads dynamic via lightweight centralized accessors
- centralize storage and integrity configuration without changing JSON contracts or runtime deployment state

## Validation
- focused settings/auth/integrity: 30 passed
- Ruff: passed
- Mypy: passed
- canonical `scripts/validate-local.sh`: 504 passed; role contract and API persistence smoke passed
- dynamic token accessor benchmark: ~0.60 µs/read versus ~0.46 µs direct env read after removing an initial model-construction hot-path regression

No Chronik runtime activation is included.