### PR TITLE
feat(audit): log structured ingest decisions

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Final, NoReturn
 from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Request
+from fastapi.exception_handlers import http_exception_handler
 from fastapi.responses import JSONResponse, PlainTextResponse
 from filelock import FileLock, Timeout
 from prometheus_fastapi_instrumentator import Instrumentator
@@ -57,6 +58,7 @@ from http_adapter import (
     adapt_ingest_http_items,
     ingest_request_body_openapi,
 )
+from audit_log import AuditAction, emit_audit_event
 from settings import Settings
 
 # --- Runtime constants & logging ---
@@ -202,6 +204,7 @@ async def request_id_logging(request: Request, call_next):
     raw_rid = request.headers.get("X-Request-ID") or str(uuid.uuid4())
     # Sanitize to prevent log injection and limit length
     rid = _METRIC_LABEL_SANITIZER.sub("_", raw_rid)[:MAX_RID_LENGTH]
+    request.state.request_id = rid
     start = time.perf_counter()
     # Falls im Handler ein Fehler hochgeht, loggen wir konservativ 500
     status = 500
@@ -223,6 +226,51 @@ async def request_id_logging(request: Request, call_next):
         )
 
 
+def _is_ingest_request(request: Request) -> bool:
+    path = str(request.scope.get("path", ""))
+    return path == "/v1/ingest" or path.startswith("/ingest/")
+
+
+def _request_audit_domain(request: Request) -> str | None:
+    remembered = getattr(request.state, "audit_domain", None)
+    if remembered is not None:
+        return str(remembered)
+    path_domain = request.path_params.get("domain")
+    if path_domain is not None:
+        return str(path_domain)
+    query_domain = request.query_params.get("domain")
+    if query_domain is not None:
+        return str(query_domain)
+    return None
+
+
+def _audit_ingest_decision(
+    request: Request,
+    action: AuditAction,
+    reason: str,
+    *,
+    domain: str | None = None,
+) -> None:
+    if not _is_ingest_request(request):
+        return
+    if domain is not None:
+        request.state.audit_domain = domain
+    client_ip = request.client.host if request.client is not None else None
+    emit_audit_event(
+        request_id=getattr(request.state, "request_id", None),
+        domain=_request_audit_domain(request),
+        action=action,
+        reason=reason,
+        client_ip=client_ip,
+    )
+
+
+@app.exception_handler(HTTPException)
+async def _on_http_exception(request: Request, exc: HTTPException):
+    _audit_ingest_decision(request, "REJECTED", str(exc.detail))
+    return await http_exception_handler(request, exc)
+
+
 limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter
 app.add_middleware(SlowAPIMiddleware)
@@ -230,6 +278,7 @@ app.add_middleware(SlowAPIMiddleware)
 
 @app.exception_handler(RateLimitExceeded)
 async def _on_rate_limited(request: Request, exc: RateLimitExceeded):
+    _audit_ingest_decision(request, "REJECTED", "rate_limited")
     response = PlainTextResponse("too many requests", status_code=429)
     # Defaulting to 60s which matches our window size.
     # A more precise calculation would require querying the limiter storage.
@@ -557,6 +606,7 @@ async def ingest_v1(
 ):
     # Determine domain from query param or payload
     if domain:
+        request.state.audit_domain = domain
         dom = _sanitize_domain(domain)
     else:
         dom = None
@@ -590,6 +640,7 @@ async def ingest_v1(
 
     if not items:
         logger.warning("empty payload received")
+        _audit_ingest_decision(request, "ACCEPTED", "empty", domain=dom)
         return PlainTextResponse("ok", status_code=202)
 
     # If domain was not in query, try to get it from the first item.
@@ -604,6 +655,7 @@ async def ingest_v1(
                 status_code=400,
                 detail="domain must be specified via query or payload",
             )
+        request.state.audit_domain = first_item_domain
         dom = _sanitize_domain(first_item_domain)
 
     try:
@@ -612,7 +664,9 @@ async def ingest_v1(
         _raise_storage_http_exception(exc, domain=dom)
 
     if result is not None:
+        _audit_ingest_decision(request, "ACCEPTED", str(result["result"]), domain=dom)
         return JSONResponse(result, status_code=202)
+    _audit_ingest_decision(request, "ACCEPTED", "accepted", domain=dom)
     return PlainTextResponse("ok", status_code=202)
 
 
@@ -628,6 +682,7 @@ async def ingest(
     domain: str,
     request: Request,
 ):
+    request.state.audit_domain = domain
     dom = _sanitize_domain(domain)
 
     # JSON parsen
@@ -649,7 +704,11 @@ async def ingest(
         _raise_storage_http_exception(exc, domain=dom)
 
     if result is not None:
+        _audit_ingest_decision(request, "ACCEPTED", str(result["result"]), domain=dom)
         return JSONResponse(result, status_code=202)
+    _audit_ingest_decision(
+        request, "ACCEPTED", "empty" if not items else "accepted", domain=dom
+    )
     return PlainTextResponse("ok", status_code=202)
 
 

--- a/audit_log.py
+++ b/audit_log.py
@@ -1,0 +1,116 @@
+"""Structured, non-authoritative audit logging for Chronik ingest decisions.
+
+Audit events are emitted as one-line JSON to a dedicated logger. They are
+observability evidence only: they do not grant append authority and never
+replace Chronik's canonical JSONL ledger.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import secrets
+from datetime import datetime, timezone
+from typing import Literal
+
+AuditAction = Literal["ACCEPTED", "REJECTED"]
+
+_AUDIT_IP_KEY = secrets.token_bytes(32)
+_MAX_REQUEST_ID = 128
+_MAX_DOMAIN = 253
+_MAX_REASON = 240
+
+
+def _configure_audit_logger() -> logging.Logger:
+    logger = logging.getLogger("chronik.audit")
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    return logger
+
+
+audit_logger = _configure_audit_logger()
+
+
+def _bounded_text(value: str | None, *, default: str, max_length: int) -> str:
+    if value is None:
+        return default
+    text = str(value)
+    if not text:
+        return default
+    return text[:max_length]
+
+
+def anonymize_client_ip(client_ip: str | None, *, key: bytes | None = None) -> str:
+    """Return a process-local pseudonymous identifier without persisting raw IPs."""
+    if not client_ip:
+        return "unknown"
+    digest = hmac.new(
+        _AUDIT_IP_KEY if key is None else key,
+        client_ip.encode("utf-8", errors="replace"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"anon:{digest[:20]}"
+
+
+def build_audit_event(
+    *,
+    request_id: str | None,
+    domain: str | None,
+    action: AuditAction,
+    reason: str | None,
+    client_ip: str | None,
+    now: datetime | None = None,
+) -> dict[str, str]:
+    """Build the stable JSON-compatible audit event contract."""
+    timestamp = now or datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    timestamp = timestamp.astimezone(timezone.utc)
+    timestamp_text = timestamp.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+    return {
+        "timestamp": timestamp_text,
+        "request_id": _bounded_text(
+            request_id, default="unknown", max_length=_MAX_REQUEST_ID
+        ),
+        "domain": _bounded_text(domain, default="unknown", max_length=_MAX_DOMAIN),
+        "action": action,
+        "reason": _bounded_text(reason, default="unspecified", max_length=_MAX_REASON),
+        "client_ip": anonymize_client_ip(client_ip),
+    }
+
+
+def emit_audit_event(
+    *,
+    request_id: str | None,
+    domain: str | None,
+    action: AuditAction,
+    reason: str | None,
+    client_ip: str | None,
+) -> dict[str, str]:
+    """Emit one audit event without allowing logging failure to change HTTP semantics."""
+    event = build_audit_event(
+        request_id=request_id,
+        domain=domain,
+        action=action,
+        reason=reason,
+        client_ip=client_ip,
+    )
+    try:
+        audit_logger.info(
+            json.dumps(event, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        )
+    except Exception:
+        # Audit telemetry must never become append or response authority, even
+        # when both the dedicated and fallback logging backends are unhealthy.
+        try:
+            logging.getLogger("chronik").exception("failed to emit ingest audit event")
+        except Exception:
+            pass
+    return event

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 python_version = 3.10
-files = settings.py, http_adapter.py, ingest_validation.py, canonical_ingest.py
+files = audit_log.py, settings.py, http_adapter.py, ingest_validation.py, canonical_ingest.py
 ignore_missing_imports = True
 show_error_codes = True
 error_summary = False

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,167 @@
+import json
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app
+import audit_log
+import storage
+from audit_log import anonymize_client_ip, build_audit_event, emit_audit_event
+
+
+@pytest.fixture
+def audit_client(monkeypatch, tmp_path):
+    monkeypatch.setenv("CHRONIK_TOKEN", "test-token")
+    monkeypatch.setenv("CHRONIK_INTEGRITY_ENABLED", "0")
+    monkeypatch.setattr(storage, "DATA_DIR", tmp_path)
+    app.limiter.reset()
+
+    events = []
+
+    def capture_event(**kwargs):
+        events.append(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(app, "emit_audit_event", capture_event)
+    try:
+        with TestClient(app.app) as client:
+            yield client, events
+    finally:
+        app.limiter.reset()
+
+
+def test_audit_event_contract_anonymizes_client_ip():
+    raw_ip = "203.0.113.42"
+    event = build_audit_event(
+        request_id="req-123",
+        domain="example.com",
+        action="ACCEPTED",
+        reason="accepted",
+        client_ip=raw_ip,
+        now=datetime(2026, 8, 12, 11, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert event == {
+        "timestamp": "2026-08-12T11:00:00.000Z",
+        "request_id": "req-123",
+        "domain": "example.com",
+        "action": "ACCEPTED",
+        "reason": "accepted",
+        "client_ip": anonymize_client_ip(raw_ip),
+    }
+    assert event["client_ip"].startswith("anon:")
+    assert raw_ip not in json.dumps(event)
+
+
+def test_audit_ip_identifier_is_process_local_and_stable():
+    key = b"test-audit-key"
+    first = anonymize_client_ip("198.51.100.10", key=key)
+    second = anonymize_client_ip("198.51.100.10", key=key)
+    other = anonymize_client_ip("198.51.100.11", key=key)
+
+    assert first == second
+    assert first != other
+    assert "198.51.100" not in first
+
+
+def test_audit_emission_is_one_json_line(monkeypatch):
+    messages = []
+    monkeypatch.setattr(audit_log.audit_logger, "info", messages.append)
+
+    event = emit_audit_event(
+        request_id="req-1",
+        domain="example.com",
+        action="REJECTED",
+        reason="invalid\npayload",
+        client_ip="192.0.2.7",
+    )
+
+    assert len(messages) == 1
+    assert "\n" not in messages[0]
+    assert json.loads(messages[0]) == event
+    assert "192.0.2.7" not in messages[0]
+
+
+def test_audit_logging_failure_cannot_change_ingest_semantics(monkeypatch):
+    def fail_log(_message):
+        raise RuntimeError("logging unavailable")
+
+    monkeypatch.setattr(audit_log.audit_logger, "info", fail_log)
+
+    event = emit_audit_event(
+        request_id="req-1",
+        domain="example.com",
+        action="ACCEPTED",
+        reason="accepted",
+        client_ip="192.0.2.8",
+    )
+
+    assert event["action"] == "ACCEPTED"
+
+
+def test_successful_ingest_emits_accepted_audit_event(audit_client):
+    client, events = audit_client
+
+    response = client.post(
+        "/v1/ingest?domain=example.com",
+        headers={"X-Auth": "test-token", "X-Request-ID": "audit:accepted"},
+        json={"data": "value"},
+    )
+
+    assert response.status_code == 202
+    assert events == [
+        {
+            "request_id": "audit_accepted",
+            "domain": "example.com",
+            "action": "ACCEPTED",
+            "reason": "accepted",
+            "client_ip": "testclient",
+        }
+    ]
+
+
+def test_invalid_json_emits_rejected_audit_event(audit_client):
+    client, events = audit_client
+
+    response = client.post(
+        "/ingest/example.com",
+        headers={
+            "X-Auth": "test-token",
+            "X-Request-ID": "audit:json",
+            "Content-Type": "application/json",
+        },
+        content="{invalid json}",
+    )
+
+    assert response.status_code == 400
+    assert events == [
+        {
+            "request_id": "audit_json",
+            "domain": "example.com",
+            "action": "REJECTED",
+            "reason": "invalid json",
+            "client_ip": "testclient",
+        }
+    ]
+
+
+def test_auth_rejection_is_audited_before_endpoint_execution(audit_client):
+    client, events = audit_client
+
+    response = client.post(
+        "/ingest/example.com",
+        headers={"X-Auth": "wrong", "X-Request-ID": "audit:auth"},
+        json={"data": "value"},
+    )
+
+    assert response.status_code == 401
+    assert events == [
+        {
+            "request_id": "audit_auth",
+            "domain": "example.com",
+            "action": "REJECTED",
+            "reason": "unauthorized",
+            "client_ip": "testclient",
+        }
+    ]


### PR DESCRIPTION
## Summary
- emit one-line JSON audit events for Chronik ingest ACCEPTED/REJECTED decisions
- include timestamp, request_id, domain, reason and process-local HMAC-anonymized client IP
- keep audit telemetry non-authoritative and unable to affect append/HTTP semantics
- cover dependency-level auth/rate-limit failures and endpoint validation/storage HTTP failures without changing existing responses

## Validation
- focused audit/app/auth suite: 77 passed
- regression for direct rate-limit handler scope: passed
- final `scripts/validate-local.sh`: 511 passed, Ruff/Mypy/role-contract/API smoke all green

No JSON contracts, append-only semantics, or runtime deployment state are changed.