### PR TITLE
feat(coding-memory): publish runtime contract

### DIFF
--- a/docs/chronik/coding-memory-runtime-v1.schema.json
+++ b/docs/chronik/coding-memory-runtime-v1.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heimgewebe.org/chronik/coding-memory-runtime-v1.schema.json",
+  "title": "Chronik coding-memory runtime contract v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "entrypoint",
+    "requirements_source",
+    "python",
+    "required_distributions",
+    "does_not_establish"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "chronik-coding-memory-runtime.v1"
+    },
+    "entrypoint": {
+      "const": "tools/coding_memory.py"
+    },
+    "requirements_source": {
+      "const": "requirements.txt"
+    },
+    "python": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requires"],
+      "properties": {
+        "requires": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "required_distributions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["distribution", "specifier", "imports"],
+        "properties": {
+          "distribution": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+          },
+          "specifier": {
+            "type": "string",
+            "minLength": 2
+          },
+          "imports": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+            }
+          }
+        }
+      }
+    },
+    "does_not_establish": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/chronik/coding-memory-v1.md
+++ b/docs/chronik/coding-memory-v1.md
@@ -11,6 +11,17 @@ Grabowski task outbox -> tools/coding_memory.py import -> agent.ledger JSONL
 
 No Plexer, Heimlern, Leitstand or long-running Chronik service is required. API and CLI use the same canonical envelope constructor. Imports are idempotent by `event_id` under the domain file lock.
 
+## Runtime contract
+
+`tools/coding_memory.runtime.v1.json` is the producer-owned, machine-readable runtime contract for the coding-memory CLI. It is deliberately a static release asset: a consumer can inspect the entrypoint, Python requirement and complete external import/distribution mapping **without executing Chronik code first**.
+
+The contract is checked against two independent sources of truth:
+
+- `requirements.txt` must contain the same distribution specifier for every declared runtime dependency;
+- `tools/validate_coding_memory_runtime_contract.py` follows the local Python import closure from `tools/coding_memory.py` with the AST and fails if a non-stdlib import appears without a contract mapping, or if a declared import is no longer reachable.
+
+The current closure declares `filelock`, `jsonschema`, `pydantic`, `pydantic-settings` and `PyYAML`. Consumers may resolve those constraints into their own reproducible lock, but must validate that their selected distributions satisfy the producer contract. The contract does not prove what is installed in a consumer environment and does not by itself prove runtime success.
+
 `import-outbox` maintains a private, reconstructible `source-index.v1.json` next
 to the import receipts. The projection binds loose files and immutable bundle
 artifacts to full filesystem identity (including size, mtime and ctime) and

--- a/docs/chronik/coding-memory-v1.md
+++ b/docs/chronik/coding-memory-v1.md
@@ -13,14 +13,14 @@ No Plexer, Heimlern, Leitstand or long-running Chronik service is required. API 
 
 ## Runtime contract
 
-`tools/coding_memory.runtime.v1.json` is the producer-owned, machine-readable runtime contract for the coding-memory CLI. It is deliberately a static release asset: a consumer can inspect the entrypoint, Python requirement and complete external import/distribution mapping **without executing Chronik code first**.
+`tools/coding_memory.runtime.v1.json` is the producer-owned, machine-readable runtime contract for the coding-memory CLI. It is deliberately a static release asset: a consumer can inspect the entrypoint, Python requirement and external import/distribution mapping **without executing Chronik code first**.
 
 The contract is checked against two independent sources of truth:
 
 - `requirements.txt` must contain the same distribution specifier for every declared runtime dependency;
-- `tools/validate_coding_memory_runtime_contract.py` follows the local Python import closure from `tools/coding_memory.py` with the AST and fails if a non-stdlib import appears without a contract mapping, or if a declared import is no longer reachable.
+- `tools/validate_coding_memory_runtime_contract.py` follows the statically reachable local Python import closure from `tools/coding_memory.py` with the AST and fails if a non-stdlib import appears without a contract mapping, or if a declared import is no longer reachable.
 
-The current closure declares `filelock`, `jsonschema`, `pydantic`, `pydantic-settings` and `PyYAML`. Consumers may resolve those constraints into their own reproducible lock, but must validate that their selected distributions satisfy the producer contract. The contract does not prove what is installed in a consumer environment and does not by itself prove runtime success.
+The current static closure declares `filelock`, `jsonschema`, `pydantic`, `pydantic-settings` and `PyYAML`. Consumers may resolve those constraints into their own reproducible lock, but must validate that their selected distributions satisfy the producer contract. Dynamic import absence is explicitly not established; neither are installed consumer versions or runtime success.
 
 `import-outbox` maintains a private, reconstructible `source-index.v1.json` next
 to the import receipts. The projection binds loose files and immutable bundle

--- a/scripts/validate-local.sh
+++ b/scripts/validate-local.sh
@@ -24,6 +24,10 @@ export CHRONIK_DATA_DIR="$TMP_DATA_DIR"
 # worker control / orchestration authority).
 ./.venv/bin/python scripts/check_role.py
 
+# Coding-memory is consumed cross-repository. Its static producer contract must
+# remain complete before any consumer executes Chronik code to discover imports.
+./.venv/bin/python tools/validate_coding_memory_runtime_contract.py
+
 # Keep static analysis in the same canonical validation path used by local
 # development and the Metarepo repository-verification workflow. Ruff is
 # intentionally limited to high-signal correctness rules while historical

--- a/tests/test_coding_memory_runtime_contract.py
+++ b/tests/test_coding_memory_runtime_contract.py
@@ -1,0 +1,79 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR_PATH = ROOT / "tools" / "validate_coding_memory_runtime_contract.py"
+SPEC = importlib.util.spec_from_file_location("coding_memory_runtime_validator", VALIDATOR_PATH)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+def test_coding_memory_runtime_contract_is_schema_valid_and_complete():
+    contract = json.loads((ROOT / "tools" / "coding_memory.runtime.v1.json").read_text(encoding="utf-8"))
+    schema = json.loads((ROOT / "docs" / "chronik" / "coding-memory-runtime-v1.schema.json").read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(contract)
+
+    result = validator.validate_root(ROOT)
+    assert result["external_imports"] == [
+        "filelock",
+        "jsonschema",
+        "pydantic",
+        "pydantic_settings",
+        "yaml",
+    ]
+    assert result["required_distributions"] == [
+        "filelock",
+        "jsonschema",
+        "pydantic",
+        "pydantic-settings",
+        "pyyaml",
+    ]
+
+
+def _fixture_root(tmp_path: Path, *, surprise: bool = False) -> Path:
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools" / "coding_memory.py").write_text("import worker\n", encoding="utf-8")
+    worker = "import known_dep\n"
+    if surprise:
+        worker += "import surprise_dep\n"
+    worker += "raise RuntimeError('must never execute during validation')\n"
+    (tmp_path / "worker.py").write_text(worker, encoding="utf-8")
+    (tmp_path / "requirements.txt").write_text("known-dep>=1\n", encoding="utf-8")
+    (tmp_path / "tools" / "coding_memory.runtime.v1.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "chronik-coding-memory-runtime.v1",
+                "entrypoint": "tools/coding_memory.py",
+                "requirements_source": "requirements.txt",
+                "python": {"requires": ">=3.10"},
+                "required_distributions": [
+                    {
+                        "distribution": "known-dep",
+                        "specifier": ">=1",
+                        "imports": ["known_dep"],
+                    }
+                ],
+                "does_not_establish": ["runtime_success_without_consumer_validation"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_runtime_contract_validation_is_static_and_does_not_execute_local_modules(tmp_path):
+    root = _fixture_root(tmp_path)
+    result = validator.validate_root(root)
+    assert result["external_imports"] == ["known_dep"]
+
+
+def test_runtime_contract_detects_new_external_import_before_consumer_drift(tmp_path):
+    root = _fixture_root(tmp_path, surprise=True)
+    with pytest.raises(ValueError, match=r"missing=.*surprise_dep"):
+        validator.validate_root(root)

--- a/tools/coding_memory.runtime.v1.json
+++ b/tools/coding_memory.runtime.v1.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "chronik-coding-memory-runtime.v1",
+  "entrypoint": "tools/coding_memory.py",
+  "requirements_source": "requirements.txt",
+  "python": {
+    "requires": ">=3.10"
+  },
+  "required_distributions": [
+    {
+      "distribution": "filelock",
+      "specifier": ">=3.13",
+      "imports": ["filelock"]
+    },
+    {
+      "distribution": "jsonschema",
+      "specifier": ">=4.0",
+      "imports": ["jsonschema"]
+    },
+    {
+      "distribution": "pydantic",
+      "specifier": ">=2.6,<3",
+      "imports": ["pydantic"]
+    },
+    {
+      "distribution": "pydantic-settings",
+      "specifier": ">=2.15,<3",
+      "imports": ["pydantic_settings"]
+    },
+    {
+      "distribution": "pyyaml",
+      "specifier": ">=6.0",
+      "imports": ["yaml"]
+    }
+  ],
+  "does_not_establish": [
+    "installed_distribution_versions",
+    "consumer_environment_compatibility",
+    "runtime_success_without_consumer_validation"
+  ]
+}

--- a/tools/coding_memory.runtime.v1.json
+++ b/tools/coding_memory.runtime.v1.json
@@ -33,6 +33,7 @@
     }
   ],
   "does_not_establish": [
+    "dynamic_import_absence",
     "installed_distribution_versions",
     "consumer_environment_compatibility",
     "runtime_success_without_consumer_validation"

--- a/tools/validate_coding_memory_runtime_contract.py
+++ b/tools/validate_coding_memory_runtime_contract.py
@@ -12,6 +12,8 @@ from typing import Iterable
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT_PATH = Path("tools/coding_memory.runtime.v1.json")
 EXPECTED_SCHEMA_VERSION = "chronik-coding-memory-runtime.v1"
+EXPECTED_ENTRYPOINT = "tools/coding_memory.py"
+EXPECTED_REQUIREMENTS_SOURCE = "requirements.txt"
 
 
 def _normalize_distribution(name: str) -> str:
@@ -31,15 +33,23 @@ def _requirement_map(root: Path, source: str) -> dict[str, str]:
     return values
 
 
+def _repo_file(root: Path, relative: Path) -> Path | None:
+    candidate = root / relative
+    if candidate.is_symlink() or not candidate.is_file():
+        return None
+    resolved_root = root.resolve()
+    resolved = candidate.resolve()
+    if not resolved.is_relative_to(resolved_root):
+        return None
+    return candidate
+
+
 def _local_module(root: Path, module: str) -> Path | None:
     parts = module.split(".")
-    file_candidate = root.joinpath(*parts).with_suffix(".py")
-    if file_candidate.is_file():
+    file_candidate = _repo_file(root, Path(*parts).with_suffix(".py"))
+    if file_candidate is not None:
         return file_candidate
-    package_candidate = root.joinpath(*parts, "__init__.py")
-    if package_candidate.is_file():
-        return package_candidate
-    return None
+    return _repo_file(root, Path(*parts) / "__init__.py")
 
 
 def _import_roots(path: Path) -> set[str]:
@@ -48,13 +58,21 @@ def _import_roots(path: Path) -> set[str]:
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             roots.update(alias.name.split(".", 1)[0] for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
-            roots.add(node.module.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                raise ValueError(
+                    f"relative import is not supported by coding-memory runtime contract v1: {path}"
+                )
+            if node.module:
+                roots.add(node.module.split(".", 1)[0])
     return roots
 
 
 def external_import_closure(root: Path, entrypoint: str) -> set[str]:
-    pending = [root / entrypoint]
+    entrypoint_path = _repo_file(root, Path(entrypoint))
+    if entrypoint_path is None:
+        raise ValueError(f"runtime entrypoint is missing or untrusted: {entrypoint}")
+    pending = [entrypoint_path]
     seen: set[Path] = set()
     external: set[str] = set()
     stdlib = set(sys.stdlib_module_names) | {"__future__"}
@@ -63,8 +81,6 @@ def external_import_closure(root: Path, entrypoint: str) -> set[str]:
         resolved = path.resolve()
         if resolved in seen:
             continue
-        if not path.is_file():
-            raise ValueError(f"runtime entrypoint/module is missing: {path.relative_to(root)}")
         seen.add(resolved)
         for imported in _import_roots(path):
             local = _local_module(root, imported)
@@ -76,16 +92,20 @@ def external_import_closure(root: Path, entrypoint: str) -> set[str]:
 
 
 def validate_root(root: Path) -> dict[str, object]:
-    contract_path = root / CONTRACT_PATH
+    contract_path = _repo_file(root, CONTRACT_PATH)
+    if contract_path is None:
+        raise ValueError("coding-memory runtime contract is missing or untrusted")
     contract = json.loads(contract_path.read_text(encoding="utf-8"))
     if contract.get("schema_version") != EXPECTED_SCHEMA_VERSION:
         raise ValueError("coding-memory runtime schema_version mismatch")
     entrypoint = contract.get("entrypoint")
     source = contract.get("requirements_source")
-    if not isinstance(entrypoint, str) or not entrypoint:
-        raise ValueError("coding-memory runtime entrypoint is invalid")
-    if not isinstance(source, str) or not source:
-        raise ValueError("coding-memory requirements_source is invalid")
+    if entrypoint != EXPECTED_ENTRYPOINT:
+        raise ValueError("coding-memory runtime entrypoint mismatch")
+    if source != EXPECTED_REQUIREMENTS_SOURCE:
+        raise ValueError("coding-memory requirements_source mismatch")
+    if _repo_file(root, Path(source)) is None:
+        raise ValueError("coding-memory requirements source is missing or untrusted")
 
     declared_imports: set[str] = set()
     declared_distributions: set[str] = set()

--- a/tools/validate_coding_memory_runtime_contract.py
+++ b/tools/validate_coding_memory_runtime_contract.py
@@ -122,7 +122,7 @@ def validate_root(root: Path) -> dict[str, object]:
     stale = sorted(declared_imports - observed_imports)
     if missing or stale:
         raise ValueError(
-            "coding-memory import closure drift: "
+            "coding-memory static import closure drift: "
             f"missing={missing or []} stale={stale or []}"
         )
     return {
@@ -134,7 +134,7 @@ def validate_root(root: Path) -> dict[str, object]:
 
 
 def main(argv: Iterable[str] | None = None) -> int:
-    args = list(argv or sys.argv[1:])
+    args = list(sys.argv[1:] if argv is None else argv)
     if args:
         raise SystemExit("usage: validate_coding_memory_runtime_contract.py")
     try:

--- a/tools/validate_coding_memory_runtime_contract.py
+++ b/tools/validate_coding_memory_runtime_contract.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Validate Chronik's static coding-memory runtime contract without importing Chronik."""
+from __future__ import annotations
+
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = Path("tools/coding_memory.runtime.v1.json")
+EXPECTED_SCHEMA_VERSION = "chronik-coding-memory-runtime.v1"
+
+
+def _normalize_distribution(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _requirement_map(root: Path, source: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw in (root / source).read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        match = re.fullmatch(r"([A-Za-z0-9_.-]+)(?:\[[^]]+\])?(.+)", line)
+        if match is None:
+            raise ValueError(f"unsupported requirement line: {raw!r}")
+        values[_normalize_distribution(match.group(1))] = match.group(2).replace(" ", "")
+    return values
+
+
+def _local_module(root: Path, module: str) -> Path | None:
+    parts = module.split(".")
+    file_candidate = root.joinpath(*parts).with_suffix(".py")
+    if file_candidate.is_file():
+        return file_candidate
+    package_candidate = root.joinpath(*parts, "__init__.py")
+    if package_candidate.is_file():
+        return package_candidate
+    return None
+
+
+def _import_roots(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            roots.add(node.module.split(".", 1)[0])
+    return roots
+
+
+def external_import_closure(root: Path, entrypoint: str) -> set[str]:
+    pending = [root / entrypoint]
+    seen: set[Path] = set()
+    external: set[str] = set()
+    stdlib = set(sys.stdlib_module_names) | {"__future__"}
+    while pending:
+        path = pending.pop()
+        resolved = path.resolve()
+        if resolved in seen:
+            continue
+        if not path.is_file():
+            raise ValueError(f"runtime entrypoint/module is missing: {path.relative_to(root)}")
+        seen.add(resolved)
+        for imported in _import_roots(path):
+            local = _local_module(root, imported)
+            if local is not None:
+                pending.append(local)
+            elif imported not in stdlib:
+                external.add(imported)
+    return external
+
+
+def validate_root(root: Path) -> dict[str, object]:
+    contract_path = root / CONTRACT_PATH
+    contract = json.loads(contract_path.read_text(encoding="utf-8"))
+    if contract.get("schema_version") != EXPECTED_SCHEMA_VERSION:
+        raise ValueError("coding-memory runtime schema_version mismatch")
+    entrypoint = contract.get("entrypoint")
+    source = contract.get("requirements_source")
+    if not isinstance(entrypoint, str) or not entrypoint:
+        raise ValueError("coding-memory runtime entrypoint is invalid")
+    if not isinstance(source, str) or not source:
+        raise ValueError("coding-memory requirements_source is invalid")
+
+    declared_imports: set[str] = set()
+    declared_distributions: set[str] = set()
+    requirements = _requirement_map(root, source)
+    entries = contract.get("required_distributions")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("coding-memory required_distributions is empty")
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("coding-memory distribution entry is invalid")
+        distribution = entry.get("distribution")
+        specifier = entry.get("specifier")
+        imports = entry.get("imports")
+        if not isinstance(distribution, str) or not isinstance(specifier, str):
+            raise ValueError("coding-memory distribution/specifier is invalid")
+        normalized = _normalize_distribution(distribution)
+        if normalized in declared_distributions:
+            raise ValueError(f"duplicate coding-memory distribution: {distribution}")
+        declared_distributions.add(normalized)
+        if requirements.get(normalized) != specifier.replace(" ", ""):
+            raise ValueError(
+                f"coding-memory requirement drift for {distribution}: "
+                f"contract={specifier!r} requirements={requirements.get(normalized)!r}"
+            )
+        if not isinstance(imports, list) or not imports or not all(isinstance(item, str) and item for item in imports):
+            raise ValueError(f"coding-memory import mapping is invalid for {distribution}")
+        for imported in imports:
+            if imported in declared_imports:
+                raise ValueError(f"duplicate coding-memory import root: {imported}")
+            declared_imports.add(imported)
+
+    observed_imports = external_import_closure(root, entrypoint)
+    missing = sorted(observed_imports - declared_imports)
+    stale = sorted(declared_imports - observed_imports)
+    if missing or stale:
+        raise ValueError(
+            "coding-memory import closure drift: "
+            f"missing={missing or []} stale={stale or []}"
+        )
+    return {
+        "schema_version": EXPECTED_SCHEMA_VERSION,
+        "entrypoint": entrypoint,
+        "external_imports": sorted(observed_imports),
+        "required_distributions": sorted(declared_distributions),
+    }
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = list(argv or sys.argv[1:])
+    if args:
+        raise SystemExit("usage: validate_coding_memory_runtime_contract.py")
+    try:
+        result = validate_root(ROOT)
+    except (OSError, ValueError, json.JSONDecodeError, SyntaxError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Ziel
Chronik veröffentlicht den Coding-Memory-Runtime-Vertrag producerseitig, damit Verbraucher die benötigte Python-Umgebung bestimmen können, ohne zum Dependency-Discovery zuerst Chronik-Code auszuführen.

## Änderung
- statischer Release-Asset `tools/coding_memory.runtime.v1.json` mit Entry-Point, Python-Anforderung und vollständiger statisch erreichbarer Fremdimport-Abbildung;
- explizite Distributionen: `filelock`, `jsonschema`, `pydantic`, `pydantic-settings`, `PyYAML`;
- JSON-Schema für den Vertrag;
- stdlib-only Validator, der `requirements.txt` gegen den Vertrag prüft und die lokale Import-Closure per AST verfolgt;
- Regressionstest erkennt neue undeclared Fremdimports, ohne lokale Module auszuführen;
- `validate-local` bindet den Vertrag als reguläres Gate ein;
- Dokumentation grenzt statische Import-Closure, dynamische Imports und Consumer-Runtime-Evidenz sauber ab.

## Hintergrund
Folgebefund aus heimgewebe/grabowski#743 / Bureau-Kandidat `candidate-81c46db6e542e6118df5ebec`. Der dortige kurzfristige Fix musste Chronik-Abhängigkeiten in Grabowski spiegeln. Dieser PR macht Chronik zur Quelle des Runtime-Vertrags und beseitigt die producerseitige Lücke.

## Verifikation
Die Repository-Regression liegt in `tests/test_coding_memory_runtime_contract.py`; vollständige lokale Aktivierung/Deployment ist nicht Teil dieses PRs und bleibt gemäß `AGENTS.md` separat autorisiert.