### PR TITLE
fix(runtime): use published pydantic-settings floor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi>=0.110
 pydantic>=2.6,<3
-pydantic-settings>=2.15,<3
+pydantic-settings>=2.14,<3
 uvicorn[standard]>=0.27
 filelock>=3.13
 prometheus-fastapi-instrumentator>=6.1,<7

--- a/tools/coding_memory.runtime.v1.json
+++ b/tools/coding_memory.runtime.v1.json
@@ -23,7 +23,7 @@
     },
     {
       "distribution": "pydantic-settings",
-      "specifier": ">=2.15,<3",
+      "specifier": ">=2.14,<3",
       "imports": ["pydantic_settings"]
     },
     {


### PR DESCRIPTION
## Problem
Der mit #275 veröffentlichte Coding-Memory-Runtime-Vertrag hat eine bestehende fehlerhafte Chronik-Vorgabe sichtbar gemacht: `pydantic-settings>=2.15,<3` ist aktuell nicht erfüllbar. Die neueste veröffentlichte Version ist 2.14.2.

## Fix
- `requirements.txt`: Floor auf `pydantic-settings>=2.14,<3` korrigiert.
- `tools/coding_memory.runtime.v1.json`: producerseitigen Coding-Memory-Vertrag identisch korrigiert.

Damit bleibt der Vertrag strikt an Chroniks Requirements gebunden, zeigt aber auf einen tatsächlich lösbaren Versionsbereich. Grabowskis bestehender Lock `pydantic-settings==2.14.2` erfüllt diesen Bereich bereits; es ist kein künstliches Consumer-Upgrade nötig.

## Evidenz
PyPI Release-Historie: 2.14.2 ist die aktuelle veröffentlichte Version (2026-06-19); eine 2.15-Version ist nicht veröffentlicht.