### PR TITLE
fix(http): centralize storage error mapping

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,8 @@ from storage import (
     StorageCursorError,
     StorageFullError,
     StorageBusyError,
+    StorageConflictError,
+    StorageRequiredIdentityError,
     read_tail,
     read_last_line,
     scan_domain,
@@ -542,19 +544,25 @@ def _raise_storage_http_exception(
         raise HTTPException(status_code=507, detail="insufficient storage") from exc
     if isinstance(exc, StorageBusyError):
         raise HTTPException(status_code=429, detail="busy, try again") from exc
-
-    # Fallback for other storage errors (e.g. symlinks, invalid paths).
-    msg = str(exc).lower()
-    if msg.startswith("conflicting event_id:"):
+    if isinstance(exc, StorageCursorError):
+        raise HTTPException(
+            status_code=400, detail="cursor must point to a record boundary"
+        ) from exc
+    if isinstance(exc, StorageConflictError):
         if domain == "agent.ledger":
             _record_agent_ledger_outcome("conflict")
-        raise HTTPException(status_code=409, detail="conflicting event_id") from exc
-    if msg == "missing event_id":
+        raise HTTPException(
+            status_code=409, detail=f"conflicting {exc.identity_key}"
+        ) from exc
+    if isinstance(exc, StorageRequiredIdentityError):
         if domain == "agent.ledger":
             _record_agent_ledger_outcome("invalid_identity")
-        raise HTTPException(status_code=400, detail="missing event_id") from exc
-    if "invalid target" in msg:
-        raise HTTPException(status_code=400, detail="invalid target") from exc
+        raise HTTPException(
+            status_code=400, detail=f"missing {exc.identity_key}"
+        ) from exc
+
+    # All other storage failures are server-side. Internal messages can contain
+    # paths, platform details or recovery state and must never cross the HTTP boundary.
     raise HTTPException(status_code=500, detail="storage error") from exc
 
 
@@ -783,16 +791,8 @@ async def events_v1(
 
     try:
         events, next_cursor, has_more = await run_in_threadpool(_fetch_events_helper, dom, cursor, limit)
-    except StorageCursorError as exc:
-        raise HTTPException(
-            status_code=400, detail="cursor must point to a record boundary"
-        ) from exc
-    except StorageBusyError as exc:
-        raise HTTPException(status_code=429, detail="busy, try again") from exc
     except StorageError as exc:
-        if "invalid target" in str(exc):
-            raise HTTPException(status_code=400, detail="invalid domain") from exc
-        raise HTTPException(status_code=500, detail="storage error") from exc
+        _raise_storage_http_exception(exc)
 
     return {
         "events": events,
@@ -816,10 +816,8 @@ async def latest_v1(domain: str, unwrap: int = 0):
     try:
         # Use storage.read_last_line to get exactly one line efficiently
         line = await run_in_threadpool(read_last_line, dom)
-    except StorageBusyError as exc:
-        raise HTTPException(status_code=429, detail="busy, try again") from exc
     except StorageError as exc:
-        raise HTTPException(status_code=500, detail="storage error") from exc
+        _raise_storage_http_exception(exc)
 
     if line is None:
         raise HTTPException(status_code=404, detail="no data")
@@ -904,11 +902,8 @@ async def tail_v1(
 
     try:
         lines = await run_in_threadpool(read_tail, dom, limit)
-    except StorageBusyError as exc:
-        raise HTTPException(status_code=429, detail="busy, try again") from exc
     except StorageError as exc:
-        # read_tail returns [] on ENOENT, so StorageError means something else
-        raise HTTPException(status_code=500, detail="storage error") from exc
+        _raise_storage_http_exception(exc)
 
     results, dropped, last_seen_dt = await run_in_threadpool(
         _process_tail_lines, lines, since_dt, dom

--- a/storage.py
+++ b/storage.py
@@ -33,6 +33,8 @@ __all__ = [
     "StorageCursorError",
     "StorageFullError",
     "StorageBusyError",
+    "StorageConflictError",
+    "StorageRequiredIdentityError",
     "StorageRecoveryError",
     "StorageMissingIdentityError",
     "sanitize_domain",
@@ -73,6 +75,23 @@ class StorageFullError(StorageError):
 
 class StorageBusyError(StorageError):
     """Raised when the target file is locked/busy."""
+
+
+class StorageConflictError(StorageError):
+    """Raised when a caller-provided identity conflicts with durable ledger truth."""
+
+    def __init__(self, identity_key: str, identity: str) -> None:
+        self.identity_key = identity_key
+        self.identity = identity
+        super().__init__(f"conflicting {identity_key}: {identity}")
+
+
+class StorageRequiredIdentityError(StorageError):
+    """Raised when an append contract requires an identity field that is absent."""
+
+    def __init__(self, identity_key: str) -> None:
+        self.identity_key = identity_key
+        super().__init__(f"missing {identity_key}")
 
 
 class StorageRecoveryError(StorageError):
@@ -844,7 +863,7 @@ def write_payload_unique_groups(
         verified: list[tuple[str, bytes]] = []
         for identity, fingerprint in identities:
             if not isinstance(identity, str) or not identity:
-                raise StorageError(f"missing {identity_key}")
+                raise StorageRequiredIdentityError(identity_key)
             if not isinstance(fingerprint, bytes) or len(fingerprint) != 40:
                 raise StorageError("invalid verification-only payload fingerprint")
             verified.append((identity, fingerprint))
@@ -863,13 +882,13 @@ def write_payload_unique_groups(
             except (TypeError, ValueError) as exc:
                 raise StorageError("invalid JSON line") from exc
             if not parsed_identity:
-                raise StorageError(f"missing {identity_key}")
+                raise StorageRequiredIdentityError(identity_key)
             fingerprint = _payload_fingerprint(canonical_payload)
             previous = candidate_fingerprints.get(parsed_identity)
             if previous is None:
                 candidate_fingerprints[parsed_identity] = fingerprint
             elif previous != fingerprint:
-                raise StorageError(f"conflicting {identity_key}: {parsed_identity}")
+                raise StorageConflictError(identity_key, parsed_identity)
             parsed_rows.append((parsed_identity, line, fingerprint))
             candidate_count += 1
         parsed_groups.append((group_id, parsed_rows, False))
@@ -880,7 +899,7 @@ def write_payload_unique_groups(
             if previous is None:
                 candidate_fingerprints[identity] = fingerprint
             elif previous != fingerprint:
-                raise StorageError(f"conflicting {identity_key}: {identity}")
+                raise StorageConflictError(identity_key, identity)
             verified_rows.append((identity, None, fingerprint))
             candidate_count += 1
         parsed_groups.append((group_id, verified_rows, True))
@@ -950,7 +969,7 @@ def write_payload_unique_groups(
                     for identity, _, fingerprint in parsed:
                         previous = existing.get(identity)
                         if previous is not None and previous != fingerprint:
-                            raise StorageError(f"conflicting {identity_key}: {identity}")
+                            raise StorageConflictError(identity_key, identity)
 
                 missing_verified_groups = [
                     group_id

--- a/tests/test_http_error_mapping.py
+++ b/tests/test_http_error_mapping.py
@@ -1,0 +1,83 @@
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+import app
+import storage
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    monkeypatch.setenv("CHRONIK_TOKEN", "test-token")
+    monkeypatch.setenv("CHRONIK_INTEGRITY_ENABLED", "0")
+    monkeypatch.setattr(storage, "DATA_DIR", tmp_path)
+    app.limiter.reset()
+    try:
+        with TestClient(app.app) as test_client:
+            yield test_client
+    finally:
+        app.limiter.reset()
+
+
+@pytest.mark.parametrize(
+    ("error", "status", "detail"),
+    [
+        (storage.StorageCursorError("internal cursor detail"), 400, "cursor must point to a record boundary"),
+        (storage.StorageBusyError("internal lock path"), 429, "busy, try again"),
+        (storage.StorageFullError("device /secret is full"), 507, "insufficient storage"),
+        (storage.StorageConflictError("event_id", "secret-event-id"), 409, "conflicting event_id"),
+        (storage.StorageRequiredIdentityError("event_id"), 400, "missing event_id"),
+    ],
+)
+def test_storage_contract_errors_have_bounded_http_mapping(error, status, detail):
+    with pytest.raises(HTTPException) as caught:
+        app._raise_storage_http_exception(error)
+
+    assert caught.value.status_code == status
+    assert caught.value.detail == detail
+    assert "secret-event-id" not in str(caught.value.detail)
+
+
+def test_generic_storage_error_is_always_masked_as_server_error():
+    error = storage.StorageError("invalid target /private/storage/path")
+
+    with pytest.raises(HTTPException) as caught:
+        app._raise_storage_http_exception(error)
+
+    assert caught.value.status_code == 500
+    assert caught.value.detail == "storage error"
+    assert "private" not in str(caught.value.detail)
+    assert "invalid target" not in str(caught.value.detail)
+
+
+def test_identity_index_conflict_message_cannot_masquerade_as_client_conflict():
+    error = storage.StorageError("conflicting event_id: damaged-ledger")
+
+    with pytest.raises(HTTPException) as caught:
+        app._raise_storage_http_exception(error, domain="agent.ledger")
+
+    assert caught.value.status_code == 500
+    assert caught.value.detail == "storage error"
+
+
+@pytest.mark.parametrize(
+    ("path", "storage_attr"),
+    [
+        ("/v1/events?domain=example.com", "scan_domain"),
+        ("/v1/latest?domain=example.com", "read_last_line"),
+        ("/v1/tail?domain=example.com", "read_tail"),
+    ],
+)
+def test_read_endpoints_mask_internal_storage_failures(
+    client, monkeypatch, path, storage_attr
+):
+    def fail_storage(*_args, **_kwargs):
+        raise storage.StorageError("backend failure at /private/ledger.jsonl")
+
+    monkeypatch.setattr(app, storage_attr, fail_storage)
+
+    response = client.get(path, headers={"X-Auth": "test-token"})
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "storage error"}
+    assert "private" not in response.text


### PR DESCRIPTION
## Summary
- replace message-string based StorageError classification with typed storage contract errors
- centralize StorageError -> HTTP mapping across ingest/events/latest/tail
- mask all non-contract storage, path, recovery and index failures as 500 `storage error`
- preserve established 400/409/429/507 client-facing contracts

## Validation
- focused error-mapping/security regressions: 15 passed
- full `scripts/validate-local.sh`: 525 passed
- Ruff, Mypy, role contract, coding-memory runtime contract and API smoke green

No runtime activation or deployment is part of this PR.