### PR TITLE
feat(api): add received-at tail window filters

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,8 @@ import re
 import secrets
 import time
 import uuid
-from datetime import datetime, timezone
+from collections import deque
+from datetime import datetime, timedelta, timezone
 from threading import Lock
 from typing import TYPE_CHECKING, Any, Callable, Final, Literal, NoReturn, TypeVar
 
@@ -348,7 +349,11 @@ storage_io_duration_seconds = Histogram(
 )
 
 StorageIOOperation = Literal[
-    "ingest_write", "events_scan", "latest_read", "tail_read"
+    "ingest_write",
+    "events_scan",
+    "latest_read",
+    "tail_read",
+    "tail_window_scan",
 ]
 _StorageResult = TypeVar("_StorageResult")
 
@@ -879,38 +884,73 @@ async def latest_v1(domain: str, unwrap: int = 0):
         raise HTTPException(status_code=500, detail="data corruption") from exc
 
 
+def _parse_tail_query_bound(
+    value: str | None, name: Literal["since", "until"]
+) -> datetime | None:
+    """Parse a public tail bound as an explicit UTC ISO8601 timestamp ending in Z."""
+    if value is None:
+        return None
+    if "T" not in value or not value.endswith("Z"):
+        raise HTTPException(status_code=400, detail=f"invalid {name} format")
+    parsed = parse_iso_ts(value)
+    if parsed is None or parsed.tzinfo is None or parsed.utcoffset() != timedelta(0):
+        raise HTTPException(status_code=400, detail=f"invalid {name} format")
+    return parsed.astimezone(timezone.utc)
+
+
+def _tail_received_at(item: Any) -> datetime | None:
+    """Return an absolute received_at timestamp without producer timestamp fallback."""
+    if not isinstance(item, dict):
+        return None
+    raw = item.get("received_at")
+    if not isinstance(raw, str):
+        return None
+    parsed = parse_iso_ts(raw)
+    if parsed is None or parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def _tail_time_matches(
+    received_at: datetime,
+    since_dt: datetime | None,
+    until_dt: datetime | None,
+) -> bool:
+    if since_dt is not None and received_at < since_dt:
+        return False
+    if until_dt is not None and received_at >= until_dt:
+        return False
+    return True
+
+
 def _process_tail_lines(
-    lines: list[str], since_dt: datetime | None, dom: str
+    lines: list[str],
+    since_dt: datetime | None,
+    dom: str,
+    until_dt: datetime | None = None,
 ) -> tuple[list[Any], int, datetime | None]:
-    """CPU-bound parsing; run in threadpool."""
+    """Parse tail lines; bounded time filters apply strictly to received_at."""
     results: list[Any] = []
     dropped = 0
     last_seen_dt: datetime | None = None
+    filtering = since_dt is not None or until_dt is not None
 
     for line in lines:
         try:
             item = json.loads(line)
-
-            ts_str = None
-            if isinstance(item, dict):
-                ts_str = (
-                    item.get("received_at")
-                    or item.get("ts")
-                    or item.get("timestamp")
-                )
-
-            dt = None
-            if isinstance(ts_str, str):
-                dt = parse_iso_ts(ts_str)
-
-            if since_dt and (dt is None or dt <= since_dt):
-                continue
+            if filtering:
+                dt = _tail_received_at(item)
+                if dt is None or not _tail_time_matches(dt, since_dt, until_dt):
+                    continue
+            else:
+                ts_str = None
+                if isinstance(item, dict):
+                    ts_str = item.get("received_at") or item.get("ts") or item.get("timestamp")
+                dt = parse_iso_ts(ts_str) if isinstance(ts_str, str) else None
 
             results.append(item)
-
-            if dt is not None:
-                if last_seen_dt is None or dt > last_seen_dt:
-                    last_seen_dt = dt
+            if dt is not None and (last_seen_dt is None or dt > last_seen_dt):
+                last_seen_dt = dt
         except json.JSONDecodeError:
             dropped += 1
 
@@ -920,7 +960,37 @@ def _process_tail_lines(
             dropped,
             extra={"domain": dom, "dropped": dropped},
         )
+    return results, dropped, last_seen_dt
 
+
+def _fetch_tail_window_helper(
+    dom: str,
+    limit: int,
+    since_dt: datetime | None,
+    until_dt: datetime | None,
+) -> tuple[list[Any], int, datetime | None]:
+    """Stream forward and retain only the last matching time-window rows."""
+    selected: deque[tuple[Any, datetime]] = deque(maxlen=limit)
+    dropped = 0
+    for _start, _next, line in scan_domain(dom):
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            dropped += 1
+            continue
+        received_at = _tail_received_at(item)
+        if received_at is None or not _tail_time_matches(received_at, since_dt, until_dt):
+            continue
+        selected.append((item, received_at))
+
+    if dropped > 0:
+        logger.warning(
+            "dropped corrupt lines: %d",
+            dropped,
+            extra={"domain": dom, "dropped": dropped},
+        )
+    results = [item for item, _received_at in selected]
+    last_seen_dt = max((received_at for _item, received_at in selected), default=None)
     return results, dropped, last_seen_dt
 
 
@@ -929,32 +999,37 @@ async def tail_v1(
     domain: str,
     limit: int = 200,
     since: str | None = None,
+    until: str | None = None,
 ):
     if limit < 1:
         raise HTTPException(status_code=400, detail="limit must be >= 1")
     if limit > 2000:
         raise HTTPException(status_code=400, detail="limit must be <= 2000")
 
-    since_dt: datetime | None = None
-    if since:
-        since_dt = parse_iso_ts(since)
-        if since_dt is None:
-            raise HTTPException(status_code=400, detail="invalid since format")
-
+    since_dt = _parse_tail_query_bound(since, "since")
+    until_dt = _parse_tail_query_bound(until, "until")
     try:
         dom = _sanitize_domain(domain)
     except HTTPException:
-        # If domain invalid, _sanitize_domain raises 400
         raise
 
     try:
-        lines = await _run_storage_io("tail_read", read_tail, dom, limit)
+        if since_dt is not None or until_dt is not None:
+            results, dropped, last_seen_dt = await _run_storage_io(
+                "tail_window_scan",
+                _fetch_tail_window_helper,
+                dom,
+                limit,
+                since_dt,
+                until_dt,
+            )
+        else:
+            lines = await _run_storage_io("tail_read", read_tail, dom, limit)
+            results, dropped, last_seen_dt = await run_in_threadpool(
+                _process_tail_lines, lines, None, dom
+            )
     except StorageError as exc:
         _raise_storage_http_exception(exc)
-
-    results, dropped, last_seen_dt = await run_in_threadpool(
-        _process_tail_lines, lines, since_dt, dom
-    )
 
     headers = {
         "X-Chronik-Lines-Returned": str(len(results)),

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,7 +43,15 @@ Retrieve events for a given domain using a robust, cursor-based pagination mecha
 ## Legacy Endpoints (Deprecated)
 
 ### GET /v1/tail (Deprecated)
-Use `/v1/events` instead.
+Use `/v1/events` instead. The legacy endpoint additionally supports bounded time-window queries for compatibility.
+
+**Parameters:**
+* `domain` (required): Domain to read.
+* `limit` (optional, default 200, max 2000): Maximum number of matching events returned.
+* `since` (optional): ISO8601 UTC timestamp ending in `Z`; inclusive lower bound.
+* `until` (optional): ISO8601 UTC timestamp ending in `Z`; exclusive upper bound.
+
+When either time bound is supplied, filtering is based **only** on the server-generated `received_at` field. Producer-controlled `ts` or `timestamp` fields are not used as substitutes, and records without a valid absolute `received_at` do not match a bounded query. The endpoint returns the last `limit` matching records in append order; newer records outside an `until` window do not hide older matching records. Unfiltered requests retain the existing fast tail behavior.
 
 ### GET /v1/latest (Deprecated)
 Use `/v1/events` with `limit=1` (and iterate backwards if needed, though `/v1/events` is forward-only currently).

--- a/tests/test_process_tail_lines_unit.py
+++ b/tests/test_process_tail_lines_unit.py
@@ -57,70 +57,57 @@ def test_process_tail_lines_all_malformed():
     assert last_seen_dt is None
     mock_logger.warning.assert_called_once()
 
-def test_process_tail_lines_with_since_filter():
-    """
-    Test that _process_tail_lines correctly filters lines based on since_dt
-    even when malformed lines are present.
-    """
+def test_process_tail_lines_with_since_filter_ignores_legacy_timestamps():
     from app import _process_tail_lines
-
     lines = [
-        json.dumps({"ts": "2023-01-01T10:00:00Z", "id": 1}),
+        json.dumps({"ts": "2023-01-01T11:00:00Z", "id": 1}),
         "malformed",
-        json.dumps({"ts": "2023-01-01T11:00:00Z", "id": 2}),
-        json.dumps({"ts": "2023-01-01T12:00:00Z", "id": 3}),
+        json.dumps({"timestamp": "2023-01-01T12:00:00Z", "id": 2}),
     ]
-
     since_dt = datetime(2023, 1, 1, 10, 30, 0, tzinfo=timezone.utc)
-    dom = "test-domain"
-
-    results, dropped, last_seen_dt = _process_tail_lines(lines, since_dt, dom)
-
-    assert len(results) == 2
-    assert results[0]["id"] == 2
-    assert results[1]["id"] == 3
+    results, dropped, last_seen_dt = _process_tail_lines(lines, since_dt, "test-domain")
+    assert results == []
     assert dropped == 1
-    assert last_seen_dt == datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    assert last_seen_dt is None
 
-def test_process_tail_lines_with_received_at():
-    """Regression: _process_tail_lines must use received_at for since= filtering.
 
-    Canonical wrappers store the envelope timestamp in received_at. Before the fix,
-    only ts/timestamp were checked, so all canonical-wrapper lines were treated as
-    having no timestamp and were always included (or skipped) regardless of since=.
-    """
+def test_process_tail_lines_received_at_since_is_inclusive():
     from app import _process_tail_lines
-
     lines = [
-        json.dumps({"received_at": "2023-01-01T10:00:00Z", "payload": {"id": 1}}),
-        json.dumps({"received_at": "2023-01-01T11:00:00Z", "payload": {"id": 2}}),
-        json.dumps({"received_at": "2023-01-01T12:00:00Z", "payload": {"id": 3}}),
+        json.dumps({"received_at": "2023-01-01T10:00:00Z", "id": 1}),
+        json.dumps({"received_at": "2023-01-01T11:00:00Z", "id": 2}),
+        json.dumps({"received_at": "2023-01-01T12:00:00Z", "id": 3}),
     ]
-
-    since_dt = datetime(2023, 1, 1, 10, 30, 0, tzinfo=timezone.utc)
-    dom = "test-canonical"
-
-    results, dropped, last_seen_dt = _process_tail_lines(lines, since_dt, dom)
-
-    assert len(results) == 2
-    assert results[0]["payload"]["id"] == 2
-    assert results[1]["payload"]["id"] == 3
+    since_dt = datetime(2023, 1, 1, 11, 0, 0, tzinfo=timezone.utc)
+    results, dropped, last_seen_dt = _process_tail_lines(lines, since_dt, "test-canonical")
+    assert [item["id"] for item in results] == [2, 3]
     assert dropped == 0
     assert last_seen_dt == datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
-    """
-    Test that _process_tail_lines handles valid JSON lines that lack timestamps.
-    """
-    from app import _process_tail_lines
 
+def test_process_tail_lines_until_is_exclusive():
+    from app import _process_tail_lines
+    lines = [
+        json.dumps({"received_at": "2023-01-01T10:00:00Z", "id": 1}),
+        json.dumps({"received_at": "2023-01-01T11:00:00Z", "id": 2}),
+    ]
+    until_dt = datetime(2023, 1, 1, 11, 0, 0, tzinfo=timezone.utc)
+    results, dropped, last_seen_dt = _process_tail_lines(
+        lines, None, "test-canonical", until_dt=until_dt
+    )
+    assert [item["id"] for item in results] == [1]
+    assert dropped == 0
+    assert last_seen_dt == datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def test_process_tail_lines_without_timestamps():
+    from app import _process_tail_lines
     lines = [
         json.dumps({"msg": "no timestamp"}),
         "corrupt",
         json.dumps({"msg": "still no timestamp"}),
     ]
-
     results, dropped, last_seen_dt = _process_tail_lines(lines, None, "test")
-
     assert len(results) == 2
     assert dropped == 1
     assert last_seen_dt is None

--- a/tests/test_tail.py
+++ b/tests/test_tail.py
@@ -85,32 +85,80 @@ def test_tail_valid_data(client, auth_header):
     assert response.headers["X-Chronik-Lines-Returned"] == "5"
     assert "X-Chronik-Last-Seen-TS" in response.headers
 
-def test_tail_since_filter(client, auth_header):
+def test_tail_since_filter_is_inclusive_on_received_at(client, auth_header):
     domain = f"test-since-{secrets.token_hex(4)}"
-    # Events with timestamps
     events = [
-        {"ts": "2023-01-01T10:00:00Z", "id": 1},
-        {"ts": "2023-01-01T11:00:00Z", "id": 2},
-        {"ts": "2023-01-01T12:00:00Z", "id": 3},
+        {"received_at": "2023-01-01T10:00:00Z", "ts": "2099-01-01T00:00:00Z", "id": 1},
+        {"received_at": "2023-01-01T11:00:00Z", "id": 2},
+        {"received_at": "2023-01-01T12:00:00Z", "id": 3},
     ]
     storage.write_payload(domain, [json.dumps(e) for e in events])
-
-    # Since 10:30 -> should match id 2 and 3
     response = client.get(
-        f"/v1/tail?domain={domain}&since=2023-01-01T10:30:00Z", headers=auth_header
+        "/v1/tail",
+        params={"domain": domain, "since": "2023-01-01T11:00:00Z"},
+        headers=auth_header,
     )
     assert response.status_code == 200
-    results = response.json()
-    assert len(results) == 2
-    assert results[0]["id"] == 2
-    assert results[1]["id"] == 3
+    assert [item["id"] for item in response.json()] == [2, 3]
+    assert "12:00:00" in response.headers["X-Chronik-Last-Seen-TS"]
 
-    # Invalid since format
+
+def test_tail_until_is_exclusive_and_reaches_older_matches(client, auth_header):
+    domain = f"test-until-{secrets.token_hex(4)}"
+    events = [
+        {"received_at": f"2023-01-01T{hour:02d}:00:00Z", "id": hour}
+        for hour in (10, 11, 12, 13)
+    ]
+    storage.write_payload(domain, [json.dumps(e) for e in events])
     response = client.get(
-        f"/v1/tail?domain={domain}&since=invalid-ts", headers=auth_header
+        "/v1/tail",
+        params={"domain": domain, "limit": 2, "until": "2023-01-01T12:00:00Z"},
+        headers=auth_header,
+    )
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()] == [10, 11]
+    assert "11:00:00" in response.headers["X-Chronik-Last-Seen-TS"]
+
+
+def test_tail_time_window_uses_received_at_only(client, auth_header):
+    domain = f"test-received-at-only-{secrets.token_hex(4)}"
+    events = [
+        {"ts": "2023-01-01T11:00:00Z", "id": 1},
+        {"timestamp": "2023-01-01T11:30:00Z", "id": 2},
+        {"received_at": "2023-01-01T11:45:00Z", "id": 3},
+    ]
+    storage.write_payload(domain, [json.dumps(e) for e in events])
+    response = client.get(
+        "/v1/tail",
+        params={
+            "domain": domain,
+            "since": "2023-01-01T10:00:00Z",
+            "until": "2023-01-01T12:00:00Z",
+        },
+        headers=auth_header,
+    )
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()] == [3]
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("since", "invalid-ts"),
+        ("since", "2023-01-01T10:00:00+00:00"),
+        ("until", "2023-01-01T12:00:00"),
+        ("until", ""),
+    ],
+)
+def test_tail_time_bounds_require_iso8601_utc_z(client, auth_header, name, value):
+    response = client.get(
+        "/v1/tail",
+        params={"domain": "example.com", name: value},
+        headers=auth_header,
     )
     assert response.status_code == 400
-    assert "invalid since format" in response.text
+    assert response.json() == {"detail": f"invalid {name} format"}
+
 
 def test_tail_corrupt_data(client, auth_header):
     domain = f"test-corrupt-{secrets.token_hex(4)}"


### PR DESCRIPTION
## Summary
- add strict UTC `Z` `since` and `until` bounds to deprecated `/v1/tail`
- filter bounded queries strictly on server-generated `received_at`
- make `since` inclusive and `until` exclusive
- retain the last `limit` matching rows with O(limit) memory so newer out-of-window rows do not hide older matches
- preserve the existing fast unfiltered tail path
- document the contract and extend the storage I/O metric with fixed `tail_window_scan`

## Verification
- focused tail/error/observability suite: 39 passed
- full `scripts/validate-local.sh`: 537 passed
- Ruff, Mypy, role contract, coding-memory runtime contract and API smoke green

No storage-layout, append-only persistence, global timestamp parser, deployment or runtime-activation changes.