### PR TITLE
feat: add Weltgewebe history projection contract

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,6 +56,7 @@ from canonical_ingest import (
     payload_event_type,
 )
 from ingest_validation import validate_and_normalize_item
+from weltgewebe_history import WELTGEWEBE_HISTORY_DOMAIN
 from http_adapter import (
     HttpPayloadShapeError,
     adapt_ingest_http_items,
@@ -616,7 +617,9 @@ def _raise_storage_http_exception(
     raise HTTPException(status_code=500, detail="storage error") from exc
 
 
-def _agent_ledger_result(*, requested: int, written: int, skipped: int) -> dict[str, Any]:
+def _unique_ingest_result(
+    domain: str, *, requested: int, written: int, skipped: int
+) -> dict[str, Any]:
     if written == requested:
         result = "accepted"
     elif skipped == requested:
@@ -624,7 +627,7 @@ def _agent_ledger_result(*, requested: int, written: int, skipped: int) -> dict[
     else:
         result = "mixed"
     return {
-        "domain": "agent.ledger",
+        "domain": domain,
         "result": result,
         "requested": requested,
         "written": written,
@@ -633,19 +636,21 @@ def _agent_ledger_result(*, requested: int, written: int, skipped: int) -> dict[
 
 
 def _process_and_write_combined(dom: str, items: list[Any]) -> dict[str, Any] | None:
-    """Process one request and preserve existing semantics outside agent.ledger."""
+    """Process one request and preserve existing semantics outside unique domains."""
     lines_to_write = _process_items(items, dom)
     if not lines_to_write:
         return None
-    if dom == "agent.ledger":
+    if dom in {"agent.ledger", WELTGEWEBE_HISTORY_DOMAIN}:
         written, skipped = write_payload_unique(dom, lines_to_write, identity_key="event_id")
-        result = _agent_ledger_result(
+        result = _unique_ingest_result(
+            dom,
             requested=len(lines_to_write),
             written=written,
             skipped=skipped,
         )
         _record_persisted_events(dom, written)
-        _record_agent_ledger_outcome(str(result["result"]))
+        if dom == "agent.ledger":
+            _record_agent_ledger_outcome(str(result["result"]))
         return result
     write_payload(dom, lines_to_write)
     _record_persisted_events(dom, len(lines_to_write))

--- a/docs/chronik/weltgewebe-history-event-v1.schema.json
+++ b/docs/chronik/weltgewebe-history-event-v1.schema.json
@@ -1,0 +1,251 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heimgewebe.local/chronik/weltgewebe-history-event-v1.schema.json",
+  "title": "Chronik Weltgewebe History Event v1",
+  "description": "A projection-only, append-only Chronik event for Weltgewebe domain, deployment, federation-delivery and operator-receipt history.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "domain",
+    "event_id",
+    "kind",
+    "ts",
+    "source",
+    "correlation_id",
+    "source_evidence",
+    "privacy",
+    "lifecycle",
+    "authority",
+    "payload"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "weltgewebe.history.v1"
+    },
+    "domain": {
+      "const": "weltgewebe.history"
+    },
+    "event_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "kind": {
+      "enum": [
+        "domain_event",
+        "deployment",
+        "federation_delivery",
+        "operator_receipt"
+      ]
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "origin",
+        "repo",
+        "component",
+        "version"
+      ],
+      "properties": {
+        "origin": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160
+        },
+        "repo": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "component": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160
+        },
+        "revision": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 160
+        }
+      }
+    },
+    "correlation_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "source_evidence": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 16,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "authority",
+          "reference",
+          "sha256"
+        ],
+        "properties": {
+          "authority": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "reference": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1000
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    },
+    "privacy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "classification",
+        "contains_personal_data"
+      ],
+      "properties": {
+        "classification": {
+          "enum": [
+            "public",
+            "restricted",
+            "private"
+          ]
+        },
+        "contains_personal_data": {
+          "type": "boolean"
+        }
+      }
+    },
+    "lifecycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "target_event_id",
+        "authority_reference"
+      ],
+      "properties": {
+        "state": {
+          "enum": [
+            "active",
+            "redacted",
+            "revoked",
+            "deleted"
+          ]
+        },
+        "target_event_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "authority_reference": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "state": {
+                "const": "active"
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          "then": {
+            "properties": {
+              "target_event_id": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "state": {
+                "enum": [
+                  "redacted",
+                  "revoked",
+                  "deleted"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          "then": {
+            "properties": {
+              "target_event_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200
+              }
+            }
+          }
+        }
+      ]
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "primary_truth",
+        "chronik_role",
+        "writeback_allowed"
+      ],
+      "properties": {
+        "primary_truth": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160,
+          "not": {
+            "enum": [
+              "chronik",
+              "heimgewebe/chronik"
+            ]
+          }
+        },
+        "chronik_role": {
+          "const": "historical_projection"
+        },
+        "writeback_allowed": {
+          "const": false
+        }
+      }
+    },
+    "payload": {
+      "type": "object"
+    }
+  }
+}

--- a/docs/chronik/weltgewebe-history-event-v1.schema.json
+++ b/docs/chronik/weltgewebe-history-event-v1.schema.json
@@ -230,10 +230,7 @@
           "minLength": 1,
           "maxLength": 160,
           "not": {
-            "enum": [
-              "chronik",
-              "heimgewebe/chronik"
-            ]
+            "pattern": "^(?:heimgewebe/)?chronik(?:$|[.:/])"
           }
         },
         "chronik_role": {

--- a/docs/chronik/weltgewebe-history-projection-v1.md
+++ b/docs/chronik/weltgewebe-history-projection-v1.md
@@ -1,0 +1,111 @@
+# Weltgewebe History Projection v1
+
+Status: implementation contract
+Bureau task: `WELTGEWEBE-OS-V1-T007`
+Domain: `weltgewebe.history`
+Schema: [`weltgewebe-history-event-v1.schema.json`](weltgewebe-history-event-v1.schema.json)
+
+## Zweck
+
+Chronik führt für Weltgewebe einen append-only Ereignis- und Wirkungsverlauf. Dieser Verlauf ist eine historische Projektion: Er speichert belegte Aussagen über Vorgänge, ersetzt aber keine Primärwahrheit in Weltgewebe, GitHub/Deployment, der Föderation oder Grabowski.
+
+Der Vertrag unterscheidet vier Ereignisklassen ausdrücklich:
+
+- `domain_event` – fachliches Weltgewebe-Ereignis;
+- `deployment` – Deployment-/Release-Beobachtung;
+- `federation_delivery` – Föderationszustellung;
+- `operator_receipt` – Grabowski-/Operator-Receipt.
+
+## Provenienz
+
+Jeder Eintrag muss maschinenlesbar binden:
+
+- `source.origin` – Ursprung des Ereignisses;
+- `source.repo` und `source.component` – erzeugendes Systemteil;
+- `source.version` – Version des Quellvertrags;
+- optional `source.revision` – konkrete Quellrevision;
+- `correlation_id` – Verbindung zu demselben fachlichen Vorgang;
+- mindestens einen `source_evidence`-Beleg aus `authority`, `reference` und SHA-256.
+
+Chronik erzeugt aus fehlender Provenienz keine Ersatzwahrheit. Ein unvollständiges `weltgewebe.history`-Ereignis wird vor Persistenz abgelehnt.
+
+## Authority Boundary
+
+Jedes Ereignis trägt:
+
+```json
+{
+  "authority": {
+    "primary_truth": "weltgewebe",
+    "chronik_role": "historical_projection",
+    "writeback_allowed": false
+  }
+}
+```
+
+`writeback_allowed` ist im Schema konstant `false`. Der zugehörige Python-Code validiert und projiziert ausschließlich; er enthält keinen Netzwerk-, Git-, Queue-, Deployment- oder Weltgewebe-Schreibpfad.
+
+Chroniks bestehende Leseoberfläche `GET /v1/events?domain=weltgewebe.history` kann den Verlauf ausgeben. Ledgerpräsenz autorisiert keine Wiederholung, Korrektur oder Mutation im Quellsystem.
+
+## Datenschutz und Lebenszyklus
+
+Datenschutz wird pro Ereignis explizit klassifiziert:
+
+- `public`;
+- `restricted`;
+- `private`.
+
+Zusätzlich wird festgehalten, ob der Eintrag personenbezogene Daten enthält.
+
+Widerruf, Redaktion und Löschung werden **nicht** durch Umschreiben einer alten Ledgerzeile ausgedrückt. Stattdessen wird ein neues, belegtes Ereignis angehängt, dessen `lifecycle` auf das ältere `target_event_id` zeigt:
+
+- `active` – ursprünglicher aktiver Eintrag; `target_event_id` ist `null`;
+- `redacted` – eine Redaktionsprojektion wurde festgestellt;
+- `revoked` – die Quellaussage wurde widerrufen;
+- `deleted` – eine Löschprojektion wurde festgestellt.
+
+`project_weltgewebe_lifecycle(...)` leitet daraus read-only den jeweils zuletzt beobachteten Zustand ab. Die Eingabeereignisse werden dabei weder geändert noch entfernt.
+
+Wichtig: `deleted` bedeutet in Chronik eine historische Löschprojektion. Es behauptet nicht, dass Primärdaten im Quellsystem physisch gelöscht wurden. Dafür bleibt die jeweils benannte Primärwahrheit zuständig.
+
+## Retention
+
+Die tatsächliche Chronik-Aufbewahrung bleibt serverseitige Chronik-Wahrheit. Wie bei anderen Ereignissen ergänzt der kanonische Ingest-Envelope:
+
+```json
+{
+  "retention": {
+    "ttl_days": 30,
+    "expires_at": "..."
+  }
+}
+```
+
+Die Werte stammen aus `config/retention.yml`; ein Weltgewebe-Produzent darf keinen eigenen TTL-Wert als Chronik-Retention durchsetzen. So bleiben fachliche Lebenszyklusprojektion und physische Ledger-Aufbewahrung getrennte Begriffe.
+
+## Ingest
+
+Nur die exakte Domain `weltgewebe.history` aktiviert diesen zusätzlichen Vertrag. Andere Chronik-Domains behalten ihre bisherigen Provenienz- und Ingestregeln. Das verhindert, dass T007 bestehende Eventproduzenten rückwirkend verschärft.
+
+Verarbeitung:
+
+```text
+HTTP /v1/ingest
+  -> Domain = weltgewebe.history
+  -> Weltgewebe-History-Schema validieren
+  -> bestehende Chronik-Provenienz validieren
+  -> Quality Envelope
+  -> serverseitige Retention
+  -> append-only Ledger
+```
+
+## Nicht behauptet
+
+Dieser Vertrag begründet nicht:
+
+- fachliche Richtigkeit eines Weltgewebe-Ereignisses;
+- erfolgreiche Zustellung in der Föderation;
+- erfolgreichen Deploymentzustand;
+- Grabowski-Taskabschluss;
+- physische Löschung in einem Primärsystem;
+- Schreib-, Retry-, Rollback- oder Orchestrierungsautorität.

--- a/docs/event-contracts.md
+++ b/docs/event-contracts.md
@@ -14,9 +14,12 @@ Die **kanonischen Contracts** (Draft 2020-12) liegen im **metarepo** unter:
 → chronik validiert seine Fixtures bereits gegen diese Schemata (siehe
   `.github/workflows/validate-*.yml`).
 
-chronik führt keine eigenen, abweichenden JSON-Schemas. Alle Änderungen an der
-Event-Struktur laufen über die Contracts im **metarepo**. Dadurch wird
-Contract-Drift zwischen Repos vermieden und der Event-Backbone stabil gehalten.
+Chronik definiert keine konkurrierenden fachlichen Primärverträge. Fachliche
+Event-Strukturen bleiben bei ihren jeweiligen Quellsystemen beziehungsweise den
+zentralen Contracts. Chronik darf jedoch enge lokale Transport- und
+Projektionsverträge definieren, wenn diese ausschließlich zusätzliche
+Provenienz-, Evidence- und Authority-Grenzen für die historische Speicherung
+festlegen und die Primärwahrheit ausdrücklich beim Quellsystem belassen.
 
 Dieses Dokument beschreibt die chronik-spezifischen Details und kontextualisiert, wie die zentralen Contracts angewendet werden.
 
@@ -122,3 +125,19 @@ Chronik spiegelt das kanonische Schema aus dem Metarepo:
 - `autonomy_level` (`dormant` | `aware` | `reflective` | `critical`)
 - `last_updated` (ISO 8601 Timestamp)
 - `basis_signals` (String Array)
+
+
+## Schema: `weltgewebe.history.v1` (Chronik-local projection contract)
+
+Für `WELTGEWEBE-OS-V1-T007` definiert Chronik einen engen lokalen Projektionsvertrag unter
+`docs/chronik/weltgewebe-history-event-v1.schema.json`. Er ersetzt keinen fachlichen
+Weltgewebe-Contract. Er legt ausschließlich fest, welche Provenienz- und
+Authority-Grenzen Chronik für die historische Spiegelung verlangt.
+
+Der Vertrag unterscheidet `domain_event`, `deployment`, `federation_delivery` und
+`operator_receipt`, bindet Ursprung, Quellversion, Korrelations-ID und mindestens einen
+hashgebundenen Quellbeleg und erzwingt `chronik_role=historical_projection` sowie
+`writeback_allowed=false`. Datenschutzklassifikation und append-only
+Redaktions-/Widerrufs-/Löschprojektionen sind ebenfalls explizit.
+
+Siehe `docs/chronik/weltgewebe-history-projection-v1.md`.

--- a/ingest_validation.py
+++ b/ingest_validation.py
@@ -9,6 +9,11 @@ from fastapi import HTTPException
 from provenance import validate_provenance
 from storage import DomainError, sanitize_domain
 from validation import normalize_heimgeist_item, validate_insights_daily_payload
+from weltgewebe_history import (
+    WELTGEWEBE_HISTORY_DOMAIN,
+    WeltgewebeHistoryError,
+    validate_weltgewebe_history_event,
+)
 
 
 def validate_and_normalize_item(
@@ -24,6 +29,14 @@ def validate_and_normalize_item(
         validate_insights_daily_payload(normalized)
     elif domain == "heimgeist":
         normalized = normalize_heimgeist_item(normalized)
+    elif domain == WELTGEWEBE_HISTORY_DOMAIN:
+        try:
+            validate_weltgewebe_history_event(normalized)
+        except WeltgewebeHistoryError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"weltgewebe history validation failed: {exc}",
+            ) from exc
     else:
         summary = normalized.get("summary")
         if isinstance(summary, str) and len(summary) > 500:

--- a/tests/test_weltgewebe_history_contract.py
+++ b/tests/test_weltgewebe_history_contract.py
@@ -189,9 +189,13 @@ def test_chronik_retention_envelope_remains_authoritative_for_weltgewebe_history
     assert envelope["payload"]["privacy"]["classification"] == "public"
 
 
-def test_chronik_cannot_be_primary_truth() -> None:
+@pytest.mark.parametrize(
+    "primary_truth",
+    ["chronik", "chronik.runtime", "heimgewebe/chronik", "heimgewebe/chronik/runtime"],
+)
+def test_chronik_cannot_be_primary_truth(primary_truth: str) -> None:
     event = _event()
-    event["authority"]["primary_truth"] = "chronik"
+    event["authority"]["primary_truth"] = primary_truth
     with pytest.raises(WeltgewebeHistoryError, match="primary_truth"):
         validate_weltgewebe_history_event(event)
 
@@ -219,6 +223,30 @@ def test_http_round_trip_persists_only_the_historical_projection(
         headers=headers,
     )
     assert response.status_code == 202, response.text
+    assert response.json()["result"] == "accepted"
+
+    replay = client.post(
+        "/v1/ingest?domain=weltgewebe.history",
+        json=event,
+        headers=headers,
+    )
+    assert replay.status_code == 202, replay.text
+    assert replay.json() == {
+        "domain": "weltgewebe.history",
+        "result": "replayed",
+        "requested": 1,
+        "written": 0,
+        "skipped_existing": 1,
+    }
+
+    conflicting = copy.deepcopy(event)
+    conflicting["payload"]["node_id"] = "node-2"
+    conflict = client.post(
+        "/v1/ingest?domain=weltgewebe.history",
+        json=conflicting,
+        headers=headers,
+    )
+    assert conflict.status_code == 409, conflict.text
 
     readback = client.get(
         "/v1/events?domain=weltgewebe.history&limit=10",

--- a/tests/test_weltgewebe_history_contract.py
+++ b/tests/test_weltgewebe_history_contract.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import jsonschema
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from canonical_ingest import build_envelope
+from ingest_validation import validate_and_normalize_item
+from weltgewebe_history import (
+    WELTGEWEBE_HISTORY_DOMAIN,
+    WELTGEWEBE_HISTORY_KINDS,
+    WeltgewebeHistoryError,
+    project_weltgewebe_lifecycle,
+    validate_weltgewebe_history_event,
+)
+
+
+def _event(
+    *,
+    kind: str = "domain_event",
+    event_id: str = "wg-event-1",
+    lifecycle_state: str = "active",
+    target_event_id: str | None = None,
+) -> dict:
+    return {
+        "schema_version": "weltgewebe.history.v1",
+        "domain": WELTGEWEBE_HISTORY_DOMAIN,
+        "event_id": event_id,
+        "kind": kind,
+        "ts": "2026-08-18T10:00:00Z",
+        "source": {
+            "origin": "weltgewebe",
+            "repo": "heimgewebe/weltgewebe",
+            "component": "api",
+            "version": "weltgewebe.event.v1",
+            "revision": "a" * 40,
+        },
+        "correlation_id": "correlation-1",
+        "source_evidence": [
+            {
+                "authority": "weltgewebe",
+                "reference": "outbox:42",
+                "sha256": "b" * 64,
+            }
+        ],
+        "privacy": {
+            "classification": "public",
+            "contains_personal_data": False,
+        },
+        "lifecycle": {
+            "state": lifecycle_state,
+            "target_event_id": target_event_id,
+            "authority_reference": "policy:weltgewebe-history-v1",
+        },
+        "authority": {
+            "primary_truth": "weltgewebe",
+            "chronik_role": "historical_projection",
+            "writeback_allowed": False,
+        },
+        "payload": {"node_id": "node-1"},
+    }
+
+
+def test_schema_is_valid_draft_2020_12() -> None:
+    path = (
+        Path(__file__).parents[1]
+        / "docs"
+        / "chronik"
+        / "weltgewebe-history-event-v1.schema.json"
+    )
+    schema = json.loads(path.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+
+@pytest.mark.parametrize("kind", sorted(WELTGEWEBE_HISTORY_KINDS))
+def test_all_four_typed_event_classes_are_accepted(kind: str) -> None:
+    validate_weltgewebe_history_event(_event(kind=kind))
+
+
+def test_unknown_event_class_is_rejected() -> None:
+    with pytest.raises(WeltgewebeHistoryError, match="kind"):
+        validate_weltgewebe_history_event(_event(kind="generic_event"))
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda event: event["source"].pop("version"),
+        lambda event: event.pop("correlation_id"),
+        lambda event: event.update(source_evidence=[]),
+        lambda event: event["source"].pop("origin"),
+    ],
+)
+def test_provenance_contract_requires_origin_version_correlation_and_evidence(
+    mutation,
+) -> None:
+    event = _event()
+    mutation(event)
+    with pytest.raises(WeltgewebeHistoryError):
+        validate_weltgewebe_history_event(event)
+
+
+def test_source_evidence_requires_hash_bound_reference() -> None:
+    event = _event()
+    event["source_evidence"][0]["sha256"] = "not-a-digest"
+    with pytest.raises(WeltgewebeHistoryError, match="sha256"):
+        validate_weltgewebe_history_event(event)
+
+
+def test_writeback_authority_is_structurally_forbidden() -> None:
+    event = _event()
+    event["authority"]["writeback_allowed"] = True
+    with pytest.raises(WeltgewebeHistoryError, match="writeback_allowed"):
+        validate_weltgewebe_history_event(event)
+
+
+@pytest.mark.parametrize("state", ["redacted", "revoked", "deleted"])
+def test_lifecycle_changes_require_an_explicit_target(state: str) -> None:
+    with pytest.raises(WeltgewebeHistoryError, match="target_event_id"):
+        validate_weltgewebe_history_event(
+            _event(event_id=f"wg-{state}-1", lifecycle_state=state)
+        )
+
+
+def test_active_event_cannot_target_another_event() -> None:
+    with pytest.raises(WeltgewebeHistoryError, match="target_event_id"):
+        validate_weltgewebe_history_event(_event(target_event_id="wg-old"))
+
+
+def test_lifecycle_projection_is_append_only_and_does_not_mutate_source_events() -> None:
+    active = _event()
+    revoked = _event(
+        event_id="wg-revocation-1",
+        lifecycle_state="revoked",
+        target_event_id="wg-event-1",
+    )
+    source = [active, revoked]
+    before = copy.deepcopy(source)
+
+    projected = project_weltgewebe_lifecycle(source)
+
+    assert source == before
+    assert projected["wg-event-1"] == {
+        "state": "revoked",
+        "evidence_event_id": "wg-revocation-1",
+        "authority_reference": "policy:weltgewebe-history-v1",
+        "correlation_id": "correlation-1",
+    }
+
+
+def test_http_ingest_validation_enforces_the_weltgewebe_contract() -> None:
+    event = _event(kind="federation_delivery")
+    normalized = validate_and_normalize_item(
+        event,
+        WELTGEWEBE_HISTORY_DOMAIN,
+        provenance_enforced=True,
+    )
+    assert normalized == event
+
+    invalid = _event()
+    invalid.pop("correlation_id")
+    with pytest.raises(HTTPException) as exc:
+        validate_and_normalize_item(
+            invalid,
+            WELTGEWEBE_HISTORY_DOMAIN,
+            provenance_enforced=True,
+        )
+    assert exc.value.status_code == 400
+    assert "weltgewebe history validation failed" in str(exc.value.detail)
+
+
+def test_chronik_retention_envelope_remains_authoritative_for_weltgewebe_history() -> None:
+    event = _event(kind="operator_receipt")
+    envelope = build_envelope(
+        WELTGEWEBE_HISTORY_DOMAIN,
+        event,
+        received_at=datetime(2026, 8, 18, 10, 0, tzinfo=timezone.utc),
+    )
+
+    assert envelope["payload"] == event
+    assert envelope["retention"]["ttl_days"] >= 0
+    assert "expires_at" in envelope["retention"]
+    assert envelope["payload"]["privacy"]["classification"] == "public"
+
+
+def test_chronik_cannot_be_primary_truth() -> None:
+    event = _event()
+    event["authority"]["primary_truth"] = "chronik"
+    with pytest.raises(WeltgewebeHistoryError, match="primary_truth"):
+        validate_weltgewebe_history_event(event)
+
+
+def test_http_round_trip_persists_only_the_historical_projection(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("CHRONIK_TOKEN", "weltgewebe-test-token")
+    monkeypatch.setenv("CHRONIK_ENABLE_QUALITY", "1")
+    monkeypatch.setenv("CHRONIK_ENFORCE_PROVENANCE", "1")
+    monkeypatch.setenv("CHRONIK_DATA_DIR", str(tmp_path))
+
+    import storage
+
+    monkeypatch.setattr(storage, "DATA_DIR", tmp_path)
+    from app import app
+
+    client = TestClient(app)
+    headers = {"X-Auth": "weltgewebe-test-token"}
+    event = _event(kind="deployment")
+
+    response = client.post(
+        "/v1/ingest?domain=weltgewebe.history",
+        json=event,
+        headers=headers,
+    )
+    assert response.status_code == 202, response.text
+
+    readback = client.get(
+        "/v1/events?domain=weltgewebe.history&limit=10",
+        headers=headers,
+    )
+    assert readback.status_code == 200, readback.text
+    body = readback.json()
+    assert body["meta"]["count"] == 1
+    assert body["events"][0]["payload"] == event
+    assert body["events"][0]["retention"]["ttl_days"] >= 0
+
+    invalid = _event(event_id="wg-writeback-attempt")
+    invalid["authority"]["writeback_allowed"] = True
+    rejected = client.post(
+        "/v1/ingest?domain=weltgewebe.history",
+        json=invalid,
+        headers=headers,
+    )
+    assert rejected.status_code == 400

--- a/weltgewebe_history.py
+++ b/weltgewebe_history.py
@@ -1,0 +1,79 @@
+"""Weltgewebe history projection contract for Chronik.
+
+This module validates a narrow append-only historical projection. It contains no
+writeback, orchestration, deployment or primary-truth mutation path.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable
+
+import jsonschema
+
+WELTGEWEBE_HISTORY_DOMAIN = "weltgewebe.history"
+WELTGEWEBE_HISTORY_SCHEMA_VERSION = "weltgewebe.history.v1"
+WELTGEWEBE_HISTORY_KINDS = frozenset(
+    {"domain_event", "deployment", "federation_delivery", "operator_receipt"}
+)
+_SCHEMA_PATH = (
+    Path(__file__).parent / "docs" / "chronik" / "weltgewebe-history-event-v1.schema.json"
+)
+
+
+class WeltgewebeHistoryError(ValueError):
+    """Raised when a Weltgewebe history projection violates its contract."""
+
+
+@lru_cache(maxsize=1)
+def _validator() -> jsonschema.Draft202012Validator:
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(
+        schema, format_checker=jsonschema.FormatChecker()
+    )
+
+
+def validate_weltgewebe_history_event(payload: dict[str, Any]) -> None:
+    """Validate one projection event without changing caller-owned data."""
+    if not isinstance(payload, dict):
+        raise WeltgewebeHistoryError("payload must be an object")
+    errors = sorted(
+        _validator().iter_errors(payload),
+        key=lambda item: tuple(str(part) for part in item.absolute_path),
+    )
+    if not errors:
+        return
+    error = errors[0]
+    location = ".".join(str(part) for part in error.absolute_path) or "$"
+    raise WeltgewebeHistoryError(f"{location}: {error.message}")
+
+
+def project_weltgewebe_lifecycle(
+    events: Iterable[dict[str, Any]],
+) -> dict[str, dict[str, str]]:
+    """Derive effective lifecycle state from append-only events, read-only.
+
+    An ``active`` event establishes itself. Redaction, revocation and deletion
+    events target an earlier event id. The source events are never rewritten or
+    deleted by this projection.
+    """
+    projection: dict[str, dict[str, str]] = {}
+    for event in events:
+        validate_weltgewebe_history_event(event)
+        lifecycle = event["lifecycle"]
+        state = str(lifecycle["state"])
+        target = (
+            str(event["event_id"])
+            if state == "active"
+            else str(lifecycle["target_event_id"])
+        )
+        projection[target] = {
+            "state": state,
+            "evidence_event_id": str(event["event_id"]),
+            "authority_reference": str(lifecycle["authority_reference"]),
+            "correlation_id": str(event["correlation_id"]),
+        }
+    return projection


### PR DESCRIPTION
Implements WELTGEWEBE-OS-V1-T007 as a narrow Chronik-local historical projection contract.

- typed domain/deployment/federation/operator history events
- origin/version/correlation/source-evidence binding
- Chronik structurally forbidden as primary truth; writeback=false
- explicit privacy classification and append-only redaction/revocation/deletion projections
- event-idempotent history ingestion: exact replay is skipped, same event_id with changed payload conflicts
- exact weltgewebe.history validation without tightening unrelated domains
- HTTP ingest → ledger → readback proof plus writeback/replay/conflict negatives

Self-review fixed two material edge cases before merge: Chronik-prefixed primary-truth aliases and replay identity ambiguity.

Validation on final workspace: role contract, coding-memory contract, Ruff, Mypy, 569 tests, API smoke all green.