### PR TITLE
fix(ci): fail closed on unvalidated fixtures

### DIFF
--- a/.github/workflows/fixtures-validate.yml
+++ b/.github/workflows/fixtures-validate.yml
@@ -29,62 +29,51 @@ jobs:
       - name: Validate fixtures with AJV
         run: |
           failed=0
-          # Use process substitution or just a for loop with find results to avoid subshell issues
-          # We use a for loop over the output of find to ensure variables persist
-          # Note: filenames with spaces are not handled perfectly here but typical for repo
-          for fixture in $(find tests/fixtures -name "*.jsonl"); do
+          while IFS= read -r -d '' fixture; do
             echo "Processing $fixture..."
 
-            # Extract directory name from fixture path (e.g., "aussen" from "tests/fixtures/aussen/sample.jsonl")
-            dir_name=$(dirname "$fixture" | xargs basename)
-            
-            # Try to extract 'type' from the first line of the JSONL file as fallback
+            # Extract directory name from fixture path (e.g., "aussen" from "tests/fixtures/aussen/sample.jsonl").
+            dir_name=$(basename "$(dirname "$fixture")")
+
+            # Try to extract 'type' from the first line of the JSONL file as fallback.
             type=$(head -n 1 "$fixture" | jq -r '.type // empty' 2>/dev/null || echo "")
 
-            # Use type from data if available, otherwise use directory name + ".event"
+            # Use type from data if available, otherwise use directory name + ".event".
             if [ -n "$type" ] && [ "$type" != "null" ]; then
               schema_type="$type"
             else
               schema_type="${dir_name}.event"
             fi
 
-            # Construct schema path
             schema="contracts/json/${schema_type}.schema.json"
-
-            if [ -f "$schema" ]; then
-              echo "Validating $fixture against $schema..."
-              
-              # JSONL files need to be validated line by line
-              # Create a temp file for each line
-              line_num=0
-              while IFS= read -r line; do
-                line_num=$((line_num + 1))
-                # Skip empty lines
-                if [ -z "$line" ]; then
-                  continue
-                fi
-                
-                # Write line to temp file
-                echo "$line" > "/tmp/temp_line_${line_num}.json"
-                
-                # Validate the line
-                if ! npx --yes ajv-cli@5 validate \
-                  -s "$schema" \
-                  -d "/tmp/temp_line_${line_num}.json" \
-                  --spec=draft2020 \
-                  --errors=line \
-                  --all-errors; then
-                    echo "ERROR: Validation failed for $fixture at line $line_num"
-                    failed=1
-                fi
-                
-                # Clean up temp file
-                rm -f "/tmp/temp_line_${line_num}.json"
-              done < "$fixture"
-            else
-              echo "Warning: Schema $schema not found for type $schema_type in $fixture"
+            if [ ! -f "$schema" ]; then
+              echo "::error file=$fixture::Schema $schema not found for type $schema_type"
+              failed=1
+              continue
             fi
-          done
+
+            echo "Validating $fixture against $schema..."
+            temp_file=$(mktemp)
+            line_num=0
+            while IFS= read -r line || [ -n "$line" ]; do
+              line_num=$((line_num + 1))
+              if [ -z "$line" ]; then
+                continue
+              fi
+
+              printf '%s\n' "$line" > "$temp_file"
+              if ! npx --yes ajv-cli@5 validate \
+                -s "$schema" \
+                -d "$temp_file" \
+                --spec=draft2020 \
+                --errors=line \
+                --all-errors; then
+                  echo "::error file=$fixture,line=$line_num::Fixture validation failed"
+                  failed=1
+              fi
+            done < "$fixture"
+            rm -f "$temp_file"
+          done < <(find tests/fixtures -type f -name "*.jsonl" -print0)
 
           if [ "$failed" -ne 0 ]; then
             echo "One or more fixtures failed validation."

--- a/.github/workflows/fixtures-validate.yml
+++ b/.github/workflows/fixtures-validate.yml
@@ -29,25 +29,31 @@ jobs:
       - name: Validate fixtures with AJV
         run: |
           failed=0
+          fixtures_root="tests/fixtures"
           while IFS= read -r -d '' fixture; do
             echo "Processing $fixture..."
 
-            # Extract directory name from fixture path (e.g., "aussen" from "tests/fixtures/aussen/sample.jsonl").
-            dir_name=$(basename "$(dirname "$fixture")")
+            relative_path="${fixture#tests/fixtures/}"
+            fixture_dir=$(dirname "$relative_path")
 
-            # Try to extract 'type' from the first line of the JSONL file as fallback.
+            # Prefer an explicit contract type from the event itself.
             type=$(head -n 1 "$fixture" | jq -r '.type // empty' 2>/dev/null || echo "")
-
-            # Use type from data if available, otherwise use directory name + ".event".
             if [ -n "$type" ] && [ "$type" != "null" ]; then
               schema_type="$type"
+            elif [ "$fixture_dir" != "." ]; then
+              # Nested fixtures use their directory as the contract type fallback.
+              schema_type="$(basename "$fixture_dir").event"
             else
-              schema_type="${dir_name}.event"
+              # Root-level fixtures without an explicit type are Chronik-local test data,
+              # not contract-bound fixtures. Keep that boundary explicit instead of
+              # pretending a missing schema was successfully validated.
+              echo "Skipping unbound Chronik-local fixture $fixture"
+              continue
             fi
 
             schema="contracts/json/${schema_type}.schema.json"
             if [ ! -f "$schema" ]; then
-              echo "::error file=$fixture::Schema $schema not found for type $schema_type"
+              echo "::error file=$fixture::Schema $schema not found for contract-bound type $schema_type"
               failed=1
               continue
             fi
@@ -73,9 +79,9 @@ jobs:
               fi
             done < "$fixture"
             rm -f "$temp_file"
-          done < <(find tests/fixtures -type f -name "*.jsonl" -print0)
+          done < <(find "$fixtures_root" -type f -name "*.jsonl" -print0)
 
           if [ "$failed" -ne 0 ]; then
-            echo "One or more fixtures failed validation."
+            echo "One or more contract-bound fixtures failed validation."
             exit 1
           fi

--- a/.github/workflows/fixtures-validate.yml
+++ b/.github/workflows/fixtures-validate.yml
@@ -59,7 +59,7 @@ jobs:
             fi
 
             echo "Validating $fixture against $schema..."
-            temp_file=$(mktemp)
+            temp_file=$(mktemp --suffix=.json)
             line_num=0
             while IFS= read -r line || [ -n "$line" ]; do
               line_num=$((line_num + 1))


### PR DESCRIPTION
## Änderung
- fehlende Contracts-Schemas lassen die Fixture-Validierung jetzt fehlschlagen statt nur zu warnen
- JSONL-Fixtures werden NUL-terminiert enumeriert und funktionieren damit auch mit Leerzeichen im Pfad
- die letzte JSONL-Zeile wird auch ohne abschließenden Zeilenumbruch validiert
- temporäre Daten nutzen `mktemp` statt eines globalen statischen Dateinamens

## Verifikation
- `shellcheck` auf dem extrahierten Bash-Block: grün
- maßgebliche GitHub-Actions-Verifikation folgt auf diesem PR

## Risiko
Bewusst strengere CI: Fixtures ohne passendes Schema werden künftig rot.