### PR TITLE
perf: stream agent ledger JSONL inputs

### DIFF
--- a/tests/test_agent_ledger_view.py
+++ b/tests/test_agent_ledger_view.py
@@ -62,6 +62,50 @@ def test_load_records_accepts_jsonl_envelopes(tmp_path):
     assert rows[0].result == "completed"
 
 
+def test_iter_records_streams_jsonl_without_read_text(tmp_path, monkeypatch):
+    started = load_fixture("agent-run-started.v0.json")
+    completed = load_fixture("agent-run-completed.v0.json")
+    path = tmp_path / "events.jsonl"
+    path.write_text(
+        json.dumps({"payload": started})
+        + "\n"
+        + json.dumps({"payload": completed})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def fail_read_text(*args, **kwargs):
+        raise AssertionError("JSONL input must not use whole-file read_text")
+
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+    records = list(agent_ledger_view.iter_records(path))
+
+    assert [record["payload"]["kind"] for record in records] == [
+        started["kind"],
+        completed["kind"],
+    ]
+
+
+def test_main_passes_lazy_records_to_view(tmp_path, monkeypatch, capsys):
+    completed = load_fixture("agent-run-completed.v0.json")
+    path = tmp_path / "events.jsonl"
+    path.write_text(json.dumps({"payload": completed}) + "\n", encoding="utf-8")
+    observed = {}
+
+    original_build_view = agent_ledger_view.build_view
+
+    def tracked_build_view(records):
+        observed["is_list"] = isinstance(records, list)
+        return original_build_view(records)
+
+    monkeypatch.setattr(agent_ledger_view, "build_view", tracked_build_view)
+
+    assert agent_ledger_view.main([str(path), "--format", "json"]) == 0
+    assert observed["is_list"] is False
+    assert json.loads(capsys.readouterr().out)[0]["result"] == "completed"
+
+
 def test_format_table_contains_expected_columns():
     row = agent_ledger_view.AgentRunViewRow(
         repo="heimgewebe/chronik",

--- a/tools/agent_ledger_view.py
+++ b/tools/agent_ledger_view.py
@@ -54,22 +54,33 @@ def extract_payload(record: dict[str, Any]) -> dict[str, Any] | None:
     return record
 
 
-def load_records(path: Path) -> list[dict[str, Any]]:
+def iter_records(path: Path) -> Iterable[dict[str, Any]]:
+    if path.suffix == ".jsonl":
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if line.strip():
+                    yield json.loads(line)
+        return
+
     text = path.read_text(encoding="utf-8").strip()
     if not text:
-        return []
-
-    if path.suffix == ".jsonl":
-        return [json.loads(line) for line in text.splitlines() if line.strip()]
+        return
 
     loaded = json.loads(text)
     if isinstance(loaded, dict) and isinstance(loaded.get("events"), list):
-        return loaded["events"]
+        yield from loaded["events"]
+        return
     if isinstance(loaded, list):
-        return loaded
+        yield from loaded
+        return
     if isinstance(loaded, dict):
-        return [loaded]
+        yield loaded
+        return
     raise ValueError(f"unsupported JSON payload in {path}")
+
+
+def load_records(path: Path) -> list[dict[str, Any]]:
+    return list(iter_records(path))
 
 
 def iter_agent_run_events(records: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
@@ -162,9 +173,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--view", choices=["repo", "run"], default="repo")
     args = parser.parse_args(argv)
 
-    records: list[dict[str, Any]] = []
-    for input_path in args.input:
-        records.extend(load_records(Path(input_path)))
+    records = (
+        record
+        for input_path in args.input
+        for record in iter_records(Path(input_path))
+    )
 
     rows = build_run_view(records) if args.view == "run" else build_view(records)
     if args.format == "json":


### PR DESCRIPTION
## Summary
- stream `.jsonl` Agent-Ledger inputs line by line instead of materializing the full input
- keep `load_records()` list compatibility and preserve non-JSONL behavior
- pass a lazy record iterator through the CLI aggregation path

## Verification
- focused tests: `10 passed`
- `make test`: `575 passed` (1 pre-existing Starlette/httpx deprecation warning)
- `make validate-local`: `575 passed` plus local smoke checks
- benchmark, 20,000 records / 11.4 MB: max RSS `139,280 KB -> 30,144 KB` (-78.4%); user CPU `119.70s -> 120.66s`
