### PR TITLE
perf: stream coding-memory JSONL input

### DIFF
--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -1,4 +1,4 @@
-import hashlib, json
+import hashlib, importlib.util, json
 from pathlib import Path
 import pytest
 import coding_memory, storage
@@ -448,3 +448,55 @@ def test_queries_reuse_timestamp_parsed_during_validation(tmp_path, monkeypatch)
     calls.clear()
     coding_memory.operator_summary()
     assert len(calls) == 3
+
+def _load_coding_memory_cli():
+    path = Path(__file__).parents[1] / "tools" / "coding_memory.py"
+    spec = importlib.util.spec_from_file_location("chronik_coding_memory_cli_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cli_jsonl_loader_streams_without_whole_file_read(tmp_path, monkeypatch):
+    cli = _load_coding_memory_cli()
+    target = tmp_path / "events.jsonl"
+    target.write_text('{"index":1}\n\n  {"index":2}  \n', encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def guarded_read_text(path, *args, **kwargs):
+        if path == target:
+            raise AssertionError("JSONL input must not be materialized with Path.read_text")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
+    records = cli.load(target)
+    assert iter(records) is records
+    assert list(records) == [{"index": 1}, {"index": 2}]
+
+
+def test_cli_jsonl_loader_treats_only_lf_as_record_boundary(tmp_path):
+    cli = _load_coding_memory_cli()
+    target = tmp_path / "events.jsonl"
+    target.write_text(
+        '{"text":"left\u2028right"}\n{"text":"next"}\n', encoding="utf-8"
+    )
+
+    assert list(cli.load(target)) == [
+        {"text": "left\u2028right"},
+        {"text": "next"},
+    ]
+
+
+def test_cli_regular_json_loader_keeps_existing_list_semantics(tmp_path):
+    cli = _load_coding_memory_cli()
+    object_path = tmp_path / "event.json"
+    object_path.write_text('{"index":1}', encoding="utf-8")
+    list_path = tmp_path / "events.json"
+    list_path.write_text('[{"index":1},{"index":2}]', encoding="utf-8")
+    empty_path = tmp_path / "empty.json"
+    empty_path.write_text('  \n', encoding="utf-8")
+
+    assert cli.load(object_path) == [{"index": 1}]
+    assert cli.load(list_path) == [{"index": 1}, {"index": 2}]
+    assert cli.load(empty_path) == []

--- a/tools/coding_memory.py
+++ b/tools/coding_memory.py
@@ -146,12 +146,19 @@ def outbox_summary_line(result: dict) -> str:
     return line
 
 
+def _iter_jsonl(path: Path):
+    with path.open("r", encoding="utf-8", newline="\n") as handle:
+        for line in handle:
+            if line.strip():
+                yield json.loads(line)
+
+
 def load(path: Path):
+    if path.suffix == ".jsonl":
+        return _iter_jsonl(path)
     text = path.read_text(encoding="utf-8").strip()
     if not text:
         return []
-    if path.suffix == ".jsonl":
-        return [json.loads(line) for line in text.splitlines() if line.strip()]
     value = json.loads(text)
     return value if isinstance(value, list) else [value]
 


### PR DESCRIPTION
## Summary

- stream `.jsonl` input in `tools/coding_memory.py` instead of `Path.read_text()` + `splitlines()` + a first parsed-record list
- preserve regular JSON object/list/empty-file behavior
- preserve Chronik's LF-only JSONL record-boundary semantics explicitly (`newline="\n"`)
- keep `coding_memory.import_events()` batch materialization unchanged so existing prevalidation, atomic conflict checks, and write semantics remain intact

## Evidence

Synthetic loader-to-import-materialization benchmark, identical fixture in both runs:

- 120,000 JSONL records
- 26,288,890 bytes
- before: 222,360 KB Max-RSS, 0.62 s observed elapsed
- after: 161,480 KB Max-RSS, 0.48 s observed elapsed
- Max-RSS reduction: 27.4%

The elapsed-time pair is only an observation from one before/after run; this PR does not claim a reliable speedup. Remaining memory is intentionally dominated by the batch list retained by `import_events()`.

## Validation

- 578 pytest tests passed
- role contract: passed
- coding-memory runtime contract: passed
- Ruff: passed
- Mypy: passed
- `git diff --check`: passed
- temporary-data FastAPI smoke: passed

The existing Starlette/httpx TestClient deprecation warning remains unchanged and is tracked separately.
