### PR TITLE
refactor(api): retire legacy ingest endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ als JSON entgegennimmt und domain-spezifisch in JSON Lines Dateien ablegt. Die A
 FastAPI implementiert und lässt sich lokal oder in Codespaces betreiben.
 
 - **API-Spezifikation:** siehe `docs/openapi.yaml`.
- Alte Pfade `POST /ingest/{domain}` sind **deprecated** (Ablauf 6 Monate nach Merge) und werden durch `POST /v1/ingest` ersetzt.
+- `POST /v1/ingest` ist der kanonische Schreibendpunkt; die frühere domainspezifische Ingest-Route wurde nach Ablauf ihrer Deprecation-Frist entfernt.
 
 ## 🔗 Contracts (kanonische Definitionen)
 
@@ -102,8 +102,8 @@ In GitHub Codespaces sollte der Port 8788 veröffentlicht werden, um Anfragen an
 
 Siehe die OpenAPI-Spezifikation unter [`docs/openapi.yaml`](./docs/openapi.yaml).
 
-> **Deprecation (6 Monate):** Domainspezifische Endpoints (`/ingest/aussen`, …) sind veraltet.
-> Bitte auf `POST /v1/ingest` migrieren. Die Domain wird per `event.domain` oder `?domain=aussen` bestimmt.
+> **Ingest:** `POST /v1/ingest` ist der kanonische Schreibendpunkt.
+> Die Domain wird per `event.domain` oder `?domain=aussen` bestimmt.
 
 ## Clients
 - **Rust (Stub):** `clients/rust/chronik_producer`

--- a/app.py
+++ b/app.py
@@ -232,7 +232,7 @@ async def request_id_logging(request: Request, call_next):
 
 def _is_ingest_request(request: Request) -> bool:
     path = str(request.scope.get("path", ""))
-    return path == "/v1/ingest" or path.startswith("/ingest/")
+    return path == "/v1/ingest"
 
 
 def _request_audit_domain(request: Request) -> str | None:
@@ -733,46 +733,6 @@ async def ingest_v1(
     _audit_ingest_decision(request, "ACCEPTED", "accepted", domain=dom)
     return PlainTextResponse("ok", status_code=202)
 
-
-@app.post(
-    "/ingest/{domain}",
-    # Dependency order matters: auth FIRST, then size check.
-    dependencies=[Depends(_require_auth_dep), Depends(_validate_body_size)],
-    deprecated=True,
-    openapi_extra=ingest_request_body_openapi(include_ndjson=False),
-)
-async def ingest(
-    domain: str,
-    request: Request,
-):
-    request.state.audit_domain = domain
-    dom = _sanitize_domain(domain)
-
-    # JSON parsen
-    try:
-        body = await _read_body_as_utf8(request, MAX_PAYLOAD_SIZE)
-    except UnicodeError as exc:
-        raise HTTPException(status_code=400, detail="invalid encoding") from exc
-
-    try:
-        obj = json.loads(body)
-    except json.JSONDecodeError as exc:
-        raise HTTPException(status_code=400, detail="invalid json") from exc
-
-    # Pydantic adapts only the HTTP object shape; canonical validation follows.
-    items = _adapt_http_items(obj)
-    try:
-        result = await _run_storage_io("ingest_write", _process_and_write_combined, dom, items)
-    except StorageError as exc:
-        _raise_storage_http_exception(exc, domain=dom)
-
-    if result is not None:
-        _audit_ingest_decision(request, "ACCEPTED", str(result["result"]), domain=dom)
-        return JSONResponse(result, status_code=202)
-    _audit_ingest_decision(
-        request, "ACCEPTED", "empty" if not items else "accepted", domain=dom
-    )
-    return PlainTextResponse("ok", status_code=202)
 
 
 def _fetch_events_helper(d: str, start: int, lim: int):

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,10 +6,6 @@
 
 Accepts NDJSON or single JSON payload. Wraps it in a standard envelope and appends to storage. The domain can be specified via the `domain` query parameter or within the payload.
 
-### POST /ingest/{domain} (Deprecated)
-
-Legacy endpoint. Use `/v1/ingest` instead.
-
 ## Reading Events
 
 ### GET /v1/events

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,10 +8,10 @@ Chronik ist ein einfacher Ingest-Dienst, der auf Python und FastAPI basiert. Die
     *   Dies ist der Kern des Dienstes, der die HTTP-Endpunkte bereitstellt.
     *   Es verwendet `uvicorn` als ASGI-Server.
 
-2.  **Ingest-Endpunkt (`/ingest/{domain}`):**
+2.  **Ingest-Endpunkt (`/v1/ingest?domain={domain}`):**
     *   Nimmt JSON-Daten per `POST`-Request entgegen.
     *   Authentifiziert Anfragen über einen Shared-Secret-Token (`CHRONIK_TOKEN`), der im `X-Auth`-Header übergeben wird.
-    *   Validiert und bereinigt den `domain`-Pfadparameter.
+    *   Validiert und bereinigt die Domain aus `?domain=...` oder dem ersten Payload-Objekt.
 
 3.  **Speicherschicht (`storage.py`):**
     *   Eingehende Daten werden in domain-spezifischen JSON-Lines-Dateien (`.jsonl`) im `CHRONIK_DATA_DIR`-Verzeichnis gespeichert.
@@ -21,7 +21,7 @@ Chronik ist ein einfacher Ingest-Dienst, der auf Python und FastAPI basiert. Die
 
 ## Datenfluss
 
-1.  Ein Client sendet eine `POST`-Anfrage mit einem JSON-Body an `/ingest/{domain}`.
+1.  Ein Client sendet eine `POST`-Anfrage mit einem JSON-Body an `/v1/ingest?domain={domain}`.
 2.  Die FastAPI-Anwendung empfängt die Anfrage.
 3.  Die Authentifizierung wird über den `X-Auth`-Header überprüft.
 4.  Der `domain`-Parameter wird validiert und bereinigt.

--- a/docs/cli-curl.md
+++ b/docs/cli-curl.md
@@ -7,12 +7,12 @@ curl -H "X-Auth:$CHRONIK_TOKEN" http://localhost:8788/health
 curl -H "X-Auth:$CHRONIK_TOKEN" http://localhost:8788/version
 
 # Ingest Beispiel
-curl -X POST "http://localhost:8788/ingest/example.com" \
+curl -X POST "http://localhost:8788/v1/ingest?domain=example.com" \
   -H "Content-Type: application/json" -H "X-Auth: $CHRONIK_TOKEN" \
   -d '{"event":"deploy","status":"success"}'
 
 # Ingest Array (schreibt zwei JSONL-Zeilen)
-curl -X POST "http://localhost:8788/ingest/example.com" \
+curl -X POST "http://localhost:8788/v1/ingest?domain=example.com" \
   -H "Content-Type: application/json" -H "X-Auth: $CHRONIK_TOKEN" \
   -d '[{"event":"deploy","status":"success"},{"event":"deploy","status":"rollback"}]'
 
@@ -28,8 +28,8 @@ for i in 1 2 3 4 5; do
   code=$(curl -s -o /dev/null -w "%{http_code}" \
     -H "X-Auth:$CHRONIK_TOKEN" -H "Content-Type: application/json" \
     -d '{"event":"batch","status":"ok"}' \
-    http://localhost:8788/ingest/example.com)
-  [ "$code" = "200" ] && echo ok && break
+    http://localhost:8788/v1/ingest?domain=example.com)
+  [ "$code" = "202" ] && echo ok && break
   [ "$code" != "429" ] && echo "fail:$code" && exit 1
   sleep $((2**i))
 done

--- a/docs/mitschreiber-ingest.md
+++ b/docs/mitschreiber-ingest.md
@@ -3,15 +3,15 @@
 chronik ist Single Point of Ingest, Audit & Panels.
 
 ## Endpoints
-- `POST /ingest/os/context/state`
-- `POST /ingest/os/context/text/embed`
+- `POST /v1/ingest?domain=os.context.state`
+- `POST /v1/ingest?domain=os.context.text.embed`
 
 ### Auth
 - Lokaler Token (env/Secret); mTLS empfohlen, wenn getrennte Prozesse/Hosts.
 
 ### Beispiel-Requests
 ```http
-POST /ingest/os/context/state
+POST /v1/ingest?domain=os.context.state
 {
   "ts": "...",
   "source": "os.context.state",
@@ -23,7 +23,7 @@ POST /ingest/os/context/state
 ```
 
 ```http
-POST /ingest/os/context/text/embed
+POST /v1/ingest?domain=os.context.text.embed
 {
   "ts": "...",
   "source": "os.context.text.embed",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -16,10 +16,9 @@ paths:
       description: |
         Accepts JSON payloads either as a single object, an array of objects, or newline-delimited JSON.
         The target domain can be supplied via the `domain` query parameter (canonical) or as the `domain` field on the first
-        object in the payload (legacy behavior, normalized by Chronik).
+        object in the payload (payload compatibility, normalized by Chronik).
 
         **Canonical Endpoint**: `POST /v1/ingest?domain=heimgeist`
-        **Legacy Alias**: `POST /ingest/heimgeist`
 
         **Transport Policy**:
         - Max payload size: 1MB (configurable via `CHRONIK_MAX_BODY`).
@@ -80,50 +79,6 @@ paths:
           description: Unsupported content-type.
         '422':
           description: Semantic validation failed (e.g. summary too long).
-        '429':
-          description: Too many requests (rate limited). Clients should respect the `Retry-After` header.
-        '507':
-          description: Insufficient storage.
-  /ingest/{domain}:
-    post:
-      deprecated: true
-      summary: Deprecated ingest endpoint
-      operationId: ingestEventDeprecated
-      description: Replaced by **POST /v1/ingest**.
-      parameters:
-        - in: path
-          name: domain
-          required: true
-          schema:
-            type: string
-      security:
-        - XAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              oneOf:
-                - $ref: '#/components/schemas/Event'
-                - type: array
-                  items:
-                    $ref: '#/components/schemas/Event'
-      responses:
-        '202':
-          description: Accepted (deprecated). Body contains plain text `ok`.
-          content:
-            text/plain:
-              schema:
-                type: string
-                example: ok
-        '400':
-          description: Bad request (invalid domain, JSON, or payload).
-        '401':
-          description: Unauthorized (missing or invalid `X-Auth` header).
-        '411':
-          description: Content-Length header missing.
-        '413':
-          description: Payload too large.
         '429':
           description: Too many requests (rate limited). Clients should respect the `Retry-After` header.
         '507':

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -15,7 +15,7 @@ uvicorn app:app --host 0.0.0.0 --port 8788
 * Warten, bis keine weiteren Schreibzugriffe auf dem Datenverzeichnis stattfinden.
 
 ## Überwachung
-* **Health**: Ein Test-Request gegen `/ingest/<test-domain>` (ggf. mit Dummy-Token) sollte Status `200` liefern.
+* **Health**: Ein Test-Request gegen `/v1/ingest?domain=<test-domain>` (ggf. mit Dummy-Token) sollte Status `202` liefern.
 * **Logging**: Standardmäßig loggt Uvicorn nach STDOUT. Produktionsumgebungen sollten die Ausgabe an ein Log-Aggregationssystem weiterleiten.
 * **Metriken**: Anzahl erfolgreicher Ingest-Requests kann über Log-Analyse oder Reverse-Proxy-Zähler ermittelt werden.
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -251,7 +251,7 @@ def test_ingest_auth_ok(monkeypatch, client):
     secret = _test_secret()
     monkeypatch.setenv("CHRONIK_TOKEN", secret)
     response = client.post(
-        "/ingest/example.com", headers={"X-Auth": secret}, json={"data": "value"}
+        "/v1/ingest?domain=example.com", headers={"X-Auth": secret}, json={"data": "value"}
     )
     assert response.status_code == 202
     assert response.text == "ok"
@@ -261,7 +261,7 @@ def test_ingest_auth_fail(monkeypatch, client):
     secret = _test_secret()
     monkeypatch.setenv("CHRONIK_TOKEN", secret)
     response = client.post(
-        "/ingest/example.com", headers={"X-Auth": "wrong"}, json={"data": "value"}
+        "/v1/ingest?domain=example.com", headers={"X-Auth": "wrong"}, json={"data": "value"}
     )
     assert response.status_code == 403
 
@@ -269,7 +269,7 @@ def test_ingest_auth_fail(monkeypatch, client):
 def test_ingest_auth_missing(monkeypatch, client):
     secret = _test_secret()
     monkeypatch.setenv("CHRONIK_TOKEN", secret)
-    response = client.post("/ingest/example.com", json={"data": "value"})
+    response = client.post("/v1/ingest?domain=example.com", json={"data": "value"})
     assert response.status_code == 401
 
 
@@ -316,7 +316,7 @@ def test_ingest_single_object(monkeypatch, tmp_path: Path, client):
     domain = "example.com"
     payload = {"data": "value"}
     response = client.post(
-        f"/ingest/{domain}", headers={"X-Auth": secret}, json=payload
+        f"/v1/ingest?domain={domain}", headers={"X-Auth": secret}, json=payload
     )
     assert response.status_code == 202
     assert response.text == "ok"
@@ -341,7 +341,7 @@ def test_ingest_array_of_objects(monkeypatch, tmp_path: Path, client):
     domain = "example.com"
     payload = [{"data": "value1"}, {"data": "value2"}]
     response = client.post(
-        f"/ingest/{domain}", headers={"X-Auth": secret}, json=payload
+        f"/v1/ingest?domain={domain}", headers={"X-Auth": secret}, json=payload
     )
     assert response.status_code == 202
     assert response.text == "ok"
@@ -368,7 +368,7 @@ def test_ingest_empty_array(monkeypatch, tmp_path: Path, client):
     monkeypatch.setenv("CHRONIK_TOKEN", secret)
     monkeypatch.setattr("storage.DATA_DIR", tmp_path)
     response = client.post(
-        "/ingest/example.com",
+        "/v1/ingest?domain=example.com",
         headers={"X-Auth": secret},
         json=[],
     )
@@ -382,7 +382,7 @@ def test_ingest_invalid_json(monkeypatch, client):
     secret = _test_secret()
     monkeypatch.setenv("CHRONIK_TOKEN", secret)
     response = client.post(
-        "/ingest/example.com",
+        "/v1/ingest?domain=example.com",
         headers={"X-Auth": secret, "Content-Type": "application/json"},
         content="{invalid json}",
     )
@@ -396,7 +396,7 @@ def test_ingest_payload_too_large(monkeypatch, client):
     # Limit is 1 MiB
     large_payload = {"key": "v" * (1024 * 1024)}
     response = client.post(
-        "/ingest/example.com", headers={"X-Auth": secret}, json=large_payload
+        "/v1/ingest?domain=example.com", headers={"X-Auth": secret}, json=large_payload
     )
     assert response.status_code == 413
     assert "payload too large" in response.text
@@ -406,7 +406,7 @@ def test_ingest_invalid_payload_not_dict(monkeypatch, client):
     secret = _test_secret()
     monkeypatch.setenv("CHRONIK_TOKEN", secret)
     response = client.post(
-        "/ingest/example.com", headers={"X-Auth": secret}, json=["not-a-dict"]
+        "/v1/ingest?domain=example.com", headers={"X-Auth": secret}, json=["not-a-dict"]
     )
     assert response.status_code == 400
     assert "invalid payload" in response.text
@@ -430,7 +430,7 @@ def test_ingest_domain_mismatch(monkeypatch, client):
     secret = _test_secret()
     monkeypatch.setenv("CHRONIK_TOKEN", secret)
     response = client.post(
-        "/ingest/example.com",
+        "/v1/ingest?domain=example.com",
         headers={"X-Auth": secret},
         json={"domain": "other.example", "data": "value"},
     )
@@ -445,7 +445,7 @@ def test_ingest_domain_normalized(monkeypatch, tmp_path: Path, client):
 
     payload = {"domain": "Example.COM", "data": "value"}
     response = client.post(
-        "/ingest/example.com", headers={"X-Auth": secret}, json=payload
+        "/v1/ingest?domain=example.com", headers={"X-Auth": secret}, json=payload
     )
 
     assert response.status_code == 202
@@ -462,7 +462,7 @@ def test_ingest_no_content_length(monkeypatch, client):
     monkeypatch.setenv("CHRONIK_TOKEN", secret)
     request = client.build_request(
         "POST",
-        "/ingest/example.com",
+        "/v1/ingest?domain=example.com",
         headers={"X-Auth": secret, "Content-Type": "application/json"},
         content='{"data": "value"}',
     )
@@ -479,7 +479,7 @@ def test_ingest_no_content_length_unauthorized(monkeypatch, client):
     monkeypatch.setenv("CHRONIK_TOKEN", secret)
     request = client.build_request(
         "POST",
-        "/ingest/example.com",
+        "/v1/ingest?domain=example.com",
         headers={"Content-Type": "application/json"},
         content='{"data": "value"}',
     )
@@ -493,7 +493,7 @@ def test_ingest_negative_content_length(monkeypatch, client):
     secret = _test_secret()
     monkeypatch.setenv("CHRONIK_TOKEN", secret)
     response = client.post(
-        "/ingest/example.com",
+        "/v1/ingest?domain=example.com",
         headers={"X-Auth": secret, "Content-Length": "-1"},
         json={"data": "value"},
     )
@@ -621,7 +621,7 @@ def test_lock_timeout_returns_429(monkeypatch, client):
     secret = _test_secret()
     monkeypatch.setenv("CHRONIK_TOKEN", secret)
     response = client.post(
-        "/ingest/example.com",
+        "/v1/ingest?domain=example.com",
         headers={
             "X-Auth": secret,
             "Content-Length": "2",
@@ -637,7 +637,7 @@ def test_path_traversal_domain_is_rejected(monkeypatch, client):
     secret = _test_secret()
     monkeypatch.setenv("CHRONIK_TOKEN", secret)
     response = client.post(
-        "/ingest/..example.com",
+        "/v1/ingest?domain=..example.com",
         headers={
             "X-Auth": secret,
             "Content-Type": "application/json",
@@ -828,7 +828,7 @@ def test_agent_ledger_empty_batch_preserves_noop_response(
     monkeypatch.setattr("storage.DATA_DIR", tmp_path)
 
     response = client.post(
-        "/ingest/agent.ledger",
+        "/v1/ingest?domain=agent.ledger",
         headers={"X-Auth": _test_secret(), "Content-Type": "application/json"},
         json=[],
     )
@@ -992,7 +992,7 @@ def test_symlink_attack_rejected(monkeypatch, tmp_path, client):
     os.symlink(victim, link_name)
 
     response = client.post(
-        "/ingest/example.com",
+        "/v1/ingest?domain=example.com",
         headers={"X-Auth": secret, "Content-Type": "application/json"},
         json={"data": "value"},
     )
@@ -1010,7 +1010,7 @@ def test_concurrent_writes_are_serialized(monkeypatch, tmp_path, client):
 
     def _one(i: int) -> int:
         return client.post(
-            "/ingest/example.com",
+            "/v1/ingest?domain=example.com",
             headers={"X-Auth": secret, "Content-Type": "application/json"},
             json={"i": i},
         ).status_code
@@ -1041,7 +1041,7 @@ def test_disk_full_returns_507(monkeypatch, tmp_path, client):
     monkeypatch.setattr("storage.os.open", _raise_enospc)
 
     response = client.post(
-        "/ingest/example.com",
+        "/v1/ingest?domain=example.com",
         headers={"X-Auth": secret, "Content-Type": "application/json"},
         json={},
     )
@@ -1062,7 +1062,7 @@ def test_disk_full_during_write_returns_507(monkeypatch, tmp_path, client):
     monkeypatch.setattr("storage.os.write", _raise_enospc)
 
     response = client.post(
-        "/ingest/example.com",
+        "/v1/ingest?domain=example.com",
         headers={"X-Auth": secret, "Content-Type": "application/json"},
         json={"data": "foo"},
     )
@@ -1093,7 +1093,7 @@ def test_recovery_error_returns_500_and_preserves_original_bytes(
     monkeypatch.setattr("storage.os.fsync", fail_first_fsync)
 
     response = client.post(
-        "/ingest/example.com",
+        "/v1/ingest?domain=example.com",
         headers={"X-Auth": secret, "Content-Type": "application/json"},
         json={"data": "foo"},
     )
@@ -1130,7 +1130,7 @@ def test_fd_leak_prevented_on_oserror(monkeypatch, tmp_path, client):
     # This should fail with an OSError, but the fd should be closed
     try:
         response = client.post(
-            "/ingest/example.com",
+            "/v1/ingest?domain=example.com",
             headers={"X-Auth": secret, "Content-Type": "application/json"},
             json={"data": "value"},
         )

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -125,7 +125,7 @@ def test_invalid_json_emits_rejected_audit_event(audit_client):
     client, events = audit_client
 
     response = client.post(
-        "/ingest/example.com",
+        "/v1/ingest?domain=example.com",
         headers={
             "X-Auth": "test-token",
             "X-Request-ID": "audit:json",
@@ -150,7 +150,7 @@ def test_auth_rejection_is_audited_before_endpoint_execution(audit_client):
     client, events = audit_client
 
     response = client.post(
-        "/ingest/example.com",
+        "/v1/ingest?domain=example.com",
         headers={"X-Auth": "wrong", "X-Request-ID": "audit:auth"},
         json={"data": "value"},
     )

--- a/tests/test_heimgeist_validation.py
+++ b/tests/test_heimgeist_validation.py
@@ -99,7 +99,7 @@ def test_other_domain_loose_validation(monkeypatch, tmp_path, client):
     response = client.post("/v1/ingest?domain=other", json=payload, headers={"X-Auth": "secret"})
     assert response.status_code == 202
 
-def test_heimgeist_legacy_path(monkeypatch, tmp_path: Path, client):
+def test_heimgeist_legacy_path_is_removed(monkeypatch, tmp_path: Path, client):
     monkeypatch.setattr("storage.DATA_DIR", tmp_path)
     monkeypatch.setenv("CHRONIK_TOKEN", "secret")
 
@@ -114,7 +114,8 @@ def test_heimgeist_legacy_path(monkeypatch, tmp_path: Path, client):
         "data": {"foo": "bar"}
     }
     response = client.post("/ingest/heimgeist", json=payload, headers={"X-Auth": "secret"})
-    assert response.status_code == 202
+    assert response.status_code == 404
+    assert not list(tmp_path.glob("*.jsonl"))
 
 def test_retry_after_header_logic(client):
     from app import _on_rate_limited


### PR DESCRIPTION
## Summary
- remove the expired `POST /ingest/{domain}` compatibility route
- migrate active docs and regression tests to `POST /v1/ingest?domain=...`
- retain one negative regression proving the legacy route returns `404` without writing
- preserve canonical auth, body-size, audit, validation and storage-error behavior

## Evidence
- PR #75 merged 2025-11-12 and documented a six-month deprecation window; it elapsed 2026-05-12
- exact base: `ded3c6d183bad84e1a96907444f42383a8b3be7b`
- targeted ingest/audit/validation tests: 79 passed
- full suite: 578 passed
- `scripts/validate-local.sh`: all checks passed, 578 tests passed, smoke OK

No runtime or deployment mutation is part of this PR.