### PR TITLE
perf: cache agent-run schema validator

### DIFF
--- a/tests/test_chronik_outbox.py
+++ b/tests/test_chronik_outbox.py
@@ -1,6 +1,8 @@
+from concurrent.futures import ThreadPoolExecutor
 import hashlib
 import json
 from pathlib import Path
+from threading import Lock
 
 import pytest
 
@@ -36,6 +38,51 @@ def encoded_event(event):
         json.dumps(event, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
         + b"\n"
     )
+
+
+def test_validate_event_reuses_compiled_validator(monkeypatch):
+    event = load_event()
+    load_calls = 0
+    original_load_schema = chronik_outbox.load_schema
+
+    def counted_load_schema():
+        nonlocal load_calls
+        load_calls += 1
+        return original_load_schema()
+
+    monkeypatch.setattr(chronik_outbox, "_EVENT_VALIDATOR", None)
+    monkeypatch.setattr(chronik_outbox, "load_schema", counted_load_schema)
+
+    chronik_outbox.validate_event(event)
+    chronik_outbox.validate_event(event)
+
+    invalid = load_event()
+    invalid["data"]["raw"] = "no"
+    with pytest.raises(chronik_outbox.jsonschema.exceptions.ValidationError):
+        chronik_outbox.validate_event(invalid)
+
+    assert load_calls == 1
+
+
+def test_validate_event_compiles_once_on_concurrent_cold_start(monkeypatch):
+    event = load_event()
+    load_calls = 0
+    calls_lock = Lock()
+    original_load_schema = chronik_outbox.load_schema
+
+    def counted_load_schema():
+        nonlocal load_calls
+        with calls_lock:
+            load_calls += 1
+        return original_load_schema()
+
+    monkeypatch.setattr(chronik_outbox, "_EVENT_VALIDATOR", None)
+    monkeypatch.setattr(chronik_outbox, "load_schema", counted_load_schema)
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        list(pool.map(lambda _: chronik_outbox.validate_event(event), range(64)))
+
+    assert load_calls == 1
 
 
 def test_append_event_writes_one_run_file(tmp_path):

--- a/tools/chronik_outbox.py
+++ b/tools/chronik_outbox.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import Lock
 from typing import Any, BinaryIO, Callable, Iterable, Iterator
 from urllib.parse import urlencode
 
@@ -94,8 +95,26 @@ def load_schema() -> dict[str, Any]:
     return schema
 
 
+_EVENT_VALIDATOR: Draft7Validator | None = None
+_EVENT_VALIDATOR_LOCK = Lock()
+
+
+def _event_validator() -> Draft7Validator:
+    """Compile the immutable agent-run schema exactly once per process."""
+    global _EVENT_VALIDATOR
+    validator = _EVENT_VALIDATOR
+    if validator is not None:
+        return validator
+    with _EVENT_VALIDATOR_LOCK:
+        validator = _EVENT_VALIDATOR
+        if validator is None:
+            validator = Draft7Validator(load_schema())
+            _EVENT_VALIDATOR = validator
+        return validator
+
+
 def validate_event(event: dict[str, Any]) -> None:
-    jsonschema.validate(event, load_schema())
+    _event_validator().validate(event)
 
 
 def safe_part(value: str, label: str) -> str:
@@ -449,7 +468,7 @@ def _preflight_flush_unlocked(path: Path, body_limit: int) -> _FlushSnapshot:
         progress = _receipt_header(path, initial_state.size)
         progress_bytes = progress.source_bytes if progress is not None else 0
         progress_events = progress.event_count if progress is not None else 0
-        validator = Draft7Validator(load_schema())
+        validator = _event_validator()
         source_hasher = hashlib.sha256()
         progress_hasher = source_hasher.copy() if progress_bytes == 0 else None
         progress_line_count = 0


### PR DESCRIPTION
## Summary
- compile the immutable Draft-07 agent-run validator once per process instead of rereading and rechecking the schema for every event
- reuse the same compiled validator in outbox flush preflight
- serialize concurrent cold-start compilation while keeping the warm path lock-free

## Evidence
- focused: 38 passed
- full suite: 581 passed
- Ruff: green
- Mypy: green
- role contract and coding-memory runtime contract: green
- API persistence smoke: green
- WGX smoke test: green

## Performance
Exact current-main baseline vs this head:
- 1,000 `validate_event` calls: 5.919s -> 0.219s (~96.3% faster)
- `agent_ledger_view`, 2,000 events / 1,116,000-byte JSONL: 13.607s -> 0.555s (~95.9% faster)

Validation semantics remain Draft-07 and invalid events are still rejected. No runtime deployment is part of this PR.