### PR TITLE
fix(integrity): persist observation gaps

### DIFF
--- a/integrity.py
+++ b/integrity.py
@@ -32,6 +32,16 @@ STATUS_SEVERITY = {
 }
 
 ALLOWED_STATUS = set(STATUS_SEVERITY.keys())
+INTEGRITY_SUMMARY_KIND = "integrity.summary.published.v1"
+INTEGRITY_OBSERVATION_GAP_KIND = "integrity.observation.gap.published.v1"
+INTEGRITY_OBSERVATION_RESERVED_FIELDS = (
+    "observation_status",
+    "observation_gap_started_at",
+    "last_known_status",
+    "last_known_generated_at",
+    "failure_class",
+)
+
 
 def normalize_status(value: Any) -> str:
     """Normalize status to contract-allowed values. Unknown -> UNCLEAR."""
@@ -40,11 +50,13 @@ def normalize_status(value: Any) -> str:
     v = value.strip().upper()
     return v if v in ALLOWED_STATUS else "UNCLEAR"
 
+
 DEFAULT_SOURCES_URL = DEFAULT_INTEGRITY_SOURCES_URL
 
 # Concurrency limit for integrity aggregation to prevent threadpool starvation.
 # Default is 20, which is safe for standard Starlette/AnyIO threadpools.
 INTEGRITY_CONCURRENCY_LIMIT = Settings().integrity_concurrency_limit
+
 
 def get_current_utc_str() -> str:
     """Return current UTC time in strict ISO8601 format (Z-suffix)."""
@@ -255,15 +267,20 @@ class IntegrityManager:
         payload_data = {}
         invalid_new_generated_at = False
         error_reason = None
+        failure_class = None
 
         try:
             resp = await client.get(url)
             if resp.status_code == 200:
                 try:
                     report = resp.json()
+                    if not isinstance(report, dict):
+                        raise TypeError("Integrity summary JSON must be an object")
                     status = normalize_status(report.get("status", "UNCLEAR"))
                     # Create copy to avoid mutating cache
                     payload_data = dict(report)
+                    for reserved_field in INTEGRITY_OBSERVATION_RESERVED_FIELDS:
+                        payload_data.pop(reserved_field, None)
 
                     # Ensure minimal fields in payload (report contract)
                     if "generated_at" not in payload_data:
@@ -297,6 +314,11 @@ class IntegrityManager:
                         error_reason = "Missing or empty repo in report"
                         payload_data["repo"] = repo # Fallback to source repo
 
+                except TypeError as exc:
+                    status = "FAIL"
+                    invalid_new_generated_at = True
+                    error_reason = f"Invalid summary payload: {str(exc)}"
+                    logger.warning(f"Integrity summary payload invalid for {repo} ({url}): {exc}")
                 except ValueError as exc:
                     status = "FAIL" # Schema/Parse fail
                     error_reason = f"Invalid JSON: {str(exc)}"
@@ -305,24 +327,32 @@ class IntegrityManager:
                 logger.warning(f"Integrity fetch failed for {repo}: {resp.status_code}")
                 status = "MISSING"
                 error_reason = f"HTTP {resp.status_code}"
+                failure_class = "http_error"
         except Exception as exc:
             logger.warning(f"Integrity fetch exception for {repo}: {exc}")
             status = "MISSING"
             error_reason = f"Network Error: {str(exc)}"
+            failure_class = "network_error"
 
         # Check Latest Semantics (Optimistic concurrency control manually)
         new_generated_at = payload_data.get("generated_at")
         current_line = await run_in_threadpool(read_last_line, domain)
 
         current_payload = {}
+        current_kind = None
         curr_dt = None
         has_current_state = False
 
         if current_line:
             try:
                 current_item = json.loads(current_line)
+                current_kind = current_item.get("kind")
                 current_payload = current_item.get("payload", {})
-                current_generated_at = current_payload.get("generated_at")
+                current_generated_at = (
+                    current_payload.get("last_known_generated_at")
+                    if current_kind == INTEGRITY_OBSERVATION_GAP_KIND
+                    else current_payload.get("generated_at")
+                )
                 curr_dt = parse_iso_ts(current_generated_at) if current_generated_at else None
                 has_current_state = True
             except (json.JSONDecodeError, ValueError):
@@ -330,15 +360,49 @@ class IntegrityManager:
                 pass
 
         # Stability Logic:
-        # If fetch failed (MISSING) and we have a valid current state, preserve it.
-        # Don't overwrite known truth with transient network failure.
-        if status == "MISSING" and has_current_state:
-            logger.debug(f"Preserving existing state for {repo} despite fetch failure")
+        # If a fetch fails after a known state, keep the last summary immutable but
+        # append one explicit observation-gap event. Repeated failures do not churn
+        # the ledger; the next non-stale successful summary closes the gap.
+        if failure_class is not None and has_current_state:
+            if current_kind == INTEGRITY_OBSERVATION_GAP_KIND:
+                logger.debug(f"Integrity observation gap already open for {repo}")
+                return
+
+            last_known_status = normalize_status(current_payload.get("status", "UNCLEAR"))
+            gap_status = max(("MISSING", last_known_status), key=lambda candidate: STATUS_SEVERITY[candidate])
+            gap_payload = {
+                "repo": current_payload.get("repo") or repo,
+                "url": current_payload.get("url") or url,
+                "status": gap_status,
+                "observation_status": "MISSING",
+                "last_known_status": last_known_status,
+                "last_known_generated_at": current_payload.get("generated_at"),
+                "failure_class": failure_class,
+            }
+            gap_wrapper = {
+                "domain": domain,
+                "kind": INTEGRITY_OBSERVATION_GAP_KIND,
+                "received_at": received_at,
+                "payload": gap_payload,
+            }
+            if error_reason:
+                gap_wrapper["meta"] = {"error_reason": error_reason}
+
+            try:
+                await run_in_threadpool(write_payload, domain, [json.dumps(gap_wrapper)])
+            except Exception as exc:
+                logger.error(f"Failed to save integrity observation gap for {repo}: {exc}")
             return
 
         if has_current_state:
-            # If new generated_at invalid, preserve valid current state
-            if invalid_new_generated_at and curr_dt:
+            # If a malformed producer report arrives while a gap is open, record the
+            # truthful FAIL summary so the observation gap closes. Otherwise preserve
+            # the last valid summary exactly as before.
+            if (
+                invalid_new_generated_at
+                and curr_dt
+                and current_kind != INTEGRITY_OBSERVATION_GAP_KIND
+            ):
                 logger.warning(
                     f"Skipping overwrite for {repo}: invalid generated_at in fetched report "
                     f"({new_generated_at!r}); keeping current ({current_payload.get('generated_at')!r})"
@@ -348,11 +412,21 @@ class IntegrityManager:
             new_dt = parse_iso_ts(new_generated_at) if new_generated_at else None
 
             # Update logic:
-            # - Skip if older or equal (<=) to prevent redundant writes/churn.
-            if new_dt and curr_dt and new_dt <= curr_dt:
-                # New report is older or same, skip update
-                logger.debug(f"Skipping update for {repo}: {new_generated_at} <= {current_payload.get('generated_at')}")
-                return
+            # - Summary vs summary: skip older or equal producer timestamps.
+            # - Gap vs recovered summary: equal is a successful re-observation and
+            #   must close the gap; only an older producer timestamp stays blocked.
+            if new_dt and curr_dt:
+                stale_or_duplicate = (
+                    new_dt < curr_dt
+                    if current_kind == INTEGRITY_OBSERVATION_GAP_KIND
+                    else new_dt <= curr_dt
+                )
+                if stale_or_duplicate:
+                    logger.debug(
+                        f"Skipping stale integrity update for {repo}: "
+                        f"{new_generated_at} vs {current_generated_at}"
+                    )
+                    return
 
         # If we failed fetch/parse (and didn't return early), we synthesize a minimal payload
         if not payload_data:
@@ -380,7 +454,7 @@ class IntegrityManager:
         # Strict Schema: kind is in wrapper, not payload
         wrapper = {
             "domain": domain,
-            "kind": "integrity.summary.published.v1",
+            "kind": INTEGRITY_SUMMARY_KIND,
             "received_at": received_at,
             "payload": payload_data,
         }
@@ -486,15 +560,18 @@ class IntegrityManager:
             payload = payload.copy()
 
             # Check kind in wrapper (Canonical)
-            if item.get("kind") == "integrity.summary.published.v1":
+            if item.get("kind") == INTEGRITY_SUMMARY_KIND:
                 pass # Canonical path
+            elif item.get("kind") == INTEGRITY_OBSERVATION_GAP_KIND:
+                payload["observation_status"] = "MISSING"
+                payload["observation_gap_started_at"] = item.get("received_at")
             # Backward compatibility: check payload.kind/type if wrapper.kind missing
-            elif payload.get("kind") == "integrity.summary.published.v1":
+            elif payload.get("kind") == INTEGRITY_SUMMARY_KIND:
                 payload["legacy"] = True
-            elif payload.get("type") == "integrity.summary.published.v1":
+            elif payload.get("type") == INTEGRITY_SUMMARY_KIND:
                 payload["legacy"] = True
             # Optional: wrapper type fallback
-            elif item.get("type") == "integrity.summary.published.v1":
+            elif item.get("type") == INTEGRITY_SUMMARY_KIND:
                 payload["legacy"] = True
             else:
                 # Junk or unrelated event

--- a/integrity.py
+++ b/integrity.py
@@ -342,16 +342,33 @@ class IntegrityManager:
         current_kind = None
         curr_dt = None
         has_current_state = False
+        current_has_valid_producer_summary = False
 
         if current_line:
             try:
                 current_item = json.loads(current_line)
                 current_kind = current_item.get("kind")
                 current_payload = current_item.get("payload", {})
+                current_meta = current_item.get("meta", {})
+                if not isinstance(current_meta, dict):
+                    current_meta = {}
+                current_has_valid_producer_summary = (
+                    current_kind == INTEGRITY_SUMMARY_KIND
+                    and bool(
+                        current_meta.get(
+                            "producer_summary_valid",
+                            not bool(current_meta.get("error_reason")),
+                        )
+                    )
+                )
                 current_generated_at = (
                     current_payload.get("last_known_generated_at")
                     if current_kind == INTEGRITY_OBSERVATION_GAP_KIND
-                    else current_payload.get("generated_at")
+                    else (
+                        current_payload.get("generated_at")
+                        if current_has_valid_producer_summary
+                        else None
+                    )
                 )
                 curr_dt = parse_iso_ts(current_generated_at) if current_generated_at else None
                 has_current_state = True
@@ -360,14 +377,22 @@ class IntegrityManager:
                 pass
 
         # Stability Logic:
-        # If a fetch fails after a known state, keep the last summary immutable but
-        # append one explicit observation-gap event. Repeated failures do not churn
-        # the ledger; the next non-stale successful summary closes the gap.
+        # A transport failure may open a gap only after producer truth was observed.
+        # Receiver-synthesized/invalid summaries neither qualify as last-known producer
+        # state nor contribute a producer timestamp to freshness comparisons.
         if failure_class is not None and has_current_state:
             if current_kind == INTEGRITY_OBSERVATION_GAP_KIND:
                 logger.debug(f"Integrity observation gap already open for {repo}")
                 return
+            if current_kind == INTEGRITY_SUMMARY_KIND and not current_has_valid_producer_summary:
+                logger.debug(f"No valid producer summary available for observation gap on {repo}")
+                return
+            if not current_has_valid_producer_summary:
+                has_current_state = False
 
+        # If a fetch fails after a valid producer summary, keep that summary immutable
+        # and append one explicit observation-gap event. Repeated failures do not churn.
+        if failure_class is not None and current_has_valid_producer_summary:
             last_known_status = normalize_status(current_payload.get("status", "UNCLEAR"))
             gap_status = max(("MISSING", last_known_status), key=lambda candidate: STATUS_SEVERITY[candidate])
             gap_payload = {
@@ -459,9 +484,14 @@ class IntegrityManager:
             "payload": payload_data,
         }
 
-        # Add meta with error reason if available
+        # Receiver-owned metadata distinguishes valid producer truth from summaries
+        # synthesized or sanitized after an invalid observation. Legacy summaries
+        # without error metadata remain valid for backward compatibility.
         if error_reason:
-            wrapper["meta"] = {"error_reason": error_reason}
+            wrapper["meta"] = {
+                "error_reason": error_reason,
+                "producer_summary_valid": False,
+            }
 
         # Write to storage
         try:

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -134,6 +134,61 @@ async def test_integrity_overwrite_protection(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_integrity_fetch_failure_requires_valid_producer_summary(monkeypatch, tmp_path):
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+    from integrity import IntegrityManager
+    from storage import read_last_line, read_tail, sanitize_domain
+
+    repo = "heimgewebe/no-producer-yet"
+    domain = sanitize_domain(f"integrity.{repo.replace('/', '.')}")
+    producer_ts = "2020-01-01T00:00:00Z"
+
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=[
+        create_mock_response({}, 503),
+        create_mock_response({}, 503),
+        create_mock_response({"repo": repo, "status": "OK", "generated_at": producer_ts}),
+        create_mock_response({}, 503),
+    ])
+    manager = IntegrityManager()
+
+    # The first transport failure keeps the historical aggregate-visible MISSING
+    # summary, but marks it as receiver-generated rather than producer truth.
+    await manager._fetch_and_update(client, repo, "http://summary")
+    lines = read_tail(domain, 10)
+    assert len(lines) == 1
+    initial = json.loads(lines[0])
+    assert initial["kind"] == "integrity.summary.published.v1"
+    assert initial["payload"]["status"] == "MISSING"
+    assert initial["meta"]["producer_summary_valid"] is False
+
+    # A repeated failure must neither invent last-known producer truth nor churn
+    # another receiver-generated summary into the append-only ledger.
+    await manager._fetch_and_update(client, repo, "http://summary")
+    assert len(read_tail(domain, 10)) == 1
+    aggregate = await manager.get_aggregate_view()
+    assert aggregate["repos"][0]["status"] == "MISSING"
+    assert "observation_status" not in aggregate["repos"][0]
+
+    # Receiver time is not a producer clock: even an older producer timestamp must
+    # replace the synthetic bootstrap summary once real producer truth is observed.
+    await manager._fetch_and_update(client, repo, "http://summary")
+    latest = json.loads(read_last_line(domain))
+    assert latest["kind"] == "integrity.summary.published.v1"
+    assert latest["payload"]["status"] == "OK"
+    assert latest["payload"]["generated_at"] == producer_ts
+    assert len(read_tail(domain, 10)) == 2
+
+    # Only now may a transport failure open an observation gap.
+    await manager._fetch_and_update(client, repo, "http://summary")
+    latest = json.loads(read_last_line(domain))
+    assert latest["kind"] == "integrity.observation.gap.published.v1"
+    assert latest["payload"]["last_known_status"] == "OK"
+    assert latest["payload"]["last_known_generated_at"] == producer_ts
+    assert len(read_tail(domain, 10)) == 3
+
+
+@pytest.mark.asyncio
 async def test_integrity_fetch_failure_records_gap_without_churn_and_recovers(monkeypatch, tmp_path):
     monkeypatch.setattr("storage.DATA_DIR", tmp_path)
     from integrity import IntegrityManager

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -132,6 +132,211 @@ async def test_integrity_overwrite_protection(monkeypatch, tmp_path):
     assert data["payload"]["status"] == "OK"
     assert data["payload"]["generated_at"] == initial_ts
 
+
+@pytest.mark.asyncio
+async def test_integrity_fetch_failure_records_gap_without_churn_and_recovers(monkeypatch, tmp_path):
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+    from integrity import IntegrityManager
+    from storage import read_last_line, read_tail, sanitize_domain, write_payload
+
+    repo = "heimgewebe/gap-aware"
+    domain = sanitize_domain(f"integrity.{repo.replace('/', '.')}")
+    initial_ts = "2026-08-24T10:00:00Z"
+    recovered_ts = initial_ts
+
+    initial_wrapper = {
+        "domain": domain,
+        "kind": "integrity.summary.published.v1",
+        "received_at": initial_ts,
+        "payload": {
+            "repo": repo,
+            "url": "http://summary",
+            "status": "OK",
+            "generated_at": initial_ts,
+        },
+    }
+    write_payload(domain, [json.dumps(initial_wrapper)])
+
+    sources_data = {
+        "apiVersion": "integrity.sources.v1",
+        "generated_at": "2026-08-24T09:00:00Z",
+        "sources": [{"repo": repo, "summary_url": "http://summary", "enabled": True}],
+    }
+    summary_responses = [
+        create_mock_response({}, 503),
+        create_mock_response({}, 503),
+        create_mock_response({"repo": repo, "status": "OK", "generated_at": recovered_ts}),
+    ]
+
+    async def mock_handler(url, *args, **kwargs):
+        if "sources" in url:
+            return create_mock_response(sources_data)
+        if "summary" in url:
+            return summary_responses.pop(0)
+        return create_mock_response({}, 404)
+
+    manager = IntegrityManager()
+    manager.sources_url = "http://sources"
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = mock_handler
+
+        # First failed observation appends one explicit gap while preserving the summary.
+        await manager.sync_all()
+        lines = read_tail(domain, 10)
+        assert len(lines) == 2
+        assert json.loads(lines[0]) == initial_wrapper
+
+        gap = json.loads(lines[1])
+        assert gap["kind"] == "integrity.observation.gap.published.v1"
+        assert gap["payload"]["status"] == "MISSING"
+        assert gap["payload"]["observation_status"] == "MISSING"
+        assert gap["payload"]["last_known_status"] == "OK"
+        assert gap["payload"]["last_known_generated_at"] == initial_ts
+        assert "generated_at" not in gap["payload"]
+        assert gap["payload"]["failure_class"] == "http_error"
+
+        aggregate = await manager.get_aggregate_view()
+        assert aggregate["total_status"] == "MISSING"
+        assert len(aggregate["repos"]) == 1
+        current = aggregate["repos"][0]
+        assert current["repo"] == repo
+        assert current["status"] == "MISSING"
+        assert current["observation_status"] == "MISSING"
+        assert current["observation_gap_started_at"] == gap["received_at"]
+        assert current["last_known_status"] == "OK"
+        assert current["last_known_generated_at"] == initial_ts
+
+        # Repeated failure leaves the already-open gap as the sole gap event.
+        await manager.sync_all()
+        assert len(read_tail(domain, 10)) == 2
+
+        # A non-stale successful producer summary (including equal timestamp) closes the gap.
+        await manager.sync_all()
+
+    latest = json.loads(read_last_line(domain))
+    assert latest["kind"] == "integrity.summary.published.v1"
+    assert latest["payload"]["status"] == "OK"
+    assert latest["payload"]["generated_at"] == recovered_ts
+
+    aggregate = await manager.get_aggregate_view()
+    assert aggregate["total_status"] == "OK"
+    assert aggregate["repos"][0]["status"] == "OK"
+    assert "observation_status" not in aggregate["repos"][0]
+    assert len(read_tail(domain, 10)) == 3
+
+    # Losing observability must never make a known FAIL look healthier.
+    failed_ts = "2026-08-24T12:00:00Z"
+    write_payload(domain, [json.dumps({
+        "domain": domain,
+        "kind": "integrity.summary.published.v1",
+        "received_at": failed_ts,
+        "payload": {
+            "repo": repo,
+            "url": "http://summary",
+            "status": "FAIL",
+            "generated_at": failed_ts,
+        },
+    })])
+    failing_client = MagicMock()
+    failing_client.get = AsyncMock(return_value=create_mock_response({}, 503))
+    await manager._fetch_and_update(failing_client, repo, "http://summary")
+
+    aggregate = await manager.get_aggregate_view()
+    assert aggregate["total_status"] == "FAIL"
+    current = aggregate["repos"][0]
+    assert current["status"] == "FAIL"
+    assert current["observation_status"] == "MISSING"
+    assert current["last_known_status"] == "FAIL"
+
+    # A successful fetch with an invalid producer timestamp is observable truth:
+    # close the gap as a sanitized FAIL summary instead of leaving MISSING sticky.
+    malformed_client = MagicMock()
+    malformed_client.get = AsyncMock(return_value=create_mock_response({
+        "repo": repo,
+        "status": "OK",
+        "generated_at": "not-a-date",
+    }))
+    await manager._fetch_and_update(malformed_client, repo, "http://summary")
+
+    latest = json.loads(read_last_line(domain))
+    assert latest["kind"] == "integrity.summary.published.v1"
+    assert latest["payload"]["status"] == "FAIL"
+    assert latest["payload"]["generated_at_sanitized"] is True
+    aggregate = await manager.get_aggregate_view()
+    assert aggregate["total_status"] == "FAIL"
+    assert "observation_status" not in aggregate["repos"][0]
+
+
+@pytest.mark.asyncio
+async def test_integrity_producer_reported_missing_is_not_observation_gap(monkeypatch, tmp_path):
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+    from integrity import IntegrityManager
+    from storage import read_last_line, sanitize_domain, write_payload
+
+    repo = "heimgewebe/producer-missing"
+    domain = sanitize_domain(f"integrity.{repo.replace('/', '.')}")
+    initial_ts = "2026-08-24T10:00:00Z"
+    producer_ts = "2026-08-24T11:00:00Z"
+    write_payload(domain, [json.dumps({
+        "domain": domain,
+        "kind": "integrity.summary.published.v1",
+        "received_at": initial_ts,
+        "payload": {"repo": repo, "status": "OK", "generated_at": initial_ts},
+    })])
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=create_mock_response({
+        "repo": repo,
+        "status": "MISSING",
+        "generated_at": producer_ts,
+        "observation_status": "MISSING",
+        "observation_gap_started_at": "forged",
+        "last_known_status": "FAIL",
+        "last_known_generated_at": "forged",
+        "failure_class": "network_error",
+    }))
+    manager = IntegrityManager()
+    await manager._fetch_and_update(client, repo, "http://summary")
+
+    latest = json.loads(read_last_line(domain))
+    assert latest["kind"] == "integrity.summary.published.v1"
+    assert latest["payload"]["status"] == "MISSING"
+    assert latest["payload"]["generated_at"] == producer_ts
+    assert "observation_status" not in latest["payload"]
+    assert "observation_gap_started_at" not in latest["payload"]
+    assert "last_known_status" not in latest["payload"]
+    assert "last_known_generated_at" not in latest["payload"]
+    assert "failure_class" not in latest["payload"]
+
+
+@pytest.mark.asyncio
+async def test_integrity_non_object_200_does_not_open_network_gap(monkeypatch, tmp_path):
+    monkeypatch.setattr("storage.DATA_DIR", tmp_path)
+    from integrity import IntegrityManager
+    from storage import read_last_line, read_tail, sanitize_domain, write_payload
+
+    repo = "heimgewebe/non-object"
+    domain = sanitize_domain(f"integrity.{repo.replace('/', '.')}")
+    initial_ts = "2026-08-24T10:00:00Z"
+    write_payload(domain, [json.dumps({
+        "domain": domain,
+        "kind": "integrity.summary.published.v1",
+        "received_at": initial_ts,
+        "payload": {"repo": repo, "status": "OK", "generated_at": initial_ts},
+    })])
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=create_mock_response([]))
+    manager = IntegrityManager()
+    await manager._fetch_and_update(client, repo, "http://summary")
+
+    assert len(read_tail(domain, 10)) == 1
+    latest = json.loads(read_last_line(domain))
+    assert latest["kind"] == "integrity.summary.published.v1"
+    assert latest["payload"]["status"] == "OK"
+    assert latest["payload"]["generated_at"] == initial_ts
+
 # 3. Invalid Timestamps (Future/Corrupt)
 @pytest.mark.asyncio
 async def test_integrity_invalid_timestamp_handling(monkeypatch, tmp_path):


### PR DESCRIPTION
## Ziel
Persistiert eine explizite Observation-Gap-Evidenz, wenn ein Integrity-Fetch nach vorhandenem gültigem Producer-Zustand fehlschlägt, ohne den letzten Producer-Summary zu überschreiben.

## Semantik
- echter Transport-/HTTP-Fehler -> genau ein append-only `integrity.observation.gap.published.v1` pro zusammenhängender Beobachtungslücke
- ein Gap darf nur nach einer gültig beobachteten Producer-Summary geöffnet werden
- receiver-synthetisierte oder sanitizierte Fehler-Summaries liefern weder `last_known_*`-Producer-Wahrheit noch einen Producer-Zeitstempel für Freshness-Vergleiche
- wiederholte initiale Fetchfehler erzeugen keinen falschen Gap und keinen Ledger-Churn
- eine später beobachtete echte Producer-Summary kann einen synthetischen Bootstrap-Zustand auch mit älterem Producer-Timestamp ersetzen
- legitimer Producer-Status `MISSING` bleibt Producer-Summary und wird nicht als Fetchfehler umgedeutet
- bekannte `FAIL`-Wahrheit wird durch Beobachtungsverlust nie verbessert
- erfolgreiche Re-Observation mit gleichem Producer-Timestamp schließt einen echten Gap
- malformed Recovery wird als sanitizierter `FAIL`-Summary sichtbar
- Producer kann die Chronik-eigenen `observation_*`/`last_known_*`/`failure_class`-Felder nicht einschleusen
- Retention-Semantik und übrige Chronik-Architektur bleiben unverändert

## Review-Fix
Der P2-Hinweis „Require a producer summary before opening a gap“ ist auf Head `c835ab7fdccd307c6e281db865774e65b1762223` eingearbeitet. Ein Regressionstest deckt die Sequenz initialer Fehler -> echte ältere Producer-Summary -> späterer echter Observation-Gap ab.

## Verifikation
- `./scripts/validate-local.sh`: Ruff grün, Mypy grün, 585 Tests grün, API-Smoke grün
- gezielt: `tests/test_integrity.py`: 10 Tests grün

Audit-Intake: `candidate-2b665bf1f14e41f61c741455`.

Nicht Teil dieses PRs: Retention-Fallback-Änderungen, neue Stores/Worker oder breitere Chronik-Architektur.