### PR TITLE
fix(storage): enforce committed read boundaries

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -11,7 +11,7 @@ import re
 import stat
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Final, Iterable, Iterator, NoReturn, Tuple
+from typing import BinaryIO, Final, Iterable, Iterator, NoReturn, Tuple
 
 from filelock import FileLock, Timeout
 
@@ -352,6 +352,22 @@ def _target_stat_for_fd(target_path: Path, fd: int) -> os.stat_result:
     return opened
 
 
+@contextmanager
+def _open_committed_read(
+    target_path: Path,
+) -> Iterator[Tuple[BinaryIO, int]]:
+    """Capture a verified size under the domain lock, then release it for reads."""
+    with _safe_open_read(target_path) as fh:
+        lock_path = get_lock_path(target_path)
+        try:
+            with FileLock(str(lock_path), timeout=LOCK_TIMEOUT):
+                committed_size = _target_stat_for_fd(target_path, fh.fileno()).st_size
+        except Timeout as exc:
+            logger.warning("busy (lock timeout)", extra={"file": str(target_path)})
+            raise StorageBusyError("busy, try again") from exc
+        yield fh, committed_size
+
+
 def _fsync_file(fd: int) -> None:
     """Sync file contents or expose a distinct durability failure."""
     try:
@@ -540,9 +556,10 @@ def read_last_line(domain: str) -> str | None:
 def read_domain_snapshot(domain: str, start_offset: int = 0) -> bytes:
     """Read one byte-exact, append-stable snapshot of complete JSONL records.
 
-    The file size is captured from the opened descriptor before reading. Bytes
-    appended afterwards are outside this snapshot. An incomplete tail is
-    excluded so parsing, offsets and hashes share one complete-record boundary.
+    The opened file's identity and size are verified under the domain lock,
+    which is released before reading. Bytes appended afterwards are outside
+    this snapshot. An incomplete tail is excluded so parsing, offsets and
+    hashes share one complete-record boundary.
     """
     if not isinstance(start_offset, int) or isinstance(start_offset, bool) or start_offset < 0:
         raise StorageError("start_offset must be a non-negative integer")
@@ -552,12 +569,11 @@ def read_domain_snapshot(domain: str, start_offset: int = 0) -> bytes:
         raise StorageError("invalid target path") from exc
 
     try:
-        with _safe_open_read(target_path) as fh:
-            observed_size = os.fstat(fh.fileno()).st_size
-            if start_offset >= observed_size:
+        with _open_committed_read(target_path) as (fh, committed_size):
+            if start_offset >= committed_size:
                 return b""
             fh.seek(start_offset)
-            remaining = observed_size - start_offset
+            remaining = committed_size - start_offset
             chunks: list[bytes] = []
             while remaining:
                 chunk = fh.read(min(1024 * 1024, remaining))
@@ -597,12 +613,10 @@ def scan_domain(domain: str, start_offset: int = 0) -> Iterator[Tuple[int, int, 
     except DomainError as exc:
         raise StorageError("invalid target path") from exc
 
-    # Open for reading without exclusive lock to avoid blocking writers during long scans.
-    # Writers append atomically (mostly), so worst case is a partial read at EOF,
-    # which will likely be handled as a corrupt line or ignored.
     try:
-        # Use safe open to prevent symlink attacks, but no file lock
-        with _safe_open_read(target_path) as fh:
+        with _open_committed_read(target_path) as (fh, committed_size):
+            if start_offset > committed_size:
+                return
             if start_offset:
                 try:
                     fh.seek(start_offset - 1)
@@ -623,11 +637,11 @@ def scan_domain(domain: str, start_offset: int = 0) -> Iterator[Tuple[int, int, 
                     )
                 # Reading the boundary byte already positions the handle exactly
                 # at start_offset; a second seek would be redundant.
-            while True:
+            while fh.tell() < committed_size:
                 # Capture start offset before reading
                 current_start = fh.tell()
 
-                line = fh.readline()
+                line = fh.readline(committed_size - current_start)
                 if not line:
                     break
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,7 +1,10 @@
 import json
+import queue
+import threading
 
 import pytest
 import storage
+from filelock import FileLock, Timeout
 
 @pytest.fixture
 def mock_data_dir(tmp_path, monkeypatch):
@@ -253,6 +256,135 @@ def test_scan_domain_accepts_emitted_record_boundary(mock_data_dir):
     assert list(storage.scan_domain("agent.ledger", start_offset=boundary)) == [
         (boundary, boundary + len('{"id":2}'.encode("utf-8")) + 1, '{"id":2}')
     ]
+
+
+def _assert_reader_excludes_rolled_back_append(
+    mock_data_dir, monkeypatch, reader, expected
+):
+    original = b'{"existing":1}\n'
+    transient = b'{"transient":2}\n'
+    target = mock_data_dir / "agent.ledger.jsonl"
+    target.write_bytes(original)
+
+    real_fsync = storage.os.fsync
+    fsync_calls = 0
+    transient_exposed = threading.Event()
+    release_writer = threading.Event()
+    progress = queue.Queue()
+    writer_outcome = queue.Queue()
+    reader_outcome = queue.Queue()
+    reader_thread_name = "read-committed-regression-reader"
+
+    def fail_commit_fsync(fd):
+        nonlocal fsync_calls
+        fsync_calls += 1
+        if fsync_calls == 1:
+            assert target.read_bytes() == original + transient
+            transient_exposed.set()
+            if not release_writer.wait(timeout=5):
+                raise AssertionError("reader did not attempt a committed read")
+            raise OSError(5, "simulated durability failure")
+        return real_fsync(fd)
+
+    class ObservedReaderLock:
+        def __init__(self, lock):
+            self.lock = lock
+
+        def __enter__(self):
+            progress.put("lock-attempt")
+            return self.lock.__enter__()
+
+        def __exit__(self, *args):
+            return self.lock.__exit__(*args)
+
+    def observed_file_lock(*args, **kwargs):
+        lock = FileLock(*args, **kwargs)
+        if threading.current_thread().name == reader_thread_name:
+            return ObservedReaderLock(lock)
+        return lock
+
+    def write_transient_record():
+        try:
+            storage.write_payload("agent.ledger", [transient[:-1].decode("utf-8")])
+        except BaseException as exc:
+            writer_outcome.put(exc)
+        else:
+            writer_outcome.put(None)
+
+    def run_reader():
+        try:
+            reader_outcome.put((reader(), None))
+        except BaseException as exc:
+            reader_outcome.put((None, exc))
+        progress.put("read-complete")
+
+    monkeypatch.setattr(storage.os, "fsync", fail_commit_fsync)
+    monkeypatch.setattr(storage, "FileLock", observed_file_lock)
+
+    writer_thread = threading.Thread(target=write_transient_record)
+    writer_thread.start()
+    assert transient_exposed.wait(timeout=5)
+    assert target.read_bytes() == original + transient
+
+    reader_thread = threading.Thread(target=run_reader, name=reader_thread_name)
+    reader_thread.start()
+    try:
+        assert progress.get(timeout=5) == "lock-attempt"
+        assert reader_outcome.empty()
+    finally:
+        release_writer.set()
+        writer_thread.join(timeout=5)
+        reader_thread.join(timeout=5)
+
+    assert not writer_thread.is_alive()
+    assert not reader_thread.is_alive()
+    writer_error = writer_outcome.get_nowait()
+    assert isinstance(writer_error, storage.StorageRecoveryError)
+    assert "durability sync failed" in str(writer_error)
+    value, reader_error = reader_outcome.get_nowait()
+    assert reader_error is None
+    assert value == expected
+    assert target.read_bytes() == original
+
+
+def test_scan_domain_excludes_transient_append_rolled_back_after_fsync_failure(
+    mock_data_dir, monkeypatch
+):
+    _assert_reader_excludes_rolled_back_append(
+        mock_data_dir,
+        monkeypatch,
+        lambda: list(storage.scan_domain("agent.ledger")),
+        [(0, len(b'{"existing":1}\n'), '{"existing":1}')],
+    )
+
+
+def test_read_domain_snapshot_excludes_transient_append_rolled_back_after_fsync_failure(
+    mock_data_dir, monkeypatch
+):
+    _assert_reader_excludes_rolled_back_append(
+        mock_data_dir,
+        monkeypatch,
+        lambda: storage.read_domain_snapshot("agent.ledger"),
+        b'{"existing":1}\n',
+    )
+
+
+@pytest.mark.parametrize("reader_name", ["scan", "snapshot"])
+def test_committed_reader_lock_timeout_is_storage_busy(
+    mock_data_dir, monkeypatch, reader_name
+):
+    (mock_data_dir / "agent.ledger.jsonl").write_bytes(b'{"existing":1}\n')
+
+    def timeout_file_lock(*args, **kwargs):
+        raise Timeout("agent.ledger.jsonl.lock")
+
+    monkeypatch.setattr(storage, "FileLock", timeout_file_lock)
+
+    with pytest.raises(storage.StorageBusyError, match="busy, try again"):
+        if reader_name == "scan":
+            list(storage.scan_domain("agent.ledger"))
+        else:
+            storage.read_domain_snapshot("agent.ledger")
 
 
 def test_write_payload_unique_groups_rejects_cross_group_conflict_before_write(


### PR DESCRIPTION
## Problem
Chronik readers could observe transient append bytes while a writer was still inside the durability critical section. If fsync then failed, those bytes were rolled back even though a concurrent reader may already have returned them.

## Change
- capture and verify the readable file size while holding the existing per-domain writer lock
- release the lock before the potentially long read
- bound snapshot and scan reads to that committed size
- map reader lock timeouts to `StorageBusyError`
- add deterministic concurrent rollback regressions for both reader paths

## Verification
- `tests/test_storage.py`: 37 passed
- `tests/test_app.py tests/test_coding_memory.py tests/test_http_error_mapping.py`: 102 passed (one existing Starlette/httpx deprecation warning)
- `git diff --check`: passed
- canonical CI remains authoritative for Ruff/Mypy because the reusable local test venv lacks those dev modules in this isolated worktree

No runtime activation or deployment is part of this change.