### PR TITLE
perf(storage): stream raw ledger scans

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -1972,11 +1972,12 @@ def _publish_grabowski_source_index(
 
 
 def _ledger_payloads_by_event_id() -> tuple[dict[str, bytes], int]:
-    """Read one complete ledger snapshot and bind every event id to its payload."""
-    snapshot = storage.read_domain_snapshot(DOMAIN)
+    """Stream one committed ledger view and bind every event id to its payload."""
     payloads: dict[str, bytes] = {}
     records_scanned = 0
-    for line_number, raw_line in enumerate(snapshot.splitlines(), start=1):
+    for line_number, (_start, _next, raw_line) in enumerate(
+        storage.scan_domain_bytes(DOMAIN), start=1
+    ):
         if not raw_line.strip():
             continue
         records_scanned += 1

--- a/storage.py
+++ b/storage.py
@@ -49,6 +49,7 @@ __all__ = [
     "read_domain_snapshot",
     "read_unique_storage_checkpoint_identity",
     "scan_domain",
+    "scan_domain_bytes",
     "list_domains",
     "get_lock_path",
     "FILENAME_RE",
@@ -593,13 +594,13 @@ def read_domain_snapshot(domain: str, start_offset: int = 0) -> bytes:
     return snapshot[: last_newline + 1] if last_newline >= 0 else b""
 
 
-def scan_domain(domain: str, start_offset: int = 0) -> Iterator[Tuple[int, int, str]]:
-    """Scan the domain file forward starting from the given byte offset.
+def scan_domain_bytes(
+    domain: str, start_offset: int = 0
+) -> Iterator[Tuple[int, int, bytes]]:
+    """Scan committed complete JSONL records without decoding payload bytes.
 
-    Yields:
-        (start_offset, next_offset, line_str)
-
-    If start_offset is beyond EOF, yields nothing.
+    Each yielded payload excludes only the terminating LF byte. The committed
+    size and cursor-boundary contract is identical to :func:`scan_domain`.
     """
     if (
         isinstance(start_offset, bool)
@@ -628,48 +629,35 @@ def scan_domain(domain: str, start_offset: int = 0) -> Iterator[Tuple[int, int, 
                     raise
                 previous = fh.read(1)
                 if not previous:
-                    # Preserve the documented polling contract: a cursor beyond
-                    # the current EOF yields no records and can be retried later.
                     return
                 if previous != b"\n":
                     raise StorageCursorError(
                         "start_offset must point to a JSONL record boundary"
                     )
-                # Reading the boundary byte already positions the handle exactly
-                # at start_offset; a second seek would be redundant.
+
             while fh.tell() < committed_size:
-                # Capture start offset before reading
                 current_start = fh.tell()
-
                 line = fh.readline(committed_size - current_start)
-                if not line:
+                if not line or not line.endswith(b"\n"):
                     break
-
-                # Guard against partial writes: Only process complete lines ending with newline.
-                # If we are at EOF and the line doesn't end with \n, it's likely being written.
-                # We stop here and don't yield this line or advance cursor past it.
-                if not line.endswith(b'\n'):
-                    break
-
-                # Current position is the start of the next line
                 next_offset = fh.tell()
-
-                # Decode
-                try:
-                    text = line.decode("utf-8")
-                except UnicodeDecodeError:
-                    text = line.decode("utf-8", errors="replace")
-
-                # Remove trailing newline (we know it exists now)
-                if text.endswith("\n"):
-                    text = text[:-1]
-
-                yield current_start, next_offset, text
-
+                yield current_start, next_offset, line[:-1]
     except OSError as exc:
         if exc.errno == errno.ENOENT:
             return
         raise StorageError("read error") from exc
+
+
+def scan_domain(domain: str, start_offset: int = 0) -> Iterator[Tuple[int, int, str]]:
+    """Scan the domain file forward from a committed JSONL record boundary."""
+    for current_start, next_offset, raw_line in scan_domain_bytes(
+        domain, start_offset=start_offset
+    ):
+        try:
+            text = raw_line.decode("utf-8")
+        except UnicodeDecodeError:
+            text = raw_line.decode("utf-8", errors="replace")
+        yield current_start, next_offset, text
 
 
 def list_domains(prefix: str = "") -> list[str]:

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -500,3 +500,35 @@ def test_cli_regular_json_loader_keeps_existing_list_semantics(tmp_path):
     assert cli.load(object_path) == [{"index": 1}]
     assert cli.load(list_path) == [{"index": 1}, {"index": 2}]
     assert cli.load(empty_path) == []
+
+
+def test_ledger_payload_index_streams_committed_records_without_snapshot(
+    tmp_path, monkeypatch
+):
+    setup(tmp_path, monkeypatch)
+    first = event()
+    second = event("sha256:" + "b" * 64)
+    coding_memory.import_events([first, second])
+
+    def snapshot_forbidden(*_args, **_kwargs):
+        raise AssertionError("ledger payload indexing must not materialize a full snapshot")
+
+    monkeypatch.setattr(storage, "read_domain_snapshot", snapshot_forbidden)
+    payloads, records_scanned = coding_memory._ledger_payloads_by_event_id()
+
+    assert records_scanned == 2
+    assert payloads[first["event_id"]] == coding_memory.canonical_bytes(first)
+    assert payloads[second["event_id"]] == coding_memory.canonical_bytes(second)
+
+
+def test_ledger_payload_index_treats_only_lf_as_record_boundary(
+    tmp_path, monkeypatch
+):
+    setup(tmp_path, monkeypatch)
+    first = json.dumps({"payload": event()}, separators=(",", ":")).encode("utf-8")
+    second_event = event("sha256:" + "c" * 64)
+    second = json.dumps({"payload": second_event}, separators=(",", ":")).encode("utf-8")
+    (tmp_path / "agent.ledger.jsonl").write_bytes(first + b"\r" + second + b"\n")
+
+    with pytest.raises(storage.StorageError, match="invalid ledger JSON at record 1"):
+        coding_memory._ledger_payloads_by_event_id()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -192,6 +192,28 @@ def test_write_payload_unique_groups_rejects_unrelated_historical_conflict(
         )
 
 
+def test_scan_domain_bytes_preserves_raw_record_bytes_and_offsets(mock_data_dir):
+    first = b'{"value":"\xff"}\n'
+    second = b'{"id":2}\r\n'
+    (mock_data_dir / "agent.ledger.jsonl").write_bytes(first + second)
+
+    assert list(storage.scan_domain_bytes("agent.ledger")) == [
+        (0, len(first), first[:-1]),
+        (len(first), len(first) + len(second), second[:-1]),
+    ]
+
+
+def test_scan_domain_decodes_raw_records_with_existing_replacement_semantics(
+    mock_data_dir,
+):
+    raw = b'{"value":"\xff"}\n'
+    (mock_data_dir / "agent.ledger.jsonl").write_bytes(raw)
+
+    assert list(storage.scan_domain("agent.ledger")) == [
+        (0, len(raw), '{"value":"\ufffd"}')
+    ]
+
+
 def test_scan_domain_accepts_crlf_record_boundary(mock_data_dir):
     first = b'{"id":1}\r\n'
     second = b'{"id":2}\r\n'


### PR DESCRIPTION
## Ergebnis
- ergänzt `scan_domain_bytes()` als committed-boundary-sicheren Raw-JSONL-Scanner
- lässt `scan_domain()` auf demselben Scanner aufbauen und erhält die bisherige UTF-8-Replacement-Semantik
- migriert den Coding-Memory-Event-ID-Abgleich vom vollständigen `read_domain_snapshot(...).splitlines()` auf den Streaming-Pfad
- behandelt weiterhin ausschließlich LF als JSONL-Recordgrenze; CR-only-Korruption wird fail-closed zurückgewiesen

## Nutzenmessung
Synthetischer, ledgerähnlicher Datensatz: 33.99 MB / 25,000 Records.

- Python-Peak unter `tracemalloc`: **102.8 MiB → 37.0 MiB** (ca. **64% weniger**)
- Median ohne `tracemalloc` nach Warmup: **0.2865 s → 0.3219 s** (ca. **12% langsamer**)

Der betroffene Abgleich gehört zum Vollpfad. Die bereits vorhandenen No-change- und Delta-Fastpaths bleiben unverändert. Damit wird bewusst ein kleiner Vollpfad-Laufzeitaufschlag gegen deutlich geringeren Peak-Speicher und bessere Skalierung getauscht.

## Sicherheit
- committed size wird weiterhin unter dem Domain-Lock erfasst
- Cursor müssen weiterhin auf einer echten LF-Recordgrenze liegen
- unvollständige Tails bleiben unsichtbar
- rohe Bytes werden für Integritäts-/JSON-Verarbeitung nicht vorab dekodiert
- Append-only-Autorität und Identity-Index-Semantik bleiben unverändert

## Validierung
- fokussiert: **79 passed**
- Vollsuite: **593 passed**
- Ruff: grün
- Mypy: grün
- Rollenvertrag: `OK chronik`
- API-Smoke `/health`, `/version`, Ingest + Events: grün
- `git diff --check`: grün