### PR TITLE
perf(history): bound snapshot validation memory

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -3743,30 +3743,30 @@ def _history_validation_checkpoint_path() -> Path:
     return storage.DATA_DIR / HISTORY_VALIDATION_CHECKPOINT_FILENAME
 
 
-def _load_history_validation_checkpoint(raw_snapshot: bytes) -> int:
-    """Return a previously validated byte prefix, or zero on any doubt."""
+def _load_history_validation_checkpoint() -> tuple[int, str] | None:
+    """Return validated prefix metadata, or ``None`` on any doubt."""
     path = _history_validation_checkpoint_path()
     try:
         before = path.lstat()
     except OSError:
-        return 0
+        return None
     if (
         not stat.S_ISREG(before.st_mode)
         or before.st_uid != os.geteuid()
         or before.st_mode & 0o077
     ):
-        return 0
+        return None
     try:
         raw = path.read_bytes()
         after = path.lstat()
     except OSError:
-        return 0
+        return None
     if _file_identity(before) != _file_identity(after):
-        return 0
+        return None
     try:
         document = json.loads(raw)
     except (UnicodeDecodeError, json.JSONDecodeError):
-        return 0
+        return None
     expected_keys = {
         "schema_version",
         "domain",
@@ -3777,7 +3777,7 @@ def _load_history_validation_checkpoint(raw_snapshot: bytes) -> int:
         "checkpoint_sha256",
     }
     if not isinstance(document, dict) or set(document) != expected_keys:
-        return 0
+        return None
     checkpoint_sha256 = document.get("checkpoint_sha256")
     semantic = {key: value for key, value in document.items() if key != "checkpoint_sha256"}
     if (
@@ -3788,35 +3788,46 @@ def _load_history_validation_checkpoint(raw_snapshot: bytes) -> int:
         or document.get("validation_contract") != HISTORY_VALIDATION_CONTRACT
         or document.get("event_schema_sha256") != _history_validation_schema_sha256()
     ):
-        return 0
+        return None
     validated_bytes = document.get("validated_bytes")
     prefix_sha256 = document.get("prefix_sha256")
     if (
         not isinstance(validated_bytes, int)
         or isinstance(validated_bytes, bool)
         or validated_bytes <= 0
-        or validated_bytes > len(raw_snapshot)
         or not isinstance(prefix_sha256, str)
         or len(prefix_sha256) != 64
-        or raw_snapshot[validated_bytes - 1 : validated_bytes] != b"\n"
-        or sha256_bytes(raw_snapshot[:validated_bytes]) != prefix_sha256
     ):
-        return 0
-    return validated_bytes
+        return None
+    return validated_bytes, prefix_sha256
+
+
+def _history_snapshot_identity(
+    checkpoint: tuple[int, str],
+) -> tuple[int, str, int]:
+    """Hash one committed stream and verify a checkpoint prefix without materializing it."""
+    validated_bytes, expected_prefix_sha256 = checkpoint
+    complete_bytes, snapshot_sha256, prefix_sha256 = storage.hash_domain_snapshot(
+        DOMAIN, prefix_offset=validated_bytes
+    )
+    trusted_validated_bytes = (
+        validated_bytes if prefix_sha256 == expected_prefix_sha256 else 0
+    )
+    return complete_bytes, snapshot_sha256, trusted_validated_bytes
 
 
 def _publish_history_validation_checkpoint(
-    raw_snapshot: bytes, *, snapshot_sha256: str
+    *, complete_bytes: int, snapshot_sha256: str
 ) -> None:
     """Best-effort publication of reconstructible validation evidence."""
-    if not raw_snapshot:
+    if complete_bytes <= 0:
         return
     document: dict[str, Any] = {
         "schema_version": HISTORY_VALIDATION_CHECKPOINT_SCHEMA,
         "domain": DOMAIN,
         "validation_contract": HISTORY_VALIDATION_CONTRACT,
         "event_schema_sha256": _history_validation_schema_sha256(),
-        "validated_bytes": len(raw_snapshot),
+        "validated_bytes": complete_bytes,
         "prefix_sha256": snapshot_sha256,
     }
     document["checkpoint_sha256"] = sha256_bytes(canonical_bytes(document))
@@ -3834,25 +3845,32 @@ def _publish_history_validation_checkpoint(
 def _scan_record_snapshot(
     visit: Callable[[dict[str, Any], datetime, int], None],
 ) -> dict[str, Any]:
-    """Validate complete records from one byte-bound snapshot and visit each once."""
+    """Validate a bounded committed record stream and visit each valid row once."""
     diagnostics: list[dict[str, Any]] = []
     invalid_record_count = 0
     total_record_count = 0
     valid_record_count = 0
-    raw_snapshot = storage.read_domain_snapshot(DOMAIN)
-    complete_bytes = len(raw_snapshot)
-    snapshot_sha256 = sha256_bytes(raw_snapshot)
-    trusted_validated_bytes = _load_history_validation_checkpoint(raw_snapshot)
-    start_offset = 0
 
-    while start_offset < complete_bytes:
-        newline_at = raw_snapshot.find(b"\n", start_offset)
-        if newline_at < 0:
+    checkpoint = _load_history_validation_checkpoint()
+    expected_complete_bytes: int | None = None
+    expected_snapshot_sha256: str | None = None
+    trusted_validated_bytes = 0
+    if checkpoint is not None:
+        (
+            expected_complete_bytes,
+            expected_snapshot_sha256,
+            trusted_validated_bytes,
+        ) = _history_snapshot_identity(checkpoint)
+
+    snapshot_hasher = hashlib.sha256()
+    complete_bytes = 0
+    for start_offset, next_offset, content in storage.scan_domain_bytes(DOMAIN):
+        if expected_complete_bytes is not None and next_offset > expected_complete_bytes:
             break
-        content = raw_snapshot[start_offset:newline_at]
-        next_offset = newline_at + 1
+        snapshot_hasher.update(content)
+        snapshot_hasher.update(b"\n")
+        complete_bytes = next_offset
         if not content.strip():
-            start_offset = next_offset
             continue
         total_record_count += 1
         try:
@@ -3877,17 +3895,24 @@ def _scan_record_snapshot(
                         "error": str(exc),
                     }
                 )
-            start_offset = next_offset
             continue
         row = {"received_at": envelope.get("received_at"), "payload": payload}
         visit(row, event_at, valid_record_count)
         valid_record_count += 1
-        start_offset = next_offset
+
+    snapshot_sha256 = snapshot_hasher.hexdigest()
+    if expected_complete_bytes is not None and (
+        complete_bytes != expected_complete_bytes
+        or snapshot_sha256 != expected_snapshot_sha256
+    ):
+        raise storage.StorageRecoveryError(
+            "history snapshot changed between checkpoint verification and validation"
+        )
 
     integrity_valid = invalid_record_count == 0
     if integrity_valid and trusted_validated_bytes < complete_bytes:
         _publish_history_validation_checkpoint(
-            raw_snapshot,
+            complete_bytes=complete_bytes,
             snapshot_sha256=snapshot_sha256,
         )
 

--- a/storage.py
+++ b/storage.py
@@ -47,6 +47,7 @@ __all__ = [
     "read_tail",
     "read_last_line",
     "read_domain_snapshot",
+    "hash_domain_snapshot",
     "read_unique_storage_checkpoint_identity",
     "scan_domain",
     "scan_domain_bytes",
@@ -552,6 +553,89 @@ def read_last_line(domain: str) -> str | None:
     """
     lines = read_tail(domain, 1)
     return lines[0] if lines else None
+
+
+def _complete_jsonl_size(fh: BinaryIO, committed_size: int) -> int:
+    """Return the final LF record boundary at or before ``committed_size``."""
+    if committed_size <= 0:
+        return 0
+    fh.seek(committed_size - 1)
+    if fh.read(1) == b"\n":
+        return committed_size
+
+    pointer = committed_size - 1
+    chunk_size = 64 * 1024
+    while pointer > 0:
+        read_size = min(chunk_size, pointer)
+        pointer -= read_size
+        fh.seek(pointer)
+        chunk = fh.read(read_size)
+        if not chunk:
+            break
+        newline_at = chunk.rfind(b"\n")
+        if newline_at >= 0:
+            return pointer + newline_at + 1
+    return 0
+
+
+def hash_domain_snapshot(
+    domain: str, *, prefix_offset: int | None = None
+) -> tuple[int, str, str | None]:
+    """Hash one committed complete-record snapshot without materializing it.
+
+    Returns ``(complete_bytes, snapshot_sha256, prefix_sha256)``. The prefix
+    digest is returned only when ``prefix_offset`` is an exact LF record
+    boundary inside the same committed snapshot.
+    """
+    if prefix_offset is not None and (
+        isinstance(prefix_offset, bool)
+        or not isinstance(prefix_offset, int)
+        or prefix_offset < 0
+    ):
+        raise StorageError("prefix_offset must be a non-negative integer")
+    try:
+        target_path = safe_target_path(domain)
+    except DomainError as exc:
+        raise StorageError("invalid target path") from exc
+
+    empty_sha256 = hashlib.sha256(b"").hexdigest()
+    try:
+        with _open_committed_read(target_path) as (fh, committed_size):
+            complete_bytes = _complete_jsonl_size(fh, committed_size)
+            prefix_valid = prefix_offset == 0
+            if (
+                prefix_offset is not None
+                and prefix_offset > 0
+                and prefix_offset <= complete_bytes
+            ):
+                fh.seek(prefix_offset - 1)
+                prefix_valid = fh.read(1) == b"\n"
+
+            snapshot_hasher = hashlib.sha256()
+            prefix_hasher = hashlib.sha256() if prefix_valid else None
+            position = 0
+            fh.seek(0)
+            while position < complete_bytes:
+                chunk = fh.read(min(1024 * 1024, complete_bytes - position))
+                if not chunk:
+                    raise StorageRecoveryError(
+                        "committed snapshot changed during hash read"
+                    )
+                snapshot_hasher.update(chunk)
+                if prefix_hasher is not None and prefix_offset is not None:
+                    prefix_remaining = prefix_offset - position
+                    if prefix_remaining > 0:
+                        prefix_hasher.update(chunk[:prefix_remaining])
+                position += len(chunk)
+            return (
+                complete_bytes,
+                snapshot_hasher.hexdigest(),
+                prefix_hasher.hexdigest() if prefix_hasher is not None else None,
+            )
+    except OSError as exc:
+        if exc.errno == errno.ENOENT:
+            return (0, empty_sha256, empty_sha256 if prefix_offset == 0 else None)
+        raise StorageError("read error") from exc
 
 
 def read_domain_snapshot(domain: str, start_offset: int = 0) -> bytes:

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -241,17 +241,112 @@ def test_snapshot_excludes_incomplete_tail_but_includes_complete_corruption(tmp_
     assert result["event_ids"]==[event()["event_id"]]
 
 
-def test_query_uses_one_immutable_snapshot_even_if_file_grows_after_read(tmp_path,monkeypatch):
-    setup(tmp_path,monkeypatch); coding_memory.import_events([event()]); target=tmp_path/"agent.ledger.jsonl"
-    original=storage.read_domain_snapshot; observed=target.read_bytes(); calls=[]
-    def read_then_append(domain):
-        calls.append(domain); snapshot=original(domain); target.write_bytes(snapshot+b'not-json\n'); return snapshot
-    monkeypatch.setattr(storage,"read_domain_snapshot",read_then_append)
-    result=coding_memory.query_history(repo="heimgewebe/example")
-    assert calls==[coding_memory.DOMAIN]
-    assert result["ledger_snapshot"]["sha256"]==hashlib.sha256(observed).hexdigest()
+def test_query_uses_one_immutable_snapshot_even_if_file_grows_during_scan(
+    tmp_path, monkeypatch
+):
+    setup(tmp_path, monkeypatch)
+    coding_memory.import_events([event()])
+    target = tmp_path / "agent.ledger.jsonl"
+    observed = target.read_bytes()
+    original = storage.scan_domain_bytes
+    calls = []
+
+    def snapshot_forbidden(*_args, **_kwargs):
+        raise AssertionError("history queries must not materialize a full domain snapshot")
+
+    def scan_then_append(domain, start_offset=0):
+        calls.append(domain)
+        appended = False
+        for item in original(domain, start_offset=start_offset):
+            yield item
+            if not appended:
+                with target.open("ab") as handle:
+                    handle.write(b"not-json\n")
+                appended = True
+
+    monkeypatch.setattr(storage, "read_domain_snapshot", snapshot_forbidden)
+    monkeypatch.setattr(storage, "scan_domain_bytes", scan_then_append)
+    result = coding_memory.query_history(repo="heimgewebe/example")
+
+    assert calls == [coding_memory.DOMAIN]
+    assert result["ledger_snapshot"]["sha256"] == hashlib.sha256(observed).hexdigest()
     assert result["ledger_snapshot"]["integrity_valid"] is True
-    assert target.read_bytes()==observed+b'not-json\n'
+    assert target.read_bytes() == observed + b"not-json\n"
+
+
+def test_checkpoint_query_excludes_append_between_identity_and_validation_passes(
+    tmp_path, monkeypatch
+):
+    setup(tmp_path, monkeypatch)
+    coding_memory.import_events([event()])
+    first = coding_memory.query_history(repo="heimgewebe/example")
+    target = tmp_path / "agent.ledger.jsonl"
+    observed = target.read_bytes()
+    appended_event = event("sha256:" + "d" * 64)
+    appended_line = coding_memory._envelope_lines([appended_event])[0].encode("utf-8") + b"\n"
+    original_hash = storage.hash_domain_snapshot
+    original_scan = storage.scan_domain_bytes
+    calls = []
+
+    def hash_then_append(domain, *, prefix_offset=None):
+        calls.append("hash")
+        result = original_hash(domain, prefix_offset=prefix_offset)
+        with target.open("ab") as handle:
+            handle.write(appended_line)
+        return result
+
+    def tracked_scan(domain, start_offset=0):
+        calls.append("scan")
+        yield from original_scan(domain, start_offset=start_offset)
+
+    monkeypatch.setattr(storage, "hash_domain_snapshot", hash_then_append)
+    monkeypatch.setattr(storage, "scan_domain_bytes", tracked_scan)
+    second = coding_memory.query_history(repo="heimgewebe/example")
+
+    assert calls == ["hash", "scan"]
+    assert second["ledger_snapshot"] == first["ledger_snapshot"]
+    assert second["event_ids"] == first["event_ids"]
+    assert target.read_bytes() == observed + appended_line
+
+
+def test_checkpoint_query_fails_closed_if_snapshot_changes_between_passes(
+    tmp_path, monkeypatch
+):
+    setup(tmp_path, monkeypatch)
+    coding_memory.import_events([event()])
+    coding_memory.query_history(repo="heimgewebe/example")
+    target = tmp_path / "agent.ledger.jsonl"
+    original_bytes = target.read_bytes()
+    changed = original_bytes.replace(
+        b"heimgewebe/example", b"heimgewebe/examplf", 1
+    )
+    assert len(changed) == len(original_bytes) and changed != original_bytes
+    checkpoint = tmp_path / coding_memory.HISTORY_VALIDATION_CHECKPOINT_FILENAME
+    checkpoint_before = checkpoint.read_bytes()
+    original_hash = storage.hash_domain_snapshot
+    original_scan = storage.scan_domain_bytes
+    calls = []
+
+    def hash_then_change(domain, *, prefix_offset=None):
+        calls.append("hash")
+        result = original_hash(domain, prefix_offset=prefix_offset)
+        target.write_bytes(changed)
+        return result
+
+    def tracked_scan(domain, start_offset=0):
+        calls.append("scan")
+        yield from original_scan(domain, start_offset=start_offset)
+
+    monkeypatch.setattr(storage, "hash_domain_snapshot", hash_then_change)
+    monkeypatch.setattr(storage, "scan_domain_bytes", tracked_scan)
+    with pytest.raises(
+        storage.StorageRecoveryError,
+        match="history snapshot changed between checkpoint verification and validation",
+    ):
+        coding_memory.query_history(repo="heimgewebe/example")
+
+    assert calls == ["hash", "scan"]
+    assert checkpoint.read_bytes() == checkpoint_before
 
 
 def test_read_domain_snapshot_validates_offset_and_complete_boundary(tmp_path,monkeypatch):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import queue
 import threading
@@ -192,6 +193,52 @@ def test_write_payload_unique_groups_rejects_unrelated_historical_conflict(
         )
 
 
+def test_hash_domain_snapshot_hashes_complete_records_and_exact_prefix(
+    mock_data_dir,
+):
+    first = b"one\n"
+    second = b"two\n"
+    complete = first + second
+    (mock_data_dir / "agent.ledger.jsonl").write_bytes(complete + b"partial")
+
+    complete_bytes, snapshot_sha256, prefix_sha256 = storage.hash_domain_snapshot(
+        "agent.ledger", prefix_offset=len(first)
+    )
+
+    assert complete_bytes == len(complete)
+    assert snapshot_sha256 == hashlib.sha256(complete).hexdigest()
+    assert prefix_sha256 == hashlib.sha256(first).hexdigest()
+
+
+def test_hash_domain_snapshot_rejects_non_boundary_prefix_and_invalid_offset(
+    mock_data_dir,
+):
+    raw = b"one\ntwo\n"
+    (mock_data_dir / "agent.ledger.jsonl").write_bytes(raw)
+
+    complete_bytes, snapshot_sha256, prefix_sha256 = storage.hash_domain_snapshot(
+        "agent.ledger", prefix_offset=2
+    )
+    assert complete_bytes == len(raw)
+    assert snapshot_sha256 == hashlib.sha256(raw).hexdigest()
+    assert prefix_sha256 is None
+
+    with pytest.raises(storage.StorageError, match="non-negative integer"):
+        storage.hash_domain_snapshot("agent.ledger", prefix_offset=-1)
+    with pytest.raises(storage.StorageError, match="non-negative integer"):
+        storage.hash_domain_snapshot("agent.ledger", prefix_offset=True)
+
+
+def test_hash_domain_snapshot_empty_or_missing_domain(mock_data_dir):
+    empty_sha256 = hashlib.sha256(b"").hexdigest()
+    assert storage.hash_domain_snapshot("agent.ledger") == (0, empty_sha256, None)
+    assert storage.hash_domain_snapshot("agent.ledger", prefix_offset=0) == (
+        0,
+        empty_sha256,
+        empty_sha256,
+    )
+
+
 def test_scan_domain_bytes_preserves_raw_record_bytes_and_offsets(mock_data_dir):
     first = b'{"value":"\xff"}\n'
     second = b'{"id":2}\r\n'
@@ -380,6 +427,24 @@ def test_scan_domain_excludes_transient_append_rolled_back_after_fsync_failure(
     )
 
 
+def test_hash_domain_snapshot_excludes_transient_append_rolled_back_after_fsync_failure(
+    mock_data_dir, monkeypatch
+):
+    original = b'{"existing":1}\n'
+    _assert_reader_excludes_rolled_back_append(
+        mock_data_dir,
+        monkeypatch,
+        lambda: storage.hash_domain_snapshot(
+            "agent.ledger", prefix_offset=len(original)
+        ),
+        (
+            len(original),
+            hashlib.sha256(original).hexdigest(),
+            hashlib.sha256(original).hexdigest(),
+        ),
+    )
+
+
 def test_read_domain_snapshot_excludes_transient_append_rolled_back_after_fsync_failure(
     mock_data_dir, monkeypatch
 ):
@@ -391,7 +456,7 @@ def test_read_domain_snapshot_excludes_transient_append_rolled_back_after_fsync_
     )
 
 
-@pytest.mark.parametrize("reader_name", ["scan", "snapshot"])
+@pytest.mark.parametrize("reader_name", ["scan", "snapshot", "hash"])
 def test_committed_reader_lock_timeout_is_storage_busy(
     mock_data_dir, monkeypatch, reader_name
 ):
@@ -405,8 +470,10 @@ def test_committed_reader_lock_timeout_is_storage_busy(
     with pytest.raises(storage.StorageBusyError, match="busy, try again"):
         if reader_name == "scan":
             list(storage.scan_domain("agent.ledger"))
-        else:
+        elif reader_name == "snapshot":
             storage.read_domain_snapshot("agent.ledger")
+        else:
+            storage.hash_domain_snapshot("agent.ledger")
 
 
 def test_write_payload_unique_groups_rejects_cross_group_conflict_before_write(


### PR DESCRIPTION
Bound Chronik history snapshot validation memory by streaming cold scans and using a committed chunk-hash identity pass for checkpoint-backed scans. Real 38,805,084-byte / 46,871-record corpus: Python tracemalloc peak 74.0 MiB -> 0.16 MiB cold and 2.01 MiB steady; no-trace runtime 10.5005s -> 11.0162s cold and 0.3212s -> 0.3960s steady. Snapshot SHA unchanged: f648aab422a6e4829cbf9b4eb7134886a0f9d140aaba984ec041a0653301bf5f. Validation: 86 focused tests, 600 full tests, Ruff, Mypy, role/runtime contracts, HTTP smoke, diff-check all green. Bureau source: candidate-81e72d170280393ac9f6f8dd.