### PR TITLE
perf(outbox): streamline receipt inventory

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -409,6 +409,20 @@ def _steady_checkpoint_path(receipt_dir: Path) -> Path:
     return receipt_dir / GRABOWSKI_STEADY_CHECKPOINT_FILENAME
 
 
+def _inventory_material(path: Path | str, info: os.stat_result) -> bytes:
+    """Encode the existing canonical inventory record without a temporary dict/list."""
+    identity = _file_identity(info)
+    identity_bytes = b",".join(str(value).encode("ascii") for value in identity)
+    absolute_path = str(path.absolute()) if isinstance(path, Path) else os.path.abspath(path)
+    path_bytes = json.dumps(
+        absolute_path,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return b'{"identity":[' + identity_bytes + b'],"path":' + path_bytes + b'}'
+
+
 def _inventory_fingerprint(
     paths: Iterable[Path], *, private: bool
 ) -> dict[str, Any] | None:
@@ -425,15 +439,43 @@ def _inventory_fingerprint(
             info.st_uid != os.geteuid() or info.st_mode & 0o077 or info.st_nlink != 1
         ):
             return None
-        material = canonical_bytes(
-            {
-                "path": str(path.absolute()),
-                "identity": list(_file_identity(info)),
-            }
-        )
+        material = _inventory_material(path, info)
         digest.update(len(material).to_bytes(8, "big", signed=False))
         digest.update(material)
         count += 1
+    return {"count": count, "sha256": digest.hexdigest()}
+
+
+def _directory_inventory_fingerprint(
+    directory: Path, *, suffix: str, private: bool
+) -> dict[str, Any] | None:
+    """Fingerprint one flat file inventory with the same digest contract via scandir."""
+    if not directory.is_dir():
+        return {"count": 0, "sha256": hashlib.sha256().hexdigest()}
+    try:
+        with os.scandir(directory) as iterator:
+            entries = sorted(
+                (entry for entry in iterator if entry.name.endswith(suffix)),
+                key=lambda entry: entry.name,
+            )
+        digest = hashlib.sha256()
+        count = 0
+        for entry in entries:
+            info = entry.stat(follow_symlinks=False)
+            if not stat.S_ISREG(info.st_mode):
+                return None
+            if private and (
+                info.st_uid != os.geteuid()
+                or info.st_mode & 0o077
+                or info.st_nlink != 1
+            ):
+                return None
+            material = _inventory_material(entry.path, info)
+            digest.update(len(material).to_bytes(8, "big", signed=False))
+            digest.update(material)
+            count += 1
+    except OSError:
+        return None
     return {"count": count, "sha256": digest.hexdigest()}
 
 
@@ -536,10 +578,9 @@ def _steady_fast_identity(
     )
     if source_inventory is None:
         return None
-    receipt_paths = (
-        list(receipt_dir.glob("*.receipt.json")) if receipt_dir.is_dir() else []
+    receipt_inventory = _directory_inventory_fingerprint(
+        receipt_dir, suffix=".receipt.json", private=True
     )
-    receipt_inventory = _inventory_fingerprint(receipt_paths, private=True)
     source_index_identity = _private_file_identity(source_index_path)
     delta_index_identity = _private_file_identity(delta_index_path)
     delta_overlay_identity = _private_file_identity(delta_overlay_path)
@@ -566,11 +607,8 @@ def _steady_fast_identity(
         manifests=manifests,
         bundle_files=bundle_files,
     )
-    final_receipt_paths = (
-        list(receipt_dir.glob("*.receipt.json")) if receipt_dir.is_dir() else []
-    )
-    final_receipt_inventory = _inventory_fingerprint(
-        final_receipt_paths, private=True
+    final_receipt_inventory = _directory_inventory_fingerprint(
+        receipt_dir, suffix=".receipt.json", private=True
     )
     if (
         final_source_inventory != source_inventory
@@ -3315,12 +3353,9 @@ def import_grabowski_outbox(
                 manifests=manifests,
                 bundle_files=bundle_files,
             )
-            receipt_paths = (
-                list(receipt_dir.glob("*.receipt.json"))
-                if receipt_dir.is_dir()
-                else []
+            receipt_inventory = _directory_inventory_fingerprint(
+                receipt_dir, suffix=".receipt.json", private=True
             )
-            receipt_inventory = _inventory_fingerprint(receipt_paths, private=True)
             source_index_identity = _private_file_identity(source_index_path)
             delta_index_identity = _private_file_identity(delta_index_path)
             delta_overlay_identity = _private_file_identity(delta_overlay_path)

--- a/coding_memory.py
+++ b/coding_memory.py
@@ -413,7 +413,11 @@ def _inventory_material(path: Path | str, info: os.stat_result) -> bytes:
     """Encode the existing canonical inventory record without a temporary dict/list."""
     identity = _file_identity(info)
     identity_bytes = b",".join(str(value).encode("ascii") for value in identity)
-    absolute_path = str(path.absolute()) if isinstance(path, Path) else os.path.abspath(path)
+    absolute_path = (
+        str(path.absolute())
+        if isinstance(path, Path)
+        else path if os.path.isabs(path) else os.path.join(os.getcwd(), path)
+    )
     path_bytes = json.dumps(
         absolute_path,
         ensure_ascii=False,

--- a/tests/test_grabowski_outbox_import.py
+++ b/tests/test_grabowski_outbox_import.py
@@ -84,6 +84,23 @@ def test_directory_inventory_fingerprint_preserves_existing_digest_contract(tmp_
     assert directory["count"] == 2
 
 
+def test_directory_inventory_fingerprint_preserves_dotdot_path_spelling(tmp_path):
+    receipts = tmp_path / "receipts"
+    receipts.mkdir()
+    alias = tmp_path / "alias"
+    alias.mkdir()
+    receipt = receipts / "stable.receipt.json"
+    receipt.write_text("{}", encoding="utf-8")
+    receipt.chmod(0o600)
+    aliased_receipts = alias / ".." / "receipts"
+    legacy_paths = list(aliased_receipts.glob("*.receipt.json"))
+
+    assert ".." in str(legacy_paths[0])
+    assert coding_memory._directory_inventory_fingerprint(
+        aliased_receipts, suffix=".receipt.json", private=True
+    ) == coding_memory._inventory_fingerprint(legacy_paths, private=True)
+
+
 def test_directory_inventory_fingerprint_keeps_private_file_guard(tmp_path):
     receipts = tmp_path / "receipts"
     receipts.mkdir()

--- a/tests/test_grabowski_outbox_import.py
+++ b/tests/test_grabowski_outbox_import.py
@@ -53,6 +53,52 @@ def configure(tmp_path: Path, monkeypatch) -> tuple[Path, Path, Path]:
     return data, receipts, outbox
 
 
+def test_directory_inventory_fingerprint_preserves_existing_digest_contract(tmp_path):
+    receipts = tmp_path / "receipts"
+    receipts.mkdir()
+    paths = [
+        receipts / "a.receipt.json",
+        receipts / 'z-ä-"\\.receipt.json',
+    ]
+    for index, path in enumerate(paths):
+        path.write_text(json.dumps({"index": index}), encoding="utf-8")
+        path.chmod(0o600)
+    (receipts / "ignored.txt").write_text("ignored", encoding="utf-8")
+
+    for path in paths:
+        info = path.lstat()
+        assert coding_memory._inventory_material(path, info) == coding_memory.canonical_bytes(
+            {
+                "path": str(path.absolute()),
+                "identity": list(coding_memory._file_identity(info)),
+            }
+        )
+
+    legacy = coding_memory._inventory_fingerprint(paths, private=True)
+    directory = coding_memory._directory_inventory_fingerprint(
+        receipts, suffix=".receipt.json", private=True
+    )
+
+    assert directory == legacy
+    assert directory is not None
+    assert directory["count"] == 2
+
+
+def test_directory_inventory_fingerprint_keeps_private_file_guard(tmp_path):
+    receipts = tmp_path / "receipts"
+    receipts.mkdir()
+    unsafe = receipts / "unsafe.receipt.json"
+    unsafe.write_text("{}", encoding="utf-8")
+    unsafe.chmod(0o644)
+
+    assert (
+        coding_memory._directory_inventory_fingerprint(
+            receipts, suffix=".receipt.json", private=True
+        )
+        is None
+    )
+
+
 def test_batch_import_is_idempotent_and_receipt_bound(tmp_path, monkeypatch):
     data, receipts, outbox = configure(tmp_path, monkeypatch)
     source = write_outbox(outbox, [event("agent.run.started", "a"), event("agent.run.completed", "b")])


### PR DESCRIPTION
## Summary
- preserve the existing receipt-inventory digest contract while avoiding per-entry Path/dict/list materialization
- enumerate flat receipt directories with os.scandir and DirEntry.stat without weakening private-file checks
- keep both steady-fast-path receipt drift readbacks intact

## Real-state benchmark
On the current 30,683-receipt inventory, identical digest/count:
- baseline median: 0.325313 s
- patched median: 0.285340 s
- improvement: about 12.3% per full receipt inventory

The no-change fast path performs this inventory twice, so this removes roughly 80 ms of recurring metadata overhead at the observed scale.

## Validation
- exact digest compatibility regression, including unusual UTF-8/escaped file names
- private receipt permission guard regression
- outbox/import/compaction/benchmark tests: 90 passed
- full pytest: 602 passed
- canonical validate-local: role/runtime contracts, Ruff, Mypy, 602 tests, HTTP smoke all green

Runtime note: the host currently has 6,225 loose outbox files and no installed chronik-outbox-compact.timer. This PR does not mutate runtime activation; that remains a separate deployment contract.