### PR TITLE
fix(storage): keep committed reads read-only

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import errno
+import fcntl
 import hashlib
 import json
 import logging
 import os
 import re
 import stat
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import BinaryIO, Final, Iterable, Iterator, NoReturn, Tuple
@@ -266,34 +268,112 @@ def _safe_open_read(target_path: Path) -> Iterator:
 
 
 @contextmanager
+def _fd_lock(
+    fd: int, target_path: Path, *, exclusive: bool
+) -> Iterator[None]:
+    """Acquire one bounded advisory lock on the already-open target descriptor.
+
+    Readers use a shared lock and therefore need no writable sidecar. Writers
+    retain the existing FileLock for cross-process writer serialization and add
+    an exclusive target-fd lock so committed readers share the same boundary.
+    """
+    operation = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+    deadline = time.monotonic() + LOCK_TIMEOUT
+    while True:
+        try:
+            fcntl.flock(fd, operation | fcntl.LOCK_NB)
+            break
+        except BlockingIOError as exc:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.warning("busy (fd lock timeout)", extra={"file": str(target_path)})
+                raise StorageBusyError("busy, try again") from exc
+            time.sleep(min(0.05, remaining))
+        except OSError as exc:
+            if exc.errno in {errno.EACCES, errno.EAGAIN}:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning("busy (fd lock timeout)", extra={"file": str(target_path)})
+                    raise StorageBusyError("busy, try again") from exc
+                time.sleep(min(0.05, remaining))
+                continue
+            raise StorageError("file lock error") from exc
+    try:
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError as exc:
+            raise StorageRecoveryError("file unlock failed") from exc
+
+
+@contextmanager
+def _readonly_sidecar_lock(target_path: Path) -> Iterator[None]:
+    """Honor an existing legacy FileLock without creating or writing it."""
+    lock_path = get_lock_path(target_path)
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise StorageError("platform lacks O_NOFOLLOW")
+    flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(lock_path, flags)
+    except FileNotFoundError:
+        yield
+        return
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise StorageError("invalid lock target (symlink)") from exc
+        raise StorageError("lock identity unavailable") from exc
+    try:
+        try:
+            opened = os.fstat(fd)
+        except OSError as exc:
+            raise StorageRecoveryError("lock identity unavailable") from exc
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_uid != os.geteuid()
+            or opened.st_nlink < 1
+        ):
+            raise StorageRecoveryError("lock identity is not private and regular")
+        with _fd_lock(fd, target_path, exclusive=False):
+            yield
+    finally:
+        os.close(fd)
+
+
+@contextmanager
 def _locked_open(target_path: Path, mode: str) -> Iterator:
-    """Context manager to securely open a file with locking.
-    Handles FileLock, O_NOFOLLOW, O_CLOEXEC, and error mapping.
+    """Securely open a file with read-only-safe advisory locking.
+
+    Write modes retain the historical sidecar FileLock and additionally take an
+    exclusive lock on the target fd. Read modes never create or write a sidecar;
+    they take only a shared lock on the already-open target fd.
     """
     fname = target_path.name
-    # Extra validation
     if target_path.parent != DATA_DIR:
         raise StorageError("invalid target path: wrong parent directory")
 
     lock_path = get_lock_path(target_path)
-
-    # Determine open flags and Python mode
     if mode == "r":
         flags = os.O_RDONLY
         py_mode = "r"
         encoding = "utf-8"
+        write_mode = False
     elif mode == "rb":
         flags = os.O_RDONLY
         py_mode = "rb"
         encoding = None
+        write_mode = False
     elif mode == "a":
         flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
         py_mode = "ab"
         encoding = None
+        write_mode = True
     elif mode == "a+":
         flags = os.O_RDWR | os.O_CREAT | os.O_APPEND
         py_mode = "a+b"
         encoding = None
+        write_mode = True
     else:
         raise ValueError(f"unsupported mode: {mode}")
 
@@ -302,37 +382,37 @@ def _locked_open(target_path: Path, mode: str) -> Iterator:
         raise StorageError("platform lacks O_NOFOLLOW")
     flags |= os.O_NOFOLLOW
 
+    def opened_file() -> Iterator:
+        dirfd = os.open(str(DATA_DIR), os.O_RDONLY)
+        try:
+            fd = os.open(fname, flags, 0o600, dir_fd=dirfd)
+            try:
+                fh = os.fdopen(fd, py_mode, encoding=encoding)
+            except OSError:
+                os.close(fd)
+                raise
+            with fh:
+                with _fd_lock(fh.fileno(), target_path, exclusive=write_mode):
+                    yield fh
+        except OSError as exc:
+            if exc.errno == errno.ENOSPC:
+                logger.error("disk full", extra={"file": str(target_path)})
+                raise StorageFullError("insufficient storage") from exc
+            if exc.errno == errno.ELOOP:
+                logger.warning("symlink attempt rejected", extra={"file": str(target_path)})
+                raise StorageError("invalid target (symlink)") from exc
+            raise
+        finally:
+            os.close(dirfd)
+
+    if not write_mode:
+        with _readonly_sidecar_lock(target_path):
+            yield from opened_file()
+        return
+
     try:
         with FileLock(str(lock_path), timeout=LOCK_TIMEOUT):
-            # Defense-in-depth: always use trusted DATA_DIR for dirfd
-            dirfd = os.open(str(DATA_DIR), os.O_RDONLY)
-            try:
-                fd = os.open(
-                    fname,
-                    flags,
-                    0o600,
-                    dir_fd=dirfd,
-                )
-                try:
-                    fh = os.fdopen(fd, py_mode, encoding=encoding)
-                except OSError:
-                    os.close(fd)
-                    raise
-                with fh:
-                    yield fh
-            except OSError as exc:
-                if exc.errno == errno.ENOSPC:
-                    logger.error("disk full", extra={"file": str(target_path)})
-                    raise StorageFullError("insufficient storage") from exc
-                if exc.errno == errno.ELOOP:
-                    logger.warning(
-                        "symlink attempt rejected",
-                        extra={"file": str(target_path)},
-                    )
-                    raise StorageError("invalid target (symlink)") from exc
-                raise
-            finally:
-                os.close(dirfd)
+            yield from opened_file()
     except Timeout as exc:
         logger.warning("busy (lock timeout)", extra={"file": str(target_path)})
         raise StorageBusyError("busy, try again") from exc
@@ -358,16 +438,12 @@ def _target_stat_for_fd(target_path: Path, fd: int) -> os.stat_result:
 def _open_committed_read(
     target_path: Path,
 ) -> Iterator[Tuple[BinaryIO, int]]:
-    """Capture a verified size under the domain lock, then release it for reads."""
-    with _safe_open_read(target_path) as fh:
-        lock_path = get_lock_path(target_path)
-        try:
-            with FileLock(str(lock_path), timeout=LOCK_TIMEOUT):
+    """Capture a verified committed size without requiring directory writes."""
+    with _readonly_sidecar_lock(target_path):
+        with _safe_open_read(target_path) as fh:
+            with _fd_lock(fh.fileno(), target_path, exclusive=False):
                 committed_size = _target_stat_for_fd(target_path, fh.fileno()).st_size
-        except Timeout as exc:
-            logger.warning("busy (lock timeout)", extra={"file": str(target_path)})
-            raise StorageBusyError("busy, try again") from exc
-        yield fh, committed_size
+            yield fh, committed_size
 
 
 def _fsync_file(fd: int) -> None:

--- a/storage.py
+++ b/storage.py
@@ -439,11 +439,11 @@ def _open_committed_read(
     target_path: Path,
 ) -> Iterator[Tuple[BinaryIO, int]]:
     """Capture a verified committed size without requiring directory writes."""
-    with _readonly_sidecar_lock(target_path):
-        with _safe_open_read(target_path) as fh:
+    with _safe_open_read(target_path) as fh:
+        with _readonly_sidecar_lock(target_path):
             with _fd_lock(fh.fileno(), target_path, exclusive=False):
                 committed_size = _target_stat_for_fd(target_path, fh.fileno()).st_size
-            yield fh, committed_size
+        yield fh, committed_size
 
 
 def _fsync_file(fd: int) -> None:

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -38,6 +38,24 @@ def test_query_compares_since_offset_in_utc(tmp_path,monkeypatch):
     assert result["event_ids"] == ["sha256:"+"b"*64, "sha256:"+"a"*64]
 
 
+def test_query_history_works_when_data_directory_is_read_only(tmp_path, monkeypatch):
+    setup(tmp_path, monkeypatch)
+    coding_memory.import_events([event()])
+    target = tmp_path / "agent.ledger.jsonl"
+    lock_path = storage.get_lock_path(target)
+    if lock_path.exists():
+        lock_path.unlink()
+    original_mode = tmp_path.stat().st_mode & 0o777
+    tmp_path.chmod(0o500)
+    try:
+        result = coding_memory.query_history(repo="heimgewebe/example")
+    finally:
+        tmp_path.chmod(original_mode)
+    assert result["event_ids"] == ["sha256:" + "a" * 64]
+    assert result["ledger_snapshot"]["integrity_valid"] is True
+    assert not lock_path.exists()
+
+
 def test_query_filters_and_marks_history_only(tmp_path,monkeypatch):
     setup(tmp_path,monkeypatch); coding_memory.import_events([event(),event("sha256:"+"b"*64,repo="heimgewebe/other")])
     result=coding_memory.query_history(repo="heimgewebe/example",component="grabowski",operation="implement",outcome="completed")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,11 +1,13 @@
+import fcntl
 import hashlib
 import json
+import os
 import queue
 import threading
+from contextlib import contextmanager
 
 import pytest
 import storage
-from filelock import FileLock, Timeout
 
 @pytest.fixture
 def mock_data_dir(tmp_path, monkeypatch):
@@ -250,6 +252,31 @@ def test_scan_domain_bytes_preserves_raw_record_bytes_and_offsets(mock_data_dir)
     ]
 
 
+def test_committed_readers_need_no_writable_sidecar(mock_data_dir):
+    raw = b'{"id":1}\n{"id":2}\n'
+    target = mock_data_dir / "agent.ledger.jsonl"
+    target.write_bytes(raw)
+    lock_path = storage.get_lock_path(target)
+    assert not lock_path.exists()
+
+    original_mode = mock_data_dir.stat().st_mode & 0o777
+    os.chmod(mock_data_dir, 0o500)
+    try:
+        assert list(storage.scan_domain_bytes("agent.ledger")) == [
+            (0, len(b'{"id":1}\n'), b'{"id":1}'),
+            (len(b'{"id":1}\n'), len(raw), b'{"id":2}'),
+        ]
+        assert storage.read_domain_snapshot("agent.ledger") == raw
+        assert storage.hash_domain_snapshot("agent.ledger")[:2] == (
+            len(raw),
+            hashlib.sha256(raw).hexdigest(),
+        )
+    finally:
+        os.chmod(mock_data_dir, original_mode)
+
+    assert not lock_path.exists()
+
+
 def test_scan_domain_decodes_raw_records_with_existing_replacement_semantics(
     mock_data_dir,
 ):
@@ -355,22 +382,14 @@ def _assert_reader_excludes_rolled_back_append(
             raise OSError(5, "simulated durability failure")
         return real_fsync(fd)
 
-    class ObservedReaderLock:
-        def __init__(self, lock):
-            self.lock = lock
+    real_fd_lock = storage._fd_lock
 
-        def __enter__(self):
-            progress.put("lock-attempt")
-            return self.lock.__enter__()
-
-        def __exit__(self, *args):
-            return self.lock.__exit__(*args)
-
-    def observed_file_lock(*args, **kwargs):
-        lock = FileLock(*args, **kwargs)
+    @contextmanager
+    def observed_fd_lock(fd, target_path, *, exclusive):
         if threading.current_thread().name == reader_thread_name:
-            return ObservedReaderLock(lock)
-        return lock
+            progress.put("lock-attempt")
+        with real_fd_lock(fd, target_path, exclusive=exclusive):
+            yield
 
     def write_transient_record():
         try:
@@ -388,7 +407,7 @@ def _assert_reader_excludes_rolled_back_append(
         progress.put("read-complete")
 
     monkeypatch.setattr(storage.os, "fsync", fail_commit_fsync)
-    monkeypatch.setattr(storage, "FileLock", observed_file_lock)
+    monkeypatch.setattr(storage, "_fd_lock", observed_fd_lock)
 
     writer_thread = threading.Thread(target=write_transient_record)
     writer_thread.start()
@@ -460,20 +479,23 @@ def test_read_domain_snapshot_excludes_transient_append_rolled_back_after_fsync_
 def test_committed_reader_lock_timeout_is_storage_busy(
     mock_data_dir, monkeypatch, reader_name
 ):
-    (mock_data_dir / "agent.ledger.jsonl").write_bytes(b'{"existing":1}\n')
+    target = mock_data_dir / "agent.ledger.jsonl"
+    target.write_bytes(b'{"existing":1}\n')
+    holder = os.open(target, os.O_RDWR | os.O_CLOEXEC)
+    fcntl.flock(holder, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    monkeypatch.setattr(storage, "LOCK_TIMEOUT", 0)
 
-    def timeout_file_lock(*args, **kwargs):
-        raise Timeout("agent.ledger.jsonl.lock")
-
-    monkeypatch.setattr(storage, "FileLock", timeout_file_lock)
-
-    with pytest.raises(storage.StorageBusyError, match="busy, try again"):
-        if reader_name == "scan":
-            list(storage.scan_domain("agent.ledger"))
-        elif reader_name == "snapshot":
-            storage.read_domain_snapshot("agent.ledger")
-        else:
-            storage.hash_domain_snapshot("agent.ledger")
+    try:
+        with pytest.raises(storage.StorageBusyError, match="busy, try again"):
+            if reader_name == "scan":
+                list(storage.scan_domain("agent.ledger"))
+            elif reader_name == "snapshot":
+                storage.read_domain_snapshot("agent.ledger")
+            else:
+                storage.hash_domain_snapshot("agent.ledger")
+    finally:
+        fcntl.flock(holder, fcntl.LOCK_UN)
+        os.close(holder)
 
 
 def test_write_payload_unique_groups_rejects_cross_group_conflict_before_write(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -446,6 +446,43 @@ def test_scan_domain_excludes_transient_append_rolled_back_after_fsync_failure(
     )
 
 
+def test_committed_stream_releases_locks_before_yielding_records(
+    mock_data_dir, monkeypatch
+):
+    first = b'{"id":1}\n'
+    second = b'{"id":2}\n'
+    target = mock_data_dir / "agent.ledger.jsonl"
+    target.write_bytes(first + second)
+    monkeypatch.setattr(storage, "LOCK_TIMEOUT", 0.2)
+
+    stream = storage.scan_domain_bytes("agent.ledger")
+    assert next(stream) == (0, len(first), first[:-1])
+
+    outcome = queue.Queue()
+
+    def append_after_reader_yield():
+        try:
+            storage.write_payload("agent.ledger", ['{"id":3}'])
+        except BaseException as exc:
+            outcome.put(exc)
+        else:
+            outcome.put(None)
+
+    writer = threading.Thread(target=append_after_reader_yield)
+    writer.start()
+    writer.join(timeout=1)
+    try:
+        assert not writer.is_alive()
+        assert outcome.get_nowait() is None
+        assert list(stream) == [(len(first), len(first) + len(second), second[:-1])]
+    finally:
+        stream.close()
+        if writer.is_alive():
+            writer.join(timeout=1)
+
+    assert target.read_bytes() == first + second + b'{"id":3}\n'
+
+
 def test_hash_domain_snapshot_excludes_transient_append_rolled_back_after_fsync_failure(
     mock_data_dir, monkeypatch
 ):


### PR DESCRIPTION
## Problem
Deploying current main (`7f55fe3`) exposed a production-only read-path regression: `grabowski_chronik_history` runs with the Chronik data directory read-only, but the committed-read path introduced in the recent storage hardening used `filelock.FileLock`, which opens/creates `agent.ledger.jsonl.lock` writable. The exact live query failed with `OSError: [Errno 30] Read-only file system` / `chronik-coding-memory: read error`, while the prior runtime `6ef1330` succeeded.

## Fix
- readers use shared advisory `flock` on the already-open ledger fd and therefore require no directory write;
- writers retain the legacy sidecar `FileLock` for writer serialization and additionally hold an exclusive ledger-fd lock;
- readers honor an already-existing legacy sidecar read-only, preserving the existing `/v1/tail` contention/429 contract, but never create or mutate that sidecar;
- sidecar + target locks are held only while capturing the committed size, then released before any potentially consumer-paced streaming read.

## Review follow-up
Codex correctly found that the first PR head kept the read-only sidecar lock across the streaming `yield`, which could block ingestion. Head `7eb0847` scopes both locks to committed-size capture and adds an explicit paused-reader regression proving that a writer can append while the bounded snapshot stream remains open.

## Verification
- canonical `make validate-local`: **606 passed**, role/runtime contract, Ruff, Mypy, HTTP smoke all green;
- focused storage/history/tail block: **90 passed**;
- real Grabowski runtime Python + real production ledger + read-only operator sandbox succeeds with the patched worktree: **47,705/47,705 valid records**, no diagnostics;
- transient append/fsync rollback, real kernel lock contention, read-only data-directory behavior, snapshot/hash semantics, legacy tail contention, and early lock release before streaming are covered.

The attempted runtime cutover was rolled back before timers were resumed. Production remains on `6ef133082a8d23fe757ec8d3bac2e91f25f1332d` until this fix is merged and a new exact release passes post-cutover history verification.