### PR TITLE
perf(outbox): fold compaction into delta import

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -1551,6 +1551,8 @@ def _source_index_source_record(prepared: dict[str, Any], *, loose: bool) -> dic
 def _source_index_bundle_record(
     prepared_sources: list[dict[str, Any]], metadata: dict[str, Any]
 ) -> dict[str, Any]:
+    manifest_path = str(Path(metadata["manifest_path"]).resolve())
+    bundle_path = str(Path(metadata["bundle_path"]).resolve())
     public_metadata = {
         key: metadata[key]
         for key in (
@@ -1564,10 +1566,12 @@ def _source_index_bundle_record(
             "sources",
         )
     }
+    public_metadata["manifest_path"] = manifest_path
+    public_metadata["bundle_path"] = bundle_path
     return {
-        "manifest_path": str(Path(metadata["manifest_path"]).resolve()),
+        "manifest_path": manifest_path,
         "manifest_identity": metadata["manifest_identity"],
-        "bundle_path": str(Path(metadata["bundle_path"]).resolve()),
+        "bundle_path": bundle_path,
         "bundle_identity": metadata["bundle_identity"],
         "metadata": public_metadata,
         "sources": [

--- a/coding_memory.py
+++ b/coding_memory.py
@@ -1565,9 +1565,9 @@ def _source_index_bundle_record(
         )
     }
     return {
-        "manifest_path": metadata["manifest_path"],
+        "manifest_path": str(Path(metadata["manifest_path"]).resolve()),
         "manifest_identity": metadata["manifest_identity"],
-        "bundle_path": metadata["bundle_path"],
+        "bundle_path": str(Path(metadata["bundle_path"]).resolve()),
         "bundle_identity": metadata["bundle_identity"],
         "metadata": public_metadata,
         "sources": [
@@ -1653,9 +1653,9 @@ def _delta_bundle_record_from_metadata(metadata: dict[str, Any]) -> dict[str, An
     if source_paths != sorted(set(source_paths)):
         raise ValueError("bundle metadata source paths are not unique")
     return {
-        "manifest_path": metadata["manifest_path"],
+        "manifest_path": str(Path(metadata["manifest_path"]).resolve()),
         "manifest_identity": metadata["manifest_identity"],
-        "bundle_path": metadata["bundle_path"],
+        "bundle_path": str(Path(metadata["bundle_path"]).resolve()),
         "bundle_identity": metadata["bundle_identity"],
         "source_paths": source_paths,
         "source_count": len(source_paths),

--- a/coding_memory.py
+++ b/coding_memory.py
@@ -3428,25 +3428,30 @@ def import_grabowski_outbox(
             and delta_overlay is not None
             and delta_overlay_mode == "steady"
         ):
-            compaction_delta_result = _try_checkpoint_compaction_delta_import(
-                checkpoint=prior_steady_checkpoint,
-                current_identity=delta_candidate_identity,
-                delta_index=delta_index,
-                delta_overlay=delta_overlay,
-                source_dir=source_dir,
-                bundle_dir=bundle_dir,
-                sources=sources,
-                manifests=manifests,
-                bundle_files=bundle_files,
-                receipt_dir=receipt_dir,
-                source_index_path=source_index_path,
-                delta_index_path=delta_index_path,
-                delta_overlay_path=delta_overlay_path,
-                import_started_ns=import_started_ns,
-                phase_ns=phase_ns,
-                counters=counters,
-                measured_phase=measured_phase,
-            )
+            compaction_delta_result = None
+            try:
+                with _grabowski_reader_compaction_lock(source_dir):
+                    compaction_delta_result = _try_checkpoint_compaction_delta_import(
+                        checkpoint=prior_steady_checkpoint,
+                        current_identity=delta_candidate_identity,
+                        delta_index=delta_index,
+                        delta_overlay=delta_overlay,
+                        source_dir=source_dir,
+                        bundle_dir=bundle_dir,
+                        sources=sources,
+                        manifests=manifests,
+                        bundle_files=bundle_files,
+                        receipt_dir=receipt_dir,
+                        source_index_path=source_index_path,
+                        delta_index_path=delta_index_path,
+                        delta_overlay_path=delta_overlay_path,
+                        import_started_ns=import_started_ns,
+                        phase_ns=phase_ns,
+                        counters=counters,
+                        measured_phase=measured_phase,
+                    )
+            except (OSError, ValueError):
+                counters["compaction_delta_lock_fallbacks"] += 1
             if compaction_delta_result is not None:
                 return compaction_delta_result
             delta_result = _try_checkpoint_delta_import(
@@ -3911,6 +3916,34 @@ def import_grabowski_outbox(
         "delta_fast_path": False,
     }
 
+
+
+@contextmanager
+def _grabowski_reader_compaction_lock(source_dir: Path):
+    """Share the compactor lock without requiring write access to the outbox."""
+    lock_path = source_dir / GRABOWSKI_WRITER_COMPACTION_LOCK_FILENAME
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(lock_path, flags)
+    try:
+        file_stat = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(file_stat.st_mode)
+            or file_stat.st_uid != os.geteuid()
+            or file_stat.st_nlink != 1
+            or file_stat.st_mode & 0o077
+        ):
+            raise ValueError(
+                "Grabowski writer-compaction lock must be a private owned file"
+            )
+        fcntl.flock(descriptor, fcntl.LOCK_SH)
+        yield lock_path
+    finally:
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
 
 
 @contextmanager

--- a/coding_memory.py
+++ b/coding_memory.py
@@ -450,12 +450,12 @@ def _inventory_fingerprint(
     return {"count": count, "sha256": digest.hexdigest()}
 
 
-def _directory_inventory_fingerprint(
+def _directory_inventory_snapshot(
     directory: Path, *, suffix: str, private: bool
-) -> dict[str, Any] | None:
-    """Fingerprint one flat file inventory with the same digest contract via scandir."""
+) -> tuple[dict[str, Any], dict[str, tuple[int, ...]]] | None:
+    """Fingerprint one flat inventory and retain exact file identities."""
     if not directory.is_dir():
-        return {"count": 0, "sha256": hashlib.sha256().hexdigest()}
+        return ({"count": 0, "sha256": hashlib.sha256().hexdigest()}, {})
     try:
         with os.scandir(directory) as iterator:
             entries = sorted(
@@ -463,6 +463,7 @@ def _directory_inventory_fingerprint(
                 key=lambda entry: entry.name,
             )
         digest = hashlib.sha256()
+        identities: dict[str, tuple[int, ...]] = {}
         count = 0
         for entry in entries:
             info = entry.stat(follow_symlinks=False)
@@ -477,10 +478,67 @@ def _directory_inventory_fingerprint(
             material = _inventory_material(entry.path, info)
             digest.update(len(material).to_bytes(8, "big", signed=False))
             digest.update(material)
+            identities[os.path.abspath(entry.path)] = _file_identity(info)
             count += 1
     except OSError:
         return None
-    return {"count": count, "sha256": digest.hexdigest()}
+    return {"count": count, "sha256": digest.hexdigest()}, identities
+
+
+def _directory_inventory_fingerprint(
+    directory: Path, *, suffix: str, private: bool
+) -> dict[str, Any] | None:
+    """Fingerprint one flat file inventory with the same digest contract via scandir."""
+    snapshot = _directory_inventory_snapshot(
+        directory, suffix=suffix, private=private
+    )
+    return snapshot[0] if snapshot is not None else None
+
+
+def _attest_delta_receipt_inventory(
+    receipt_dir: Path,
+    *,
+    before: dict[str, tuple[int, ...]],
+    prepared_sources: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Bind a delta receipt update while rejecting unrelated receipt drift."""
+    snapshot = _directory_inventory_snapshot(
+        receipt_dir, suffix=".receipt.json", private=True
+    )
+    if snapshot is None:
+        return None
+    fingerprint, after = snapshot
+    intended = {
+        os.path.abspath(str(item["receipt_path"])) for item in prepared_sources
+    }
+    if any(
+        before.get(path) != identity
+        for path, identity in after.items()
+        if path not in intended
+    ) or any(
+        after.get(path) != identity
+        for path, identity in before.items()
+        if path not in intended
+    ):
+        return None
+    for prepared in prepared_sources:
+        receipt_path = Path(prepared["receipt_path"])
+        try:
+            receipt = _load_receipt(receipt_path)
+        except ValueError:
+            return None
+        if not _receipt_matches_prepared_source(prepared, receipt):
+            return None
+        expected_identity = after.get(os.path.abspath(str(receipt_path)))
+        current_identity = _private_file_identity(receipt_path)
+        if (
+            expected_identity is None
+            or current_identity is None
+            or tuple(current_identity[field] for field in _FILE_IDENTITY_FIELDS)
+            != expected_identity
+        ):
+            return None
+    return fingerprint
 
 
 def _directory_identity(path: Path) -> dict[str, int] | None:
@@ -1587,6 +1645,388 @@ def _checkpoint_allows_source_only_delta(
     )
 
 
+def _delta_bundle_record_from_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    sources = metadata.get("sources")
+    if not isinstance(sources, list) or not sources:
+        raise ValueError("bundle metadata has no sources")
+    source_paths = sorted(str(item["source_path"]) for item in sources)
+    if source_paths != sorted(set(source_paths)):
+        raise ValueError("bundle metadata source paths are not unique")
+    return {
+        "manifest_path": metadata["manifest_path"],
+        "manifest_identity": metadata["manifest_identity"],
+        "bundle_path": metadata["bundle_path"],
+        "bundle_identity": metadata["bundle_identity"],
+        "source_paths": source_paths,
+        "source_count": len(source_paths),
+        "event_count": sum(len(item["event_ids"]) for item in sources),
+    }
+
+
+def _try_checkpoint_compaction_delta_import(
+    *,
+    checkpoint: dict[str, Any],
+    current_identity: dict[str, Any],
+    delta_index: dict[str, Any],
+    delta_overlay: dict[str, Any],
+    source_dir: Path,
+    bundle_dir: Path,
+    sources: list[Path],
+    manifests: list[Path],
+    bundle_files: list[Path],
+    receipt_dir: Path,
+    source_index_path: Path,
+    delta_index_path: Path,
+    delta_overlay_path: Path,
+    import_started_ns: int,
+    phase_ns: Counter[str],
+    counters: Counter[str],
+    measured_phase: Any,
+) -> dict[str, Any] | None:
+    """Fold an exact loose-to-bundle relocation without touching the ledger.
+
+    This path admits only a pure compaction transition: every disappeared loose
+    source must reappear byte-for-byte in newly added, fully validated bundle
+    manifests; all surviving loose sources and all pre-existing bundles must be
+    unchanged; no new or changed loose source may be present. Any ambiguity
+    returns ``None`` so the canonical full reconciliation remains authoritative.
+    """
+    if not _checkpoint_allows_source_only_delta(checkpoint, current_identity):
+        return None
+    summary = checkpoint.get("summary")
+    prior_identity = checkpoint.get("identity")
+    if not isinstance(summary, dict) or not isinstance(prior_identity, dict):
+        return None
+
+    raw_loose = delta_index.get("loose_sources")
+    raw_bundles = delta_index.get("bundles")
+    cached_loose_items = delta_index.get("_loose_sources")
+    cached_bundle_items = delta_index.get("_bundles")
+    raw_overlay_records = delta_overlay.get("records")
+    cached_overlay_records = delta_overlay.get("_records")
+    if not all(
+        isinstance(value, list)
+        for value in (
+            raw_loose,
+            raw_bundles,
+            cached_loose_items,
+            cached_bundle_items,
+            raw_overlay_records,
+            cached_overlay_records,
+        )
+    ):
+        return None
+
+    raw_loose_by_path = {item["source_path"]: item for item in raw_loose}
+    raw_loose_by_path.update(
+        {item["source_path"]: item for item in raw_overlay_records}
+    )
+    cached_loose = {item["source_path"]: item for item in cached_loose_items}
+    cached_loose.update(
+        {item["source_path"]: item for item in cached_overlay_records}
+    )
+    if set(raw_loose_by_path) != set(cached_loose):
+        return None
+
+    cached_bundles = {item["manifest_path"]: item for item in cached_bundle_items}
+    raw_bundles_by_manifest = {item["manifest_path"]: item for item in raw_bundles}
+    current_loose = {str(path.resolve()): path for path in sources}
+    current_manifests = {str(path.resolve()): path for path in manifests}
+    current_bundle_files = {str(path.resolve()): path for path in bundle_files}
+    if (
+        len(current_loose) != len(sources)
+        or len(current_manifests) != len(manifests)
+        or len(current_bundle_files) != len(bundle_files)
+        or set(cached_bundles) != set(raw_bundles_by_manifest)
+        or not set(current_loose).issubset(cached_loose)
+        or not set(cached_bundles).issubset(current_manifests)
+    ):
+        return None
+
+    removed_loose = set(cached_loose) - set(current_loose)
+    new_manifest_paths = set(current_manifests) - set(cached_bundles)
+    if not removed_loose or not new_manifest_paths:
+        return None
+
+    with measured_phase("compaction_delta_validation"):
+        for resolved, source in current_loose.items():
+            counters["source_artifacts_metadata_checked"] += 1
+            if not _file_matches_source_index(source, cached_loose[resolved]["_identity"]):
+                return None
+
+        existing_bundle_paths: set[str] = set()
+        all_bundle_source_paths: set[str] = set()
+        for item in cached_bundle_items:
+            manifest_path = current_manifests[item["manifest_path"]]
+            bundle_path = current_bundle_files.get(item["bundle_path"])
+            counters["source_artifacts_metadata_checked"] += 2
+            if bundle_path is None or not (
+                _file_matches_source_index(manifest_path, item["_manifest_identity"])
+                and _file_matches_source_index(bundle_path, item["_bundle_identity"])
+            ):
+                return None
+            existing_bundle_paths.add(item["bundle_path"])
+            all_bundle_source_paths.update(item["source_paths"])
+
+        relocated: dict[str, dict[str, Any]] = {}
+        new_bundle_records: list[dict[str, Any]] = []
+        new_bundle_paths: set[str] = set()
+        relocated_event_count = 0
+        for manifest_resolved in sorted(new_manifest_paths):
+            manifest_path = current_manifests[manifest_resolved]
+            try:
+                _, metadata = _load_grabowski_bundle(
+                    manifest_path,
+                    source_dir=source_dir,
+                    receipt_dir=receipt_dir,
+                )
+                bundle_record = _delta_bundle_record_from_metadata(metadata)
+            except (OSError, ValueError, storage.StorageError):
+                return None
+            bundle_path = str(Path(metadata["bundle_path"]).resolve())
+            if bundle_path not in current_bundle_files or bundle_path in new_bundle_paths:
+                return None
+            new_bundle_paths.add(bundle_path)
+            new_bundle_records.append(bundle_record)
+            counters["source_artifacts_metadata_checked"] += 2
+            counters["source_bytes_read"] += int(metadata["bundle_bytes"])
+            counters["source_bytes_hashed"] += 2 * int(metadata["bundle_bytes"])
+            counters["source_events_validated"] += int(metadata["event_count"])
+            counters["manifest_bytes_read"] += int(metadata["manifest_bytes"])
+            for source_record in metadata["sources"]:
+                source_path = str(source_record["source_path"])
+                cached = cached_loose.get(source_path)
+                if (
+                    cached is None
+                    or source_path not in removed_loose
+                    or source_path in relocated
+                    or cached["source_sha256"] != source_record["source_sha256"]
+                    or int(cached["source_bytes"]) != int(source_record["source_bytes"])
+                    or int(cached["event_count"]) != len(source_record["event_ids"])
+                ):
+                    return None
+                relocated[source_path] = source_record
+                relocated_event_count += len(source_record["event_ids"])
+
+        if set(relocated) != removed_loose:
+            return None
+        if set(current_bundle_files) != existing_bundle_paths | new_bundle_paths:
+            return None
+        all_bundle_source_paths.update(relocated)
+        if set(current_loose) & all_bundle_source_paths:
+            return None
+
+        try:
+            prior_source_count = int(summary["sources_after_deduplication"])
+            prior_event_count = int(summary["events_imported"]) + int(
+                summary["events_skipped_existing"]
+            )
+            prior_bundle_source_count = sum(
+                int(item["source_count"]) for item in cached_bundle_items
+            )
+            prior_bundle_event_count = sum(
+                int(item["event_count"]) for item in cached_bundle_items
+            )
+            cached_loose_event_count = sum(
+                int(item["event_count"]) for item in cached_loose.values()
+            )
+            removed_event_count = sum(
+                int(cached_loose[path]["event_count"]) for path in removed_loose
+            )
+            if (
+                len(cached_loose) + prior_bundle_source_count != prior_source_count
+                or cached_loose_event_count + prior_bundle_event_count != prior_event_count
+                or relocated_event_count != removed_event_count
+                or len(current_loose) + prior_bundle_source_count + len(relocated)
+                != prior_source_count
+                or int(summary["files_seen"]) != len(cached_loose)
+                or int(summary["bundle_manifests_seen"]) != len(cached_bundle_items)
+                or int(summary["bundled_sources_seen"]) != prior_bundle_source_count
+            ):
+                return None
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    with measured_phase("compaction_delta_anchor_recheck"):
+        source_index_identity = _private_file_identity(source_index_path)
+        delta_index_identity = _private_file_identity(delta_index_path)
+        delta_overlay_identity = _private_file_identity(delta_overlay_path)
+        prior_receipt_inventory = prior_identity.get("receipt_inventory")
+        if isinstance(prior_receipt_inventory, dict):
+            receipt_inventory = _directory_inventory_fingerprint(
+                receipt_dir, suffix=".receipt.json", private=True
+            )
+            counters["receipt_inventory_attestation_scans"] += 1
+            if receipt_inventory != prior_receipt_inventory:
+                return None
+        try:
+            target_identity = storage.read_unique_storage_checkpoint_identity(DOMAIN)
+        except storage.StorageError:
+            return None
+        if (
+            current_identity.get("source_inventory") is None
+            or source_index_identity != prior_identity.get("source_index_identity")
+            or delta_index_identity != prior_identity.get("delta_index_identity")
+            or delta_overlay_identity != prior_identity.get("delta_overlay_identity")
+            or target_identity != prior_identity.get("target_identity")
+        ):
+            return None
+
+    folded_loose_records = [
+        raw_loose_by_path[path] for path in sorted(current_loose)
+    ]
+    folded_bundle_records = [
+        raw_bundles_by_manifest[path] for path in sorted(raw_bundles_by_manifest)
+    ] + new_bundle_records
+    try:
+        with measured_phase("compaction_delta_index_publish"):
+            delta_index_written, _ = _publish_delta_index(
+                delta_index_path,
+                source_dir=source_dir,
+                loose_sources=folded_loose_records,
+                bundles=folded_bundle_records,
+            )
+            if delta_index_written:
+                counters["delta_index_writes"] += 1
+            published_delta_index, _, published_delta_mode = _load_delta_index(
+                delta_index_path,
+                source_dir=source_dir,
+                bundle_dir=bundle_dir,
+            )
+            if published_delta_index is None or published_delta_mode != "steady":
+                return None
+            overlay_written, _ = _publish_delta_overlay(
+                delta_overlay_path,
+                source_dir=source_dir,
+                base_index_sha256=str(published_delta_index["index_sha256"]),
+                records=[],
+            )
+            if overlay_written:
+                counters["delta_overlay_writes"] += 1
+    except (OSError, ValueError):
+        return None
+
+    final_source_index_identity = _private_file_identity(source_index_path)
+    final_delta_index_identity = _private_file_identity(delta_index_path)
+    final_delta_overlay_identity = _private_file_identity(delta_overlay_path)
+    try:
+        final_target_identity = storage.read_unique_storage_checkpoint_identity(DOMAIN)
+    except storage.StorageError:
+        return None
+    if (
+        final_source_index_identity != prior_identity.get("source_index_identity")
+        or final_delta_index_identity is None
+        or final_delta_overlay_identity is None
+        or final_target_identity != prior_identity.get("target_identity")
+    ):
+        return None
+
+    checkpoint_identity: dict[str, Any] = {
+        "source_inventory": current_identity["source_inventory"],
+        "source_index_identity": final_source_index_identity,
+        "delta_index_identity": final_delta_index_identity,
+        "delta_overlay_identity": final_delta_overlay_identity,
+        "target_identity": final_target_identity,
+    }
+    receipt_inventory = prior_identity.get("receipt_inventory")
+    receipt_inventory_deferred = prior_identity.get("receipt_inventory_deferred") is True
+    if isinstance(receipt_inventory, dict) and not receipt_inventory_deferred:
+        checkpoint_identity["receipt_inventory"] = receipt_inventory
+        receipts_reused = prior_source_count
+        receipts_deferred = 0
+    else:
+        checkpoint_identity["receipt_inventory_deferred"] = True
+        receipts_reused = 0
+        receipts_deferred = prior_source_count
+
+    current_bundle_source_count = prior_bundle_source_count + len(relocated)
+    source_index_file_bytes = (
+        int(final_source_index_identity.get("size", 0))
+        if isinstance(final_source_index_identity, dict)
+        else 0
+    )
+    base_result = {
+        "schema_version": "chronik-grabowski-outbox-batch.v2",
+        "source_dir": str(source_dir),
+        "receipt_dir": str(receipt_dir),
+        "files_seen": len(sources),
+        "loose_files_seen": len(sources),
+        "bundle_manifests_seen": len(manifests),
+        "bundles_valid": len(manifests),
+        "bundled_sources_seen": current_bundle_source_count,
+        "sources_seen_total": prior_source_count,
+        "sources_after_deduplication": prior_source_count,
+        "orphan_bundles": 0,
+        "files_imported_or_confirmed": prior_source_count,
+        "files_unchanged": prior_source_count,
+        "receipts_written": 0,
+        "receipts_reused": receipts_reused,
+        "receipts_deferred": receipts_deferred,
+        "loose_sources_imported_or_confirmed": len(sources),
+        "bundled_sources_imported_or_confirmed": current_bundle_source_count,
+        "events_imported": 0,
+        "events_skipped_existing": prior_event_count,
+        "target_scans": 0,
+        "target_records_scanned": 0,
+        "identity_index_mode": "steady",
+        "identity_index_full_rebuild": False,
+        "identity_index_entries_after": int(summary["identity_index_entries_after"]),
+        "source_index_path": str(source_index_path),
+        "source_index_mode": "deferred_delta",
+        "source_index_written": False,
+        "source_index_file_bytes": source_index_file_bytes,
+        "sources_reused": prior_source_count - len(relocated),
+        "sources_revalidated": len(relocated),
+        "sources_changed": 0,
+        "sources_added": 0,
+        "sources_removed": 0,
+        "source_bytes_read": counters["source_bytes_read"],
+        "source_bytes_hashed": counters["source_bytes_hashed"],
+        "source_events_validated": counters["source_events_validated"],
+        "bundle_inventory": [],
+        "bundle_inventory_omitted": True,
+        "errors": [],
+        "historical_only": True,
+        "does_not_establish": DOES_NOT_ESTABLISH,
+    }
+    try:
+        with measured_phase("compaction_delta_checkpoint_publish"):
+            if _publish_steady_checkpoint(
+                _steady_checkpoint_path(receipt_dir),
+                source_dir=source_dir,
+                identity=checkpoint_identity,
+                summary=_steady_summary_from_result(base_result),
+                previous=checkpoint,
+            ):
+                counters["steady_checkpoint_writes"] += 1
+            else:
+                counters["steady_checkpoint_reuses"] += 1
+    except (OSError, ValueError):
+        return None
+
+    counters["delta_fast_path_hits"] += 1
+    counters["compaction_delta_fast_path_hits"] += 1
+    counters["compaction_sources_relocated"] += len(relocated)
+    elapsed_ns = time.perf_counter_ns() - import_started_ns
+    telemetry = {
+        "schema_version": "chronik-grabowski-import-telemetry.v1",
+        "elapsed_seconds": round(elapsed_ns / 1_000_000_000, 6),
+        "phases_seconds": {
+            name: round(value / 1_000_000_000, 6)
+            for name, value in sorted(phase_ns.items())
+        },
+        "counters": dict(sorted(counters.items())),
+    }
+    return {
+        **base_result,
+        "elapsed_seconds": telemetry["elapsed_seconds"],
+        "import_telemetry": telemetry,
+        "steady_fast_path": False,
+        "delta_fast_path": True,
+        "compaction_delta_fast_path": True,
+    }
+
+
 def _try_checkpoint_delta_import(
     *,
     checkpoint: dict[str, Any],
@@ -1748,8 +2188,11 @@ def _try_checkpoint_delta_import(
 
     # Bind the authoritative state immediately before the ledger effect. Source
     # files already read by this run are immutable snapshots; a later source
-    # change is deliberately the next delta. Receipts are non-authoritative and
-    # are fully re-attested by the next full/steady reconciliation.
+    # change is deliberately the next delta. When the prior checkpoint carries
+    # a fully attested receipt inventory, snapshot receipt metadata before the
+    # effect so the postcondition can prove that only this delta's exact receipt
+    # paths changed.
+    receipt_snapshot_before: dict[str, tuple[int, ...]] | None = None
     with measured_phase("delta_anchor_recheck"):
         source_inventory = current_identity.get("source_inventory")
         source_index_identity = _private_file_identity(source_index_path)
@@ -1760,6 +2203,15 @@ def _try_checkpoint_delta_import(
         except storage.StorageError:
             return None
         prior_identity = checkpoint["identity"]
+        prior_receipt_inventory = prior_identity.get("receipt_inventory")
+        if isinstance(prior_receipt_inventory, dict):
+            receipt_snapshot = _directory_inventory_snapshot(
+                receipt_dir, suffix=".receipt.json", private=True
+            )
+            if receipt_snapshot is None or receipt_snapshot[0] != prior_receipt_inventory:
+                return None
+            receipt_snapshot_before = receipt_snapshot[1]
+            counters["receipt_inventory_attestation_scans"] += 1
         if (
             source_inventory is None
             or source_index_identity != prior_identity.get("source_index_identity")
@@ -1791,6 +2243,20 @@ def _try_checkpoint_delta_import(
         except (OSError, ValueError, storage.StorageError) as exc:
             receipt_writes_succeeded = False
             errors.append({"source_path": "<batch>", "error": str(exc)})
+
+    attested_receipt_inventory: dict[str, Any] | None = None
+    if (
+        ledger_reconciled
+        and receipt_writes_succeeded
+        and receipt_snapshot_before is not None
+    ):
+        with measured_phase("delta_receipt_attestation"):
+            attested_receipt_inventory = _attest_delta_receipt_inventory(
+                receipt_dir,
+                before=receipt_snapshot_before,
+                prepared_sources=delta_prepared,
+            )
+            counters["receipt_inventory_attestation_scans"] += 1
 
     delta_overlay_written = False
     if ledger_reconciled and receipt_writes_succeeded:
@@ -1871,10 +2337,17 @@ def _try_checkpoint_delta_import(
         "receipts_written": sum(
             1 for result in delta_results if result.get("receipt_written") is True
         ),
-        "receipts_reused": sum(
+        "receipts_reused": (
+            bypassed_source_count
+            if attested_receipt_inventory is not None
+            else 0
+        )
+        + sum(
             1 for result in delta_results if result.get("receipt_reused") is True
         ),
-        "receipts_deferred": bypassed_source_count,
+        "receipts_deferred": (
+            0 if attested_receipt_inventory is not None else bypassed_source_count
+        ),
         "loose_sources_imported_or_confirmed": len(cached_loose)
         - changed_count
         + len(delta_results),
@@ -1935,8 +2408,13 @@ def _try_checkpoint_delta_import(
                     "delta_index_identity": final_delta_index_identity,
                     "delta_overlay_identity": final_delta_overlay_identity,
                     "target_identity": final_target_identity,
-                    "receipt_inventory_deferred": True,
                 }
+                if attested_receipt_inventory is not None:
+                    checkpoint_identity["receipt_inventory"] = (
+                        attested_receipt_inventory
+                    )
+                else:
+                    checkpoint_identity["receipt_inventory_deferred"] = True
                 if _publish_steady_checkpoint(
                     _steady_checkpoint_path(receipt_dir),
                     source_dir=source_dir,
@@ -2950,6 +3428,27 @@ def import_grabowski_outbox(
             and delta_overlay is not None
             and delta_overlay_mode == "steady"
         ):
+            compaction_delta_result = _try_checkpoint_compaction_delta_import(
+                checkpoint=prior_steady_checkpoint,
+                current_identity=delta_candidate_identity,
+                delta_index=delta_index,
+                delta_overlay=delta_overlay,
+                source_dir=source_dir,
+                bundle_dir=bundle_dir,
+                sources=sources,
+                manifests=manifests,
+                bundle_files=bundle_files,
+                receipt_dir=receipt_dir,
+                source_index_path=source_index_path,
+                delta_index_path=delta_index_path,
+                delta_overlay_path=delta_overlay_path,
+                import_started_ns=import_started_ns,
+                phase_ns=phase_ns,
+                counters=counters,
+                measured_phase=measured_phase,
+            )
+            if compaction_delta_result is not None:
+                return compaction_delta_result
             delta_result = _try_checkpoint_delta_import(
                 checkpoint=prior_steady_checkpoint,
                 current_identity=delta_candidate_identity,

--- a/tests/test_benchmark_outbox_import.py
+++ b/tests/test_benchmark_outbox_import.py
@@ -37,6 +37,8 @@ def test_benchmark_reports_persistent_index_reuse(tmp_path):
     assert tier["small_delta"]["steady_fast_path"] is False
     assert tier["small_delta"]["delta_fast_path"] is True
     assert tier["bundled_rebuild"]["steady_fast_path"] is False
+    assert tier["bundled_rebuild"]["delta_fast_path"] is True
+    assert tier["bundled_rebuild"]["compaction_delta_fast_path"] is True
     assert tier["bundled_repeat"]["steady_fast_path"] is True
     assert tier["first"]["target_scans"] == 0
     assert tier["first"]["target_records_scanned"] == 0

--- a/tests/test_grabowski_outbox_import.py
+++ b/tests/test_grabowski_outbox_import.py
@@ -698,6 +698,19 @@ def test_summary_delta_fast_path_folds_exact_compaction_relocation(
     monkeypatch.setattr(
         coding_memory, "_import_prepared_grabowski_sources", unexpected_ledger_reconcile
     )
+    original_open = coding_memory.os.open
+    lock_path = source_dir / coding_memory.GRABOWSKI_WRITER_COMPACTION_LOCK_FILENAME
+    lock_open_observed = False
+
+    def observe_lock_open(path, flags, *args, **kwargs):
+        nonlocal lock_open_observed
+        if Path(path) == lock_path:
+            lock_open_observed = True
+            assert flags & os.O_ACCMODE == os.O_RDONLY
+            assert flags & os.O_CREAT == 0
+        return original_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(coding_memory.os, "open", observe_lock_open)
     result = coding_memory.import_grabowski_outbox(
         outbox_root=outbox,
         receipt_dir=receipts,
@@ -706,6 +719,7 @@ def test_summary_delta_fast_path_folds_exact_compaction_relocation(
     monkeypatch.setattr(
         coding_memory, "_import_prepared_grabowski_sources", original_import
     )
+    assert lock_open_observed is True
 
     assert result["errors"] == []
     assert result["steady_fast_path"] is False

--- a/tests/test_grabowski_outbox_import.py
+++ b/tests/test_grabowski_outbox_import.py
@@ -769,6 +769,55 @@ def test_summary_delta_fast_path_folds_exact_compaction_relocation(
     assert steady["events_skipped_existing"] == 2
 
 
+def test_summary_compaction_delta_normalizes_relative_bundle_paths(
+    tmp_path, monkeypatch
+):
+    data = tmp_path / "chronik-data"
+    receipts = tmp_path / "receipts"
+    data.mkdir()
+    monkeypatch.setattr(storage, "DATA_DIR", data)
+    monkeypatch.chdir(tmp_path)
+    outbox = Path("state")
+    write_named_outbox(
+        outbox,
+        "grabowski_task-one-a1.jsonl",
+        [event("agent.run.completed", "a")],
+    )
+    first = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    assert first["errors"] == []
+    compacted = coding_memory.compact_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        grace_seconds=0,
+        max_sources=1,
+        apply=True,
+    )
+    assert compacted["errors"] == []
+    assert compacted["sources_removed"] == 1
+
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    assert result["errors"] == []
+    assert result["compaction_delta_fast_path"] is True
+    delta_index = json.loads(
+        (receipts / coding_memory.GRABOWSKI_DELTA_INDEX_FILENAME).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert len(delta_index["bundles"]) == 1
+    bundle = delta_index["bundles"][0]
+    assert Path(bundle["manifest_path"]).is_absolute()
+    assert Path(bundle["bundle_path"]).is_absolute()
+
+
 def test_summary_compaction_delta_rejects_corrupt_new_bundle(
     tmp_path, monkeypatch
 ):

--- a/tests/test_grabowski_outbox_import.py
+++ b/tests/test_grabowski_outbox_import.py
@@ -817,6 +817,24 @@ def test_summary_compaction_delta_normalizes_relative_bundle_paths(
     assert Path(bundle["manifest_path"]).is_absolute()
     assert Path(bundle["bundle_path"]).is_absolute()
 
+    full = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=False,
+    )
+    assert full["errors"] == []
+    source_index = json.loads(
+        (receipts / coding_memory.GRABOWSKI_SOURCE_INDEX_FILENAME).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert len(source_index["bundles"]) == 1
+    source_bundle = source_index["bundles"][0]
+    assert Path(source_bundle["manifest_path"]).is_absolute()
+    assert Path(source_bundle["bundle_path"]).is_absolute()
+    assert source_bundle["metadata"]["manifest_path"] == source_bundle["manifest_path"]
+    assert source_bundle["metadata"]["bundle_path"] == source_bundle["bundle_path"]
+
 
 def test_summary_compaction_delta_rejects_corrupt_new_bundle(
     tmp_path, monkeypatch

--- a/tests/test_grabowski_outbox_import.py
+++ b/tests/test_grabowski_outbox_import.py
@@ -296,8 +296,8 @@ def test_summary_delta_fast_path_reconciles_only_added_source(tmp_path, monkeypa
     assert result["sources_reused"] == 2
     assert result["files_unchanged"] == 2
     assert result["receipts_written"] == 1
-    assert result["receipts_reused"] == 0
-    assert result["receipts_deferred"] == 2
+    assert result["receipts_reused"] == 2
+    assert result["receipts_deferred"] == 0
     assert result["target_scans"] == 0
     assert result["source_index_mode"] == "deferred_delta"
     assert result["source_index_written"] is False
@@ -313,7 +313,7 @@ def test_summary_delta_fast_path_reconciles_only_added_source(tmp_path, monkeypa
         receipt_dir=receipts,
         allow_steady_fast_path=True,
     )
-    assert next_result["steady_fast_path"] is False
+    assert next_result["steady_fast_path"] is True
     assert next_result["delta_fast_path"] is False
     assert next_result["receipts_deferred"] == 0
     assert next_result["events_skipped_existing"] == 3
@@ -324,6 +324,66 @@ def test_summary_delta_fast_path_reconciles_only_added_source(tmp_path, monkeypa
     )
     assert steady_result["steady_fast_path"] is True
     assert steady_result["events_skipped_existing"] == 3
+
+
+def test_summary_delta_receipt_attestation_defers_on_unrelated_receipt_drift(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    first = write_named_outbox(
+        outbox,
+        "grabowski_task-first-a1.jsonl",
+        [event("agent.run.completed", "a")],
+    )
+    coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    first_receipt = coding_memory._receipt_path(
+        first, receipts, coding_memory.sha256_bytes(first.read_bytes())
+    )
+    write_named_outbox(
+        outbox,
+        "grabowski_task-second-a1.jsonl",
+        [event("agent.run.completed", "b")],
+    )
+    original = coding_memory._import_prepared_grabowski_sources
+
+    def mutate_unrelated_receipt(prepared_sources, *args, **kwargs):
+        result = original(prepared_sources, *args, **kwargs)
+        stat_before = first_receipt.stat()
+        os.utime(
+            first_receipt,
+            ns=(stat_before.st_atime_ns, stat_before.st_mtime_ns + 1_000_000),
+        )
+        return result
+
+    monkeypatch.setattr(
+        coding_memory, "_import_prepared_grabowski_sources", mutate_unrelated_receipt
+    )
+    delta = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    assert delta["errors"] == []
+    assert delta["delta_fast_path"] is True
+    assert delta["events_imported"] == 1
+    assert delta["receipts_deferred"] == 1
+    assert delta["receipts_reused"] == 0
+
+    monkeypatch.setattr(coding_memory, "_import_prepared_grabowski_sources", original)
+    repaired = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    assert repaired["steady_fast_path"] is False
+    assert repaired["delta_fast_path"] is False
+    assert repaired["events_imported"] == 0
+    assert repaired["events_skipped_existing"] == 2
 
 
 def test_summary_delta_fast_path_reconciles_changed_source_generation(
@@ -377,7 +437,7 @@ def test_summary_delta_fast_path_reconciles_changed_source_generation(
         receipt_dir=receipts,
         allow_steady_fast_path=True,
     )
-    assert next_result["steady_fast_path"] is False
+    assert next_result["steady_fast_path"] is True
     assert next_result["delta_fast_path"] is False
     assert next_result["events_skipped_existing"] == 2
     steady_result = coding_memory.import_grabowski_outbox(
@@ -444,8 +504,8 @@ def test_summary_delta_overlay_accumulates_consecutive_source_deltas(
     assert second_delta["sources_revalidated"] == 1
     assert second_delta["sources_reused"] == 2
     assert second_delta["receipts_written"] == 1
-    assert second_delta["receipts_reused"] == 0
-    assert second_delta["receipts_deferred"] == 2
+    assert second_delta["receipts_reused"] == 2
+    assert second_delta["receipts_deferred"] == 0
     assert second_delta["target_scans"] == 0
     assert second_delta["source_index_mode"] == "deferred_delta"
     assert delta_index_path.read_bytes() == delta_index_before
@@ -461,11 +521,11 @@ def test_summary_delta_overlay_accumulates_consecutive_source_deltas(
         receipt_dir=receipts,
         allow_steady_fast_path=True,
     )
-    assert repair["steady_fast_path"] is False
+    assert repair["steady_fast_path"] is True
     assert repair["delta_fast_path"] is False
     assert repair["receipts_deferred"] == 0
-    repaired_overlay = json.loads(overlay_path.read_text(encoding="utf-8"))
-    assert repaired_overlay["record_count"] == 0
+    retained_overlay = json.loads(overlay_path.read_text(encoding="utf-8"))
+    assert retained_overlay["record_count"] == 2
 
     steady = coding_memory.import_grabowski_outbox(
         outbox_root=outbox,
@@ -593,6 +653,284 @@ def test_corrupt_delta_overlay_falls_back_and_repairs_full_cache(tmp_path, monke
     )
     assert steady["steady_fast_path"] is True
     assert steady["events_skipped_existing"] == 2
+
+
+def test_summary_delta_fast_path_folds_exact_compaction_relocation(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    source_dir = outbox / "grabowski" / "chronik-outbox"
+    write_named_outbox(
+        outbox,
+        "grabowski_task-first-a1.jsonl",
+        [event("agent.run.completed", "a")],
+    )
+    write_named_outbox(
+        outbox,
+        "grabowski_task-second-a1.jsonl",
+        [event("agent.run.completed", "b")],
+    )
+    first = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    assert first["errors"] == []
+    source_index_path = receipts / coding_memory.GRABOWSKI_SOURCE_INDEX_FILENAME
+    source_index_before = source_index_path.read_bytes()
+
+    compacted = coding_memory.compact_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        grace_seconds=0,
+        max_sources=2,
+        apply=True,
+    )
+    assert compacted["errors"] == []
+    assert compacted["sources_removed"] == 2
+    assert list(source_dir.glob("*.jsonl")) == []
+
+    original_import = coding_memory._import_prepared_grabowski_sources
+
+    def unexpected_ledger_reconcile(*args, **kwargs):
+        raise AssertionError("exact compaction relocation touched the ledger reconcile path")
+
+    monkeypatch.setattr(
+        coding_memory, "_import_prepared_grabowski_sources", unexpected_ledger_reconcile
+    )
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    monkeypatch.setattr(
+        coding_memory, "_import_prepared_grabowski_sources", original_import
+    )
+
+    assert result["errors"] == []
+    assert result["steady_fast_path"] is False
+    assert result["delta_fast_path"] is True
+    assert result["compaction_delta_fast_path"] is True
+    assert result["events_imported"] == 0
+    assert result["events_skipped_existing"] == 2
+    assert result["files_seen"] == 0
+    assert result["bundles_valid"] == 1
+    assert result["bundled_sources_seen"] == 2
+    assert result["sources_after_deduplication"] == 2
+    assert result["sources_revalidated"] == 2
+    assert result["sources_reused"] == 0
+    assert result["source_index_mode"] == "deferred_delta"
+    assert result["source_index_written"] is False
+    assert source_index_path.read_bytes() == source_index_before
+    assert result["target_scans"] == 0
+    assert result["target_records_scanned"] == 0
+    assert result["import_telemetry"]["counters"][
+        "compaction_delta_fast_path_hits"
+    ] == 1
+    assert result["import_telemetry"]["counters"][
+        "compaction_sources_relocated"
+    ] == 2
+
+    delta_index = json.loads(
+        (receipts / coding_memory.GRABOWSKI_DELTA_INDEX_FILENAME).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert delta_index["source_count"] == 2
+    assert delta_index["loose_sources"] == []
+    assert len(delta_index["bundles"]) == 1
+    overlay = json.loads(
+        (receipts / coding_memory.GRABOWSKI_DELTA_OVERLAY_FILENAME).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert overlay["record_count"] == 0
+
+    steady = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    assert steady["steady_fast_path"] is True
+    assert steady["events_skipped_existing"] == 2
+
+
+def test_summary_compaction_delta_rejects_corrupt_new_bundle(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    write_named_outbox(
+        outbox,
+        "grabowski_task-one-a1.jsonl",
+        [event("agent.run.completed", "a")],
+    )
+    coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    compacted = coding_memory.compact_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        grace_seconds=0,
+        max_sources=1,
+        apply=True,
+    )
+    assert compacted["errors"] == []
+    bundle = Path(compacted["bundle_path"])
+    bundle.write_bytes(bundle.read_bytes() + b" ")
+
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    assert result["steady_fast_path"] is False
+    assert result["delta_fast_path"] is False
+    assert result.get("compaction_delta_fast_path") is not True
+    assert result["bundles_valid"] == 0
+    assert result["errors"]
+    assert "bundle" in result["errors"][0]["error"]
+
+
+def test_summary_compaction_delta_falls_back_after_receipt_inventory_drift(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    source = write_named_outbox(
+        outbox,
+        "grabowski_task-one-a1.jsonl",
+        [event("agent.run.completed", "a")],
+    )
+    coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    compacted = coding_memory.compact_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        grace_seconds=0,
+        max_sources=1,
+        apply=True,
+    )
+    assert compacted["errors"] == []
+    # The generation receipt is path+source-digest bound; locate the existing
+    # canonical receipt and drift only its metadata, not its content.
+    receipt = next(receipts.glob("*.receipt.json"))
+    before = receipt.stat()
+    os.utime(receipt, ns=(before.st_atime_ns, before.st_mtime_ns + 1_000_000))
+
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    assert result["errors"] == []
+    assert result["steady_fast_path"] is False
+    assert result["delta_fast_path"] is False
+    assert result.get("compaction_delta_fast_path") is not True
+    assert result["events_imported"] == 0
+    assert result["events_skipped_existing"] == 1
+
+
+def test_summary_compaction_delta_falls_back_on_target_identity_drift(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    write_named_outbox(
+        outbox,
+        "grabowski_task-one-a1.jsonl",
+        [event("agent.run.completed", "a")],
+    )
+    coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+    compacted = coding_memory.compact_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        grace_seconds=0,
+        max_sources=1,
+        apply=True,
+    )
+    assert compacted["errors"] == []
+    original = coding_memory.storage.read_unique_storage_checkpoint_identity
+    calls = 0
+
+    def drift_once(domain):
+        nonlocal calls
+        calls += 1
+        current = dict(original(domain))
+        if calls >= 2:
+            current["test_drift"] = 1
+        return current
+
+    monkeypatch.setattr(
+        coding_memory.storage, "read_unique_storage_checkpoint_identity", drift_once
+    )
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    assert result["errors"] == []
+    assert result["steady_fast_path"] is False
+    assert result["delta_fast_path"] is False
+    assert result.get("compaction_delta_fast_path") is not True
+    assert result["events_imported"] == 0
+    assert result["events_skipped_existing"] == 1
+
+
+def test_summary_compaction_delta_falls_back_when_bundle_overlaps_live_loose(
+    tmp_path, monkeypatch
+):
+    _, receipts, outbox = configure(tmp_path, monkeypatch)
+    source_dir = outbox / "grabowski" / "chronik-outbox"
+    source = write_named_outbox(
+        outbox,
+        "grabowski_task-one-a1.jsonl",
+        [event("agent.run.completed", "a")],
+    )
+    coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    def keep_loose_source(path):
+        assert path == source
+        raise OSError("simulated unlink failure")
+
+    monkeypatch.setattr(coding_memory, "_unlink_loose_source", keep_loose_source)
+    compacted = coding_memory.compact_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        grace_seconds=0,
+        max_sources=1,
+        apply=True,
+    )
+    assert compacted["sources_removed"] == 0
+    assert source.exists()
+    assert len(list((source_dir / "bundles").glob("*.manifest.json"))) == 1
+
+    result = coding_memory.import_grabowski_outbox(
+        outbox_root=outbox,
+        receipt_dir=receipts,
+        allow_steady_fast_path=True,
+    )
+
+    assert result["errors"] == []
+    assert result["steady_fast_path"] is False
+    assert result["delta_fast_path"] is False
+    assert result.get("compaction_delta_fast_path") is not True
+    assert result["sources_after_deduplication"] == 1
+    assert result["events_imported"] == 0
+    assert result["events_skipped_existing"] == 1
 
 
 def test_summary_delta_fast_path_falls_back_on_source_removal(tmp_path, monkeypatch):

--- a/tools/benchmark_outbox_import.py
+++ b/tools/benchmark_outbox_import.py
@@ -99,6 +99,7 @@ def _measure(
         "source_index_mode": result["source_index_mode"],
         "steady_fast_path": result.get("steady_fast_path") is True,
         "delta_fast_path": result.get("delta_fast_path") is True,
+        "compaction_delta_fast_path": result.get("compaction_delta_fast_path") is True,
         "sources_reused": result["sources_reused"],
         "sources_revalidated": result["sources_revalidated"],
         "sources_changed": result["sources_changed"],
@@ -233,6 +234,8 @@ def benchmark_tier(
             and small_delta["steady_fast_path"] is False
             and small_delta["delta_fast_path"] is True
             and bundled_rebuild["steady_fast_path"] is False
+            and bundled_rebuild["delta_fast_path"] is True
+            and bundled_rebuild["compaction_delta_fast_path"] is True
             and bundled_repeat["steady_fast_path"] is True
             and first["target_scans"] <= MAX_TARGET_SCANS
             and repeat["target_scans"] <= MAX_TARGET_SCANS


### PR DESCRIPTION
Production profile: recurring ~9.9s outbox full reconciliations after compaction. This PR adds a fail-closed exact loose-to-bundle relocation delta path plus receipt-inventory attestation for normal source deltas.

Review hardening: bundle manifest/data paths are normalized to absolute paths before source/delta index publication, so relative `--outbox-root` callers keep the compaction fast path instead of falling back to full reconciliation.

Synthetic 1,000-source benchmark: post-compaction import 2.351623s on main -> 1.459300s patched (~38% faster), followed by 0.045470s steady run; target scans remain 0.

Validation: 65 focused tests and 613/613 canonical tests green; Ruff and Mypy green locally. Negative coverage includes corrupt bundle, receipt drift, target drift, loose/bundle overlap, source removal, and relative outbox-root path normalization.