### PR TITLE
feat: distinguish agent run execution failures

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -157,6 +157,8 @@ def _validate_v1_semantics(event: dict[str, Any]) -> None:
 
 def validate_event(event: dict[str, Any]) -> datetime:
     schema_version = event.get("schema_version")
+    if not isinstance(schema_version, str):
+        raise ValueError("unsupported coding event schema_version: expected string")
     errors = sorted(
         _validator(schema_version).iter_errors(event),
         key=lambda error: list(error.absolute_path),

--- a/coding_memory.py
+++ b/coding_memory.py
@@ -26,15 +26,32 @@ SCHEMA_PATH = Path(__file__).resolve().parent / "docs" / "chronik" / "agent-run-
 DOES_NOT_ESTABLISH = ["current_git_state", "current_ci_state", "current_runtime_state", "safe_retry"]
 GRABOWSKI_SOURCE_REPO = "heimgewebe/grabowski"
 GRABOWSKI_COMPONENT = "grabowski"
-HIGH_VALUE_KINDS = frozenset({"agent.run.started", "agent.run.completed", "agent.run.blocked"})
+V1_KIND_RESULT = {
+    "agent.run.started": "started",
+    "agent.run.completed": "completed",
+    "agent.run.failed": "failed",
+    "agent.run.cancelled": "cancelled",
+    "agent.run.timed_out": "timed_out",
+    "agent.run.signalled": "signalled",
+    "agent.run.blocked": "blocked",
+}
+V1_EXECUTION_FAILURE_RESULTS = frozenset({"failed", "cancelled", "timed_out", "signalled"})
+HIGH_VALUE_KINDS = frozenset(V1_KIND_RESULT)
 OPERATIONS = frozenset({"implement", "review", "merge", "deploy", "runtime_verify", "recovery", "other"})
 TASK_CLASSES = frozenset({"coding", "review", "merge", "deploy", "runtime_verify", "recovery", "maintenance", "diagnostic", "other"})
-OUTCOMES = frozenset({"started", "completed", "blocked", "failed", "reverted", "outcome_unknown"})
+OUTCOMES = frozenset({"started", "completed", "blocked", "failed", "cancelled", "timed_out", "signalled", "reverted", "outcome_unknown"})
 MAX_INTEGRITY_DIAGNOSTICS = 20
 HISTORY_VALIDATION_CHECKPOINT_FILENAME = ".history-validation-prefix.v1.json"
 HISTORY_VALIDATION_CHECKPOINT_SCHEMA = "chronik-history-validation-prefix.v1"
-HISTORY_VALIDATION_CONTRACT = "agent-run-event-v0+utc-timestamp-v1"
-GRABOWSKI_TERMINAL_KINDS = frozenset({"agent.run.completed", "agent.run.blocked"})
+HISTORY_VALIDATION_CONTRACT = "agent-run-event-v0+v1+utc-timestamp-v1"
+GRABOWSKI_TERMINAL_KINDS = frozenset({
+    "agent.run.completed",
+    "agent.run.failed",
+    "agent.run.cancelled",
+    "agent.run.timed_out",
+    "agent.run.signalled",
+    "agent.run.blocked",
+})
 GRABOWSKI_BUNDLE_DIRNAME = "bundles"
 GRABOWSKI_BUNDLE_ENTRY_SCHEMA = "chronik-grabowski-outbox-bundle-source.v1"
 GRABOWSKI_BUNDLE_MANIFEST_SCHEMA = "chronik-grabowski-outbox-bundle-manifest.v1"
@@ -95,18 +112,61 @@ def configure_data_dir(path: Path, *, create: bool) -> Path:
 
 
 @lru_cache(maxsize=1)
-def _validator() -> Draft7Validator:
+def _v1_schema() -> dict[str, Any]:
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema["$id"] = "https://heimgewebe.local/chronik/agent-run-event-v1.schema.json"
+    schema["title"] = "Chronik Agent Run Event v1"
+    schema["properties"]["schema_version"] = {"const": "agent-run-event.v1"}
+    schema["properties"]["kind"]["enum"] = sorted(V1_KIND_RESULT)
+    schema["properties"]["data"]["properties"]["result"]["enum"] = sorted(
+        set(V1_KIND_RESULT.values())
+    )
+    schema["properties"]["data"]["properties"]["outcome"]["enum"] = sorted(OUTCOMES)
+    return schema
+
+
+@lru_cache(maxsize=2)
+def _validator(schema_version: str = "agent-run-event.v0") -> Draft7Validator:
+    if schema_version == "agent-run-event.v0":
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    elif schema_version == "agent-run-event.v1":
+        schema = _v1_schema()
+    else:
+        raise ValueError(f"unsupported coding event schema_version: {schema_version}")
     Draft7Validator.check_schema(schema)
     return Draft7Validator(schema)
 
 
+def _validate_v1_semantics(event: dict[str, Any]) -> None:
+    kind = event.get("kind")
+    expected_result = V1_KIND_RESULT.get(kind)
+    if expected_result is None:
+        raise ValueError(f"unsupported v1 coding event kind: {kind}")
+    data = event.get("data")
+    if not isinstance(data, dict) or data.get("result") != expected_result:
+        raise ValueError(
+            f"v1 coding event kind/result mismatch: {kind} requires {expected_result}"
+        )
+    blocker_code = data.get("blocker_code")
+    if expected_result == "blocked":
+        if not isinstance(blocker_code, str) or not blocker_code:
+            raise ValueError("v1 blocked coding event requires blocker_code")
+    elif blocker_code is not None:
+        raise ValueError("v1 non-blocked coding event must not carry blocker_code")
+
+
 def validate_event(event: dict[str, Any]) -> datetime:
-    errors = sorted(_validator().iter_errors(event), key=lambda error: list(error.absolute_path))
+    schema_version = event.get("schema_version")
+    errors = sorted(
+        _validator(schema_version).iter_errors(event),
+        key=lambda error: list(error.absolute_path),
+    )
     if errors:
         error = errors[0]
         path = "/".join(str(part) for part in error.absolute_path) or "<root>"
         raise ValueError(f"invalid coding event at {path}: {error.message}")
+    if schema_version == "agent-run-event.v1":
+        _validate_v1_semantics(event)
     return _parse_timestamp(event["ts"], field="ts")
 
 
@@ -4311,7 +4371,9 @@ def _compact_grabowski_outbox_unlocked(
 
 @lru_cache(maxsize=1)
 def _history_validation_schema_sha256() -> str:
-    return sha256_bytes(SCHEMA_PATH.read_bytes())
+    return sha256_bytes(
+        SCHEMA_PATH.read_bytes() + b"\0" + canonical_bytes(_v1_schema())
+    )
 
 
 def _history_validation_checkpoint_path() -> Path:
@@ -4785,7 +4847,7 @@ def freeze_history(output: Path, **filters: Any) -> dict[str, Any]:
         "ledger_snapshot_sha256": ledger_snapshot["sha256"],
         "ledger_snapshot_complete_bytes": ledger_snapshot["complete_bytes"],
         "generated_at": utc_now(),
-        "redaction_contract": "agent-run-event.v0 allow-list",
+        "redaction_contract": "agent-run-event.v0+v1 allow-list",
         "historical_only": True,
         "does_not_establish": DOES_NOT_ESTABLISH,
     }

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -645,3 +645,65 @@ def test_ledger_payload_index_treats_only_lf_as_record_boundary(
 
     with pytest.raises(storage.StorageError, match="invalid ledger JSON at record 1"):
         coding_memory._ledger_payloads_by_event_id()
+
+
+def v1_event(result="failed", event_id="sha256:"+"f"*64):
+    value = event(event_id=event_id, outcome=result)
+    value["schema_version"] = "agent-run-event.v1"
+    value["kind"] = f"agent.run.{result}"
+    value["data"]["result"] = result
+    if result == "blocked":
+        value["data"]["blocker_code"] = "authority-unavailable"
+    return value
+
+
+def test_v1_execution_failure_is_not_counted_as_blocked(tmp_path, monkeypatch):
+    setup(tmp_path, monkeypatch)
+    value = v1_event("failed")
+    coding_memory.import_events([value])
+    history = coding_memory.query_history(repo="heimgewebe/example", outcome="failed")
+    summary = coding_memory.operator_summary()
+    assert history["event_ids"] == [value["event_id"]]
+    assert summary["counts_by_kind"] == {"agent.run.failed": 1}
+    assert summary["blocked_by_code"] == {}
+
+
+def test_v1_supports_execution_failure_terminal_kinds(tmp_path, monkeypatch):
+    setup(tmp_path, monkeypatch)
+    values = [
+        v1_event("cancelled", "sha256:"+"1"*64),
+        v1_event("timed_out", "sha256:"+"2"*64),
+        v1_event("signalled", "sha256:"+"3"*64),
+    ]
+    coding_memory.import_events(values)
+    for result, value in zip(("cancelled", "timed_out", "signalled"), values):
+        assert coding_memory.query_history(
+            repo="heimgewebe/example", outcome=result
+        )["event_ids"] == [value["event_id"]]
+    assert set(coding_memory.GRABOWSKI_TERMINAL_KINDS) >= {
+        "agent.run.cancelled", "agent.run.timed_out", "agent.run.signalled"
+    }
+
+
+def test_v1_blocked_requires_code_and_nonblocked_rejects_code():
+    blocked = v1_event("blocked")
+    coding_memory.validate_event(blocked)
+    missing = v1_event("blocked", "sha256:"+"4"*64)
+    missing["data"].pop("blocker_code")
+    with pytest.raises(ValueError, match="requires blocker_code"):
+        coding_memory.validate_event(missing)
+    failed = v1_event("failed", "sha256:"+"5"*64)
+    failed["data"]["blocker_code"] = "not-a-real-blocker"
+    with pytest.raises(ValueError, match="must not carry blocker_code"):
+        coding_memory.validate_event(failed)
+
+
+def test_v0_blocked_history_remains_valid_after_v1_addition(tmp_path, monkeypatch):
+    setup(tmp_path, monkeypatch)
+    value = event(outcome="blocked")
+    value["kind"] = "agent.run.blocked"
+    value["data"].update({"result": "blocked", "blocker_code": "legacy-task-failed"})
+    coding_memory.import_events([value])
+    assert coding_memory.query_history(
+        repo="heimgewebe/example", outcome="blocked"
+    )["event_ids"] == [value["event_id"]]

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -707,3 +707,11 @@ def test_v0_blocked_history_remains_valid_after_v1_addition(tmp_path, monkeypatc
     assert coding_memory.query_history(
         repo="heimgewebe/example", outcome="blocked"
     )["event_ids"] == [value["event_id"]]
+
+
+@pytest.mark.parametrize("schema_version", [[], {}])
+def test_non_string_schema_version_is_rejected_as_invalid_event(schema_version):
+    value = event()
+    value["schema_version"] = schema_version
+    with pytest.raises(ValueError, match="schema_version: expected string"):
+        coding_memory.validate_event(value)


### PR DESCRIPTION
## Summary
- keep `agent-run-event.v0` fully valid for historical data
- add a backwards-compatible v1 run-event contract with separate `failed`, `cancelled`, `timed_out`, and `signalled` terminal kinds
- reserve `agent.run.blocked` for events carrying a real `blocker_code`
- invalidate/rebuild derived history validation checkpoints against the combined v0+v1 contract

## Verification
- `47 passed` in `tests/test_coding_memory.py`
- `617 passed` full test suite
- `git diff --check`

Closes #297

Bureau self-blocking audit dependency: this lands the consumer contract before Grabowski starts emitting v1 events.