### PR TITLE
perf(outbox): stream status and compact verification

### DIFF
--- a/tests/test_chronik_outbox.py
+++ b/tests/test_chronik_outbox.py
@@ -116,6 +116,50 @@ def test_status_reports_pending_file(tmp_path):
     assert entries[0].flushed is False
 
 
+def test_status_and_compact_stream_without_materialized_snapshot(monkeypatch, tmp_path):
+    event = load_event()
+    event_count = 2048
+    raw_line = encoded_event(event)
+    path = chronik_outbox.outbox_path(event, tmp_path)
+    path.parent.mkdir(parents=True)
+    source_hasher = hashlib.sha256()
+    with path.open("wb") as handle:
+        for _ in range(event_count):
+            handle.write(raw_line)
+            source_hasher.update(raw_line)
+
+    source_bytes = path.stat().st_size
+    chronik_outbox._write_receipt_progress(
+        path,
+        chronik_outbox.ReceiptProgress(
+            source_bytes=source_bytes,
+            event_count=event_count,
+            source_sha256=source_hasher.hexdigest(),
+        ),
+        202,
+    )
+
+    def reject_materialized_snapshot(*args, **kwargs):
+        raise AssertionError("status/compact used the materializing snapshot path")
+
+    def reject_read_bytes(self):
+        raise AssertionError(f"status/compact called Path.read_bytes for {self}")
+
+    monkeypatch.setattr(chronik_outbox, "_snapshot_unlocked", reject_materialized_snapshot)
+    monkeypatch.setattr(chronik_outbox, "_parse_events", reject_materialized_snapshot)
+    monkeypatch.setattr(Path, "read_bytes", reject_read_bytes)
+
+    entries = chronik_outbox.status(tmp_path)
+
+    assert len(entries) == 1
+    assert entries[0].path == path
+    assert entries[0].events == event_count
+    assert entries[0].bytes == source_bytes
+    assert entries[0].flushed is True
+    assert chronik_outbox.compact(tmp_path) == [path]
+    assert not path.exists()
+
+
 def test_flush_file_posts_agent_ledger_domain_and_writes_bound_receipt(tmp_path):
     event = load_event()
     path = chronik_outbox.append_event(event, tmp_path)

--- a/tools/chronik_outbox.py
+++ b/tools/chronik_outbox.py
@@ -84,6 +84,14 @@ class _FlushSnapshot:
     file_state: _FileState
 
 
+@dataclass(frozen=True)
+class _OutboxScan:
+    source_bytes: int
+    event_count: int
+    sha256: str
+    progress: ReceiptProgress | None
+
+
 def load_json(path: Path) -> Any:
     with path.open("r", encoding="utf-8") as handle:
         return json.load(handle)
@@ -270,30 +278,6 @@ def _receipt_header(path: Path, source_size: int) -> ReceiptProgress | None:
     )
 
 
-def _receipt_progress(path: Path, snapshot: OutboxSnapshot) -> ReceiptProgress | None:
-    progress = _receipt_header(path, len(snapshot.raw))
-    if progress is None:
-        return None
-
-    prefix = snapshot.raw[: progress.source_bytes]
-    if progress.source_bytes > 0 and not prefix.endswith(b"\n"):
-        raise OutboxError(f"{path}: receipt ends inside a JSONL record")
-    if hashlib.sha256(prefix).hexdigest() != progress.source_sha256:
-        raise OutboxError(f"{path}: receipt prefix hash does not match the outbox")
-    if len(_parse_events(path, prefix)) != progress.event_count:
-        raise OutboxError(f"{path}: receipt event count does not match its prefix")
-    return progress
-
-
-def _receipt_covers_snapshot(progress: ReceiptProgress | None, snapshot: OutboxSnapshot) -> bool:
-    return (
-        progress is not None
-        and progress.source_bytes == len(snapshot.raw)
-        and progress.event_count == len(snapshot.events)
-        and progress.source_sha256 == snapshot.sha256
-    )
-
-
 def _fsync_directory(path: Path) -> None:
     directory_fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
     try:
@@ -368,19 +352,15 @@ def status(state_root: Path = DEFAULT_STATE_ROOT) -> list[OutboxFileStatus]:
     for path in iter_outbox_files(state_root):
         try:
             with outbox_lock(path):
-                snapshot = _snapshot_unlocked(path)
-                try:
-                    progress = _receipt_progress(path, snapshot)
-                except OutboxError:
-                    progress = None
+                scan = _scan_outbox_unlocked(path)
         except FileNotFoundError:
             continue
         entries.append(
             OutboxFileStatus(
                 path=path,
-                events=len(snapshot.events),
-                bytes=len(snapshot.raw),
-                flushed=_receipt_covers_snapshot(progress, snapshot),
+                events=scan.event_count,
+                bytes=scan.source_bytes,
+                flushed=_receipt_covers_scan(scan),
             )
         )
     return entries
@@ -452,6 +432,95 @@ def _parse_jsonl_line(path: Path, line_number: int, raw_line: bytes) -> Any | No
         return json.loads(line)
     except json.JSONDecodeError as exc:
         raise OutboxError(f"{path}:{line_number}: invalid jsonl") from exc
+
+
+def _scan_outbox_unlocked(path: Path) -> _OutboxScan:
+    """Validate one fixed outbox extent without retaining its bytes or events."""
+    try:
+        handle = path.open("rb")
+    except FileNotFoundError:
+        raise
+    except OSError as exc:
+        raise OutboxError(f"{path}: source cannot be read") from exc
+
+    with handle:
+        initial_state = _file_state(os.fstat(handle.fileno()))
+        try:
+            progress = _receipt_header(path, initial_state.size)
+        except OutboxError:
+            progress = None
+
+        validator = _event_validator()
+        source_hasher = hashlib.sha256()
+        cursor = 0
+        event_count = 0
+        line_number = 0
+        progress_verified = progress is None
+
+        if progress is not None and progress.source_bytes == 0:
+            if progress.source_sha256 == source_hasher.hexdigest() and progress.event_count == 0:
+                progress_verified = True
+            else:
+                progress = None
+                progress_verified = True
+
+        for raw_line in _bounded_lines(path, handle, initial_state.size):
+            line_start = cursor
+            cursor += len(raw_line)
+            line_number += 1
+            source_hasher.update(raw_line)
+
+            if (
+                progress is not None
+                and not progress_verified
+                and line_start < progress.source_bytes < cursor
+            ):
+                progress = None
+                progress_verified = True
+
+            event = _parse_jsonl_line(path, line_number, raw_line)
+            if event is not None:
+                validator.validate(event)
+                event_count += 1
+
+            if progress is not None and not progress_verified and cursor == progress.source_bytes:
+                if (
+                    (progress.source_bytes > 0 and not raw_line.endswith(b"\n"))
+                    or source_hasher.hexdigest() != progress.source_sha256
+                    or event_count != progress.event_count
+                ):
+                    progress = None
+                progress_verified = True
+
+        final_state = _file_state(os.fstat(handle.fileno()))
+        try:
+            path_state = _file_state(path.stat())
+        except FileNotFoundError:
+            raise
+        except OSError as exc:
+            raise OutboxError(f"{path}: source cannot be verified after scan") from exc
+        if final_state != initial_state or path_state != initial_state:
+            raise OutboxError(f"{path}: source changed while it was being scanned")
+
+    if progress is not None and not progress_verified:
+        progress = None
+
+    return _OutboxScan(
+        source_bytes=initial_state.size,
+        event_count=event_count,
+        sha256=source_hasher.hexdigest(),
+        progress=progress,
+    )
+
+
+def _receipt_covers_scan(scan: _OutboxScan) -> bool:
+    progress = scan.progress
+    return (
+        progress is not None
+        and progress.source_bytes == scan.source_bytes
+        and progress.event_count == scan.event_count
+        and progress.source_sha256 == scan.sha256
+    )
 
 
 def _preflight_flush_unlocked(path: Path, body_limit: int) -> _FlushSnapshot:
@@ -781,12 +850,8 @@ def compact(state_root: Path = DEFAULT_STATE_ROOT) -> list[Path]:
     for path in iter_outbox_files(state_root):
         try:
             with outbox_lock(path):
-                snapshot = _snapshot_unlocked(path)
-                try:
-                    progress = _receipt_progress(path, snapshot)
-                except OutboxError:
-                    continue
-                if not _receipt_covers_snapshot(progress, snapshot):
+                scan = _scan_outbox_unlocked(path)
+                if not _receipt_covers_scan(scan):
                     continue
                 path.unlink()
                 _fsync_directory(path.parent)


### PR DESCRIPTION
Closes #299

## Summary
- stream `status()` and local `compact()` verification instead of materializing the complete outbox plus all parsed events
- preserve JSONL/schema validation, receipt prefix hash/event-count/newline binding, source-stability checks and fail-closed compaction semantics
- keep `preview()` / `read_events()` materialization unchanged
- add regression coverage that makes the old `_snapshot_unlocked()` / `_parse_events()` / `Path.read_bytes()` path unusable for status/compact

## Verification
- targeted: `29 passed`
- full suite: `614 passed`
- `ruff check .`: clean
- benchmark, 10,000 events / 5.32 MiB: Python tracemalloc peak 51.77 MiB -> 0.06 MiB (-99.88%); 4.785 s -> 4.680 s; SHA-256 identical

The benchmark measures Python allocations, not process RSS.