### PR TITLE
perf(compaction): verify bounded ledger identities

### DIFF
--- a/coding_memory.py
+++ b/coding_memory.py
@@ -4116,9 +4116,9 @@ def _compact_grabowski_outbox_unlocked(
     deferred_sources = len(all_sources) - len(sources)
     skipped: Counter[str] = Counter()
     errors: list[dict[str, str]] = []
+    candidates: list[dict[str, Any]] = []
     eligible: list[dict[str, Any]] = []
     eligible_bytes = 0
-    ledger_payloads, ledger_records_scanned = _ledger_payloads_by_event_id()
     observed_ns = int(observed_at.timestamp() * 1_000_000_000)
     grace_ns = grace_seconds * 1_000_000_000
     for source in sources:
@@ -4145,10 +4145,35 @@ def _compact_grabowski_outbox_unlocked(
         ):
             skipped["receipt_invalid_or_missing"] += 1
             continue
-        if any(
-            ledger_payloads.get(event["event_id"]) != canonical_bytes(event)
-            for event in prepared["events"]
-        ):
+        candidates.append(prepared)
+
+    verification = storage.verify_payload_unique_groups(
+        DOMAIN,
+        (
+            (str(prepared["source"].resolve()), prepared["event_fingerprints"])
+            for prepared in candidates
+        ),
+        identity_key="event_id",
+    )
+    raw_group_results = verification.get("groups")
+    if not isinstance(raw_group_results, list):
+        raise storage.StorageError("invalid ledger verification result")
+    verification_by_source: dict[str, dict[str, object]] = {}
+    for item in raw_group_results:
+        if not isinstance(item, dict):
+            raise storage.StorageError("invalid ledger verification group result")
+        group_id = item.get("group_id")
+        if not isinstance(group_id, str) or group_id in verification_by_source:
+            raise storage.StorageError("invalid ledger verification group identity")
+        verification_by_source[group_id] = item
+    if len(verification_by_source) != len(candidates):
+        raise storage.StorageError("incomplete ledger verification result")
+    ledger_records_scanned = int(verification.get("target_records_scanned", 0))
+
+    for prepared in candidates:
+        source_key = str(prepared["source"].resolve())
+        group_result = verification_by_source.get(source_key)
+        if group_result is None or group_result.get("verified") is not True:
             skipped["ledger_unconfirmed"] += 1
             continue
         prepared_bytes = _prepared_source_bytes(prepared)

--- a/storage.py
+++ b/storage.py
@@ -971,6 +971,39 @@ def _parse_unique_payload(
     return identity if isinstance(identity, str) else None, canonical_payload
 
 
+def _parse_required_unique_payload(
+    line: str | bytes, identity_key: str
+) -> tuple[str, bytes]:
+    """Parse one authoritative ledger row without skipping corruption."""
+    try:
+        identity, canonical_payload = _parse_unique_payload(line, identity_key)
+    except (TypeError, ValueError) as exc:
+        raise StorageError("invalid ledger record") from exc
+    if not identity:
+        raise StorageRequiredIdentityError(identity_key)
+    return identity, canonical_payload
+
+
+def _strictly_validate_unique_ledger_records(
+    fh, *, identity_key: str, indexed_offset: int
+) -> int:
+    """Stream-validate rows when a legacy/tolerant index skipped records."""
+    scanned = 0
+    fh.seek(0)
+    while fh.tell() < indexed_offset:
+        raw = fh.readline()
+        if not raw or not raw.endswith(b"\n") or fh.tell() > indexed_offset:
+            raise StorageRecoveryError("ledger validation boundary is inconsistent")
+        if not raw.strip():
+            continue
+        scanned += 1
+        _parse_required_unique_payload(raw, identity_key)
+    if fh.tell() != indexed_offset:
+        raise StorageRecoveryError("ledger validation boundary is inconsistent")
+    fh.seek(0, os.SEEK_END)
+    return scanned
+
+
 def _payload_fingerprint(canonical_payload: bytes) -> bytes:
     """Return a fixed-width length-and-SHA-256 content identity."""
     return (
@@ -1065,15 +1098,25 @@ def verify_payload_unique_groups(
                     sync = index.synchronize(
                         fh,
                         identity_key=identity_key,
-                        parse_payload=_parse_unique_payload,
+                        parse_payload=_parse_required_unique_payload,
                         fingerprint_payload=_payload_fingerprint,
                     )
+                    strict_records_scanned = 0
+                    if (
+                        sync.mode != "rebuild"
+                        and sync.state.identity_count != sync.state.record_count
+                    ):
+                        strict_records_scanned = _strictly_validate_unique_ledger_records(
+                            fh,
+                            identity_key=identity_key,
+                            indexed_offset=sync.state.indexed_offset,
+                        )
                     existing = index.lookup(
                         fh,
                         state=sync.state,
                         identity_key=identity_key,
                         identities=candidate_ids,
-                        parse_payload=_parse_unique_payload,
+                        parse_payload=_parse_required_unique_payload,
                         fingerprint_payload=_payload_fingerprint,
                     )
             except StorageError:
@@ -1094,7 +1137,7 @@ def verify_payload_unique_groups(
 
     return {
         "target_scans": 0 if sync.mode == "steady" else 1,
-        "target_records_scanned": sync.records_scanned,
+        "target_records_scanned": sync.records_scanned + strict_records_scanned,
         "target_identity_index_entries": sync.entry_count,
         "identity_index_mode": sync.mode,
         "identity_index_entries_after": sync.entry_count,

--- a/storage.py
+++ b/storage.py
@@ -46,6 +46,7 @@ __all__ = [
     "write_payload",
     "write_payload_unique",
     "write_payload_unique_groups",
+    "verify_payload_unique_groups",
     "read_tail",
     "read_last_line",
     "read_domain_snapshot",
@@ -984,6 +985,120 @@ def _raise_identity_index_error(exc: IdentityIndexError) -> NoReturn:
     if isinstance(exc, IdentityIndexDriftError) and message.startswith("conflicting "):
         raise StorageError(message) from exc
     raise StorageRecoveryError(f"identity index unavailable: {message}") from exc
+
+
+def verify_payload_unique_groups(
+    domain: str,
+    groups: Iterable[tuple[str, Iterable[tuple[str, bytes]]]],
+    *,
+    identity_key: str = "event_id",
+) -> dict[str, object]:
+    """Verify bounded identity/fingerprint groups against ledger authority.
+
+    The persistent identity index remains only an acceleration structure. Every
+    returned index hit is re-read from its exact ledger byte range before it can
+    verify a caller-provided fingerprint. The ledger itself is never appended or
+    created by this verification path; an existing index may be synchronized as
+    derived state when the ledger already exists.
+    """
+    materialized: list[tuple[str, list[tuple[str, bytes]]]] = []
+    seen_group_ids: set[str] = set()
+    candidate_ids: list[str] = []
+    for group_id, identities in groups:
+        if not isinstance(group_id, str) or not group_id:
+            raise StorageError("group_id must be a non-empty string")
+        if group_id in seen_group_ids:
+            raise StorageError(f"duplicate group_id: {group_id}")
+        seen_group_ids.add(group_id)
+        verified: list[tuple[str, bytes]] = []
+        for identity, fingerprint in identities:
+            if not isinstance(identity, str) or not identity:
+                raise StorageRequiredIdentityError(identity_key)
+            if not isinstance(fingerprint, bytes) or len(fingerprint) != 40:
+                raise StorageError("invalid verification-only payload fingerprint")
+            verified.append((identity, fingerprint))
+            candidate_ids.append(identity)
+        materialized.append((group_id, verified))
+
+    def group_results(existing: dict[str, bytes]) -> list[dict[str, object]]:
+        results: list[dict[str, object]] = []
+        for group_id, identities in materialized:
+            missing = 0
+            conflicting = 0
+            for identity, fingerprint in identities:
+                previous = existing.get(identity)
+                if previous is None:
+                    missing += 1
+                elif previous != fingerprint:
+                    conflicting += 1
+            results.append(
+                {
+                    "group_id": group_id,
+                    "requested": len(identities),
+                    "verified": missing == 0 and conflicting == 0,
+                    "missing": missing,
+                    "conflicting": conflicting,
+                }
+            )
+        return results
+
+    if not candidate_ids:
+        return {
+            "target_scans": 0,
+            "target_records_scanned": 0,
+            "target_identity_index_entries": 0,
+            "identity_index_mode": "unused",
+            "identity_index_entries_after": 0,
+            "groups": group_results({}),
+        }
+
+    try:
+        target_path = safe_target_path(domain)
+    except DomainError as exc:
+        raise StorageError("invalid target path") from exc
+
+    try:
+        with _locked_open(target_path, "rb") as fh:
+            try:
+                with open_identity_index(target_path, timeout=LOCK_TIMEOUT) as index:
+                    sync = index.synchronize(
+                        fh,
+                        identity_key=identity_key,
+                        parse_payload=_parse_unique_payload,
+                        fingerprint_payload=_payload_fingerprint,
+                    )
+                    existing = index.lookup(
+                        fh,
+                        state=sync.state,
+                        identity_key=identity_key,
+                        identities=candidate_ids,
+                        parse_payload=_parse_unique_payload,
+                        fingerprint_payload=_payload_fingerprint,
+                    )
+            except StorageError:
+                raise
+            except IdentityIndexError as exc:
+                _raise_identity_index_error(exc)
+    except OSError as exc:
+        if exc.errno == errno.ENOENT:
+            return {
+                "target_scans": 0,
+                "target_records_scanned": 0,
+                "target_identity_index_entries": 0,
+                "identity_index_mode": "absent",
+                "identity_index_entries_after": 0,
+                "groups": group_results({}),
+            }
+        raise StorageError("read error") from exc
+
+    return {
+        "target_scans": 0 if sync.mode == "steady" else 1,
+        "target_records_scanned": sync.records_scanned,
+        "target_identity_index_entries": sync.entry_count,
+        "identity_index_mode": sync.mode,
+        "identity_index_entries_after": sync.entry_count,
+        "groups": group_results(existing),
+    }
 
 
 _ParsedUniqueRow = tuple[str, str | None, bytes]

--- a/storage.py
+++ b/storage.py
@@ -1059,6 +1059,7 @@ def verify_payload_unique_groups(
 
     try:
         with _locked_open(target_path, "rb") as fh:
+            _target_stat_for_fd(target_path, fh.fileno())
             try:
                 with open_identity_index(target_path, timeout=LOCK_TIMEOUT) as index:
                     sync = index.synchronize(

--- a/tests/test_coding_memory.py
+++ b/tests/test_coding_memory.py
@@ -615,6 +615,82 @@ def test_cli_regular_json_loader_keeps_existing_list_semantics(tmp_path):
     assert cli.load(empty_path) == []
 
 
+def test_compaction_verifies_bounded_candidates_without_full_ledger_payload_map(
+    tmp_path, monkeypatch
+):
+    outbox_root = tmp_path / "outbox"
+    source_dir = outbox_root / "grabowski" / "chronik-outbox"
+    source_dir.mkdir(parents=True)
+    source = source_dir / "candidate.jsonl"
+    raw = b"{}\n"
+    source.write_bytes(raw)
+    candidate = event()
+    prepared = {
+        "source": source,
+        "raw": raw,
+        "source_bytes": len(raw),
+        "events": [candidate],
+        "event_fingerprints": [
+            (candidate["event_id"], coding_memory._payload_fingerprint(candidate))
+        ],
+        "source_mtime_ns": 0,
+        "previous_receipt": {},
+    }
+
+    monkeypatch.setattr(
+        coding_memory, "_prepare_grabowski_outbox_source", lambda *_args, **_kwargs: prepared
+    )
+    monkeypatch.setattr(
+        coding_memory, "_receipt_matches_prepared_source", lambda *_args, **_kwargs: True
+    )
+
+    def forbidden_full_payload_map():
+        raise AssertionError("compaction must not retain the full ledger payload map")
+
+    monkeypatch.setattr(
+        coding_memory, "_ledger_payloads_by_event_id", forbidden_full_payload_map
+    )
+    observed_groups = []
+
+    def verify_groups(domain, groups, *, identity_key):
+        materialized = [(group_id, list(items)) for group_id, items in groups]
+        observed_groups.extend(materialized)
+        assert domain == coding_memory.DOMAIN
+        assert identity_key == "event_id"
+        return {
+            "target_records_scanned": 0,
+            "groups": [
+                {
+                    "group_id": materialized[0][0],
+                    "requested": 1,
+                    "verified": True,
+                    "missing": 0,
+                    "conflicting": 0,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(storage, "verify_payload_unique_groups", verify_groups)
+    result = coding_memory.compact_grabowski_outbox(
+        outbox_root=outbox_root,
+        receipt_dir=tmp_path / "receipts",
+        grace_seconds=0,
+        max_sources=1,
+        max_bytes=1024,
+        apply=False,
+        now=coding_memory.datetime(2026, 9, 1, tzinfo=coding_memory.timezone.utc),
+    )
+
+    assert result["eligible_sources"] == 1
+    assert result["eligible_events"] == 1
+    assert result["ledger_records_scanned"] == 0
+    assert result["skipped_by_reason"] == {}
+    assert observed_groups == [
+        (str(source.resolve()), prepared["event_fingerprints"])
+    ]
+    assert len(observed_groups[0][1][0][1]) == 40
+
+
 def test_ledger_payload_index_streams_committed_records_without_snapshot(
     tmp_path, monkeypatch
 ):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -114,6 +114,55 @@ def test_payload_fingerprint_is_fixed_width_and_length_bound():
     assert small[8:] != large[8:]
 
 
+def _fingerprint_for_unique_line(line: str) -> bytes:
+    _, canonical = storage._parse_unique_payload(line, "event_id")
+    return storage._payload_fingerprint(canonical)
+
+
+def test_verify_payload_unique_groups_reports_verified_missing_and_conflicting(
+    mock_data_dir,
+):
+    first = _unique_line("first", "same")
+    second = _unique_line("second", "same")
+    storage.write_payload_unique_groups(
+        "agent.ledger", [("seed", [first, second])]
+    )
+    before = (mock_data_dir / "agent.ledger.jsonl").read_bytes()
+
+    result = storage.verify_payload_unique_groups(
+        "agent.ledger",
+        [
+            ("verified", [("first", _fingerprint_for_unique_line(first))]),
+            ("missing", [("absent", _fingerprint_for_unique_line(_unique_line("absent", "x")))]),
+            ("conflicting", [("second", _fingerprint_for_unique_line(_unique_line("second", "different")))]),
+        ],
+    )
+
+    assert result["identity_index_mode"] == "steady"
+    assert result["target_records_scanned"] == 0
+    assert result["groups"] == [
+        {"group_id": "verified", "requested": 1, "verified": True, "missing": 0, "conflicting": 0},
+        {"group_id": "missing", "requested": 1, "verified": False, "missing": 1, "conflicting": 0},
+        {"group_id": "conflicting", "requested": 1, "verified": False, "missing": 0, "conflicting": 1},
+    ]
+    assert (mock_data_dir / "agent.ledger.jsonl").read_bytes() == before
+
+
+def test_verify_payload_unique_groups_missing_ledger_is_read_only(mock_data_dir):
+    fingerprint = _fingerprint_for_unique_line(_unique_line("absent", "value"))
+    result = storage.verify_payload_unique_groups(
+        "agent.ledger", [("candidate", [("absent", fingerprint)])]
+    )
+
+    assert result["identity_index_mode"] == "absent"
+    assert result["target_records_scanned"] == 0
+    assert result["groups"] == [
+        {"group_id": "candidate", "requested": 1, "verified": False, "missing": 1, "conflicting": 0}
+    ]
+    assert not (mock_data_dir / "agent.ledger.jsonl").exists()
+    assert not (mock_data_dir / ".chronik-identity-index-v1").exists()
+
+
 def test_write_payload_unique_groups_verifies_index_hits_against_ledger(
     mock_data_dir, monkeypatch
 ):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -186,6 +186,52 @@ def test_verify_payload_unique_groups_rejects_replaced_ledger_after_lock(
     assert not (mock_data_dir / ".chronik-identity-index-v1").exists()
 
 
+@pytest.mark.parametrize(
+    ("bad_row", "error_type", "message"),
+    [
+        ("not-json", storage.StorageError, "invalid ledger record"),
+        (
+            json.dumps({"payload": {"value": "missing-id"}}, sort_keys=True),
+            storage.StorageRequiredIdentityError,
+            "event_id",
+        ),
+    ],
+)
+def test_verify_payload_unique_groups_rejects_rows_skipped_by_legacy_index(
+    mock_data_dir, bad_row, error_type, message
+):
+    first = _unique_line("first", "same")
+    target = mock_data_dir / "agent.ledger.jsonl"
+    target.write_text(first + "\n" + bad_row + "\n", encoding="utf-8")
+    storage.write_payload_unique_groups(
+        "agent.ledger", [("append", [_unique_line("second", "other")])]
+    )
+
+    with pytest.raises(error_type, match=message):
+        storage.verify_payload_unique_groups(
+            "agent.ledger",
+            [("candidate", [("first", _fingerprint_for_unique_line(first))])],
+        )
+
+
+def test_verify_payload_unique_groups_allows_exact_duplicate_legacy_rows(mock_data_dir):
+    first = _unique_line("first", "same")
+    target = mock_data_dir / "agent.ledger.jsonl"
+    target.write_text(first + "\n" + first + "\n", encoding="utf-8")
+    storage.write_payload_unique_groups(
+        "agent.ledger", [("append", [_unique_line("second", "other")])]
+    )
+
+    result = storage.verify_payload_unique_groups(
+        "agent.ledger",
+        [("candidate", [("first", _fingerprint_for_unique_line(first))])],
+    )
+
+    assert result["identity_index_mode"] == "steady"
+    assert result["target_records_scanned"] == 3
+    assert result["groups"][0]["verified"] is True
+
+
 def test_write_payload_unique_groups_verifies_index_hits_against_ledger(
     mock_data_dir, monkeypatch
 ):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -163,6 +163,29 @@ def test_verify_payload_unique_groups_missing_ledger_is_read_only(mock_data_dir)
     assert not (mock_data_dir / ".chronik-identity-index-v1").exists()
 
 
+def test_verify_payload_unique_groups_rejects_replaced_ledger_after_lock(
+    mock_data_dir, monkeypatch
+):
+    line = _unique_line("first", "same")
+    target = mock_data_dir / "agent.ledger.jsonl"
+    target.write_text(line + "\n", encoding="utf-8")
+    fingerprint = _fingerprint_for_unique_line(line)
+
+    @contextmanager
+    def replacing_fd_lock(_fd, path, *, exclusive):
+        assert exclusive is False
+        path.unlink()
+        path.write_text(_unique_line("replacement", "different") + "\n", encoding="utf-8")
+        yield
+
+    monkeypatch.setattr(storage, "_fd_lock", replacing_fd_lock)
+    with pytest.raises(storage.StorageRecoveryError, match="target identity changed"):
+        storage.verify_payload_unique_groups(
+            "agent.ledger", [("candidate", [("first", fingerprint)])]
+        )
+    assert not (mock_data_dir / ".chronik-identity-index-v1").exists()
+
+
 def test_write_payload_unique_groups_verifies_index_hits_against_ledger(
     mock_data_dir, monkeypatch
 ):


### PR DESCRIPTION
Closes #301

## Summary
- remove the full-ledger `{event_id: canonical_payload_bytes}` retention from Grabowski outbox compaction;
- bound candidate sources first and verify only their existing 40-byte event fingerprints;
- reuse Chronik's ledger-bound persistent identity index, with every hit re-read from its exact authoritative ledger byte range;
- preserve fail-closed behavior for index drift/corruption, missing/conflicting identities, source order, and existing `max_bytes` semantics;
- keep an absent ledger read-only: verification does not create the ledger or derived index when the authority is absent.

## Verification
- targeted Storage/Coding-Memory/Compaction/Identity-Index suite: 160 passed;
- full test suite: 623 passed;
- full Ruff: clean;
- `git diff --check`: clean.

## Allocation/scanning sample
Controlled 10,000-event ledger with 2 KiB payload per event, steady identity index, one bounded candidate:
- old full payload map Python `tracemalloc` peak: 22.22 MiB;
- new candidate verification peak: 0.03 MiB;
- old ledger records scanned: 10,000;
- new steady-state records scanned during index synchronization: 0 (the candidate's exact ledger row is still re-read and validated by the index lookup);
- sample runtime: 0.234 s -> 0.001 s.

`tracemalloc` measures Python allocations, not process RSS. Rebuild/recovery index synchronization may still scan the full ledger, but it stores fixed-width fingerprints in the existing derived SQLite index instead of retaining canonical payload bytes in Python memory.